### PR TITLE
fix(codegen): match solc's external calls before byzantium

### DIFF
--- a/crates/codegen/src/backend/evm/codegen.rs
+++ b/crates/codegen/src/backend/evm/codegen.rs
@@ -11321,9 +11321,24 @@ impl<'gcx> EvmCodegen<'gcx> {
         };
 
         if let Some(subtracted) = late.subtracted {
+            // push <reserve>
+            // gas !meta(keep_with_next)
+            // sub !meta(keep_with_next)
+            //
+            // Before EIP-150 a call asking for more gas than is left throws, so the reserve only
+            // keeps solc's 10-gas margin while nothing but the `SUB` runs between the `GAS` and
+            // the call. Keeping both with the next instruction stops every backend transform from
+            // making that boundary a block boundary, and with it from inserting a jump.
+            let keep_with_call = !self.gcx.sess.opts.evm_version.can_overcharge_gas_for_call();
             self.asm.emit_push(subtracted);
             self.asm.emit_op(op::GAS);
+            if keep_with_call {
+                self.asm.keep_last_with_next();
+            }
             self.asm.emit_op(op::SUB);
+            if keep_with_call {
+                self.asm.keep_last_with_next();
+            }
         } else {
             self.asm.emit_op(op::GAS);
         }

--- a/crates/codegen/src/backend/evm/codegen.rs
+++ b/crates/codegen/src/backend/evm/codegen.rs
@@ -11322,8 +11322,8 @@ impl<'gcx> EvmCodegen<'gcx> {
 
         if let Some(subtracted) = late.subtracted {
             // push <reserve>
-            // gas !meta(keep_with_next)
-            // sub !meta(keep_with_next)
+            // gas !metadata(keep_with_next)
+            // sub !metadata(keep_with_next)
             //
             // Before EIP-150 a call asking for more gas than is left throws, so the reserve only
             // keeps solc's 10-gas margin while nothing but the `SUB` runs between the `GAS` and

--- a/crates/codegen/src/backend/evm/ir/builder.rs
+++ b/crates/codegen/src/backend/evm/ir/builder.rs
@@ -67,6 +67,18 @@ impl<'gcx> Assembler<'gcx> {
         self.push_ir_instruction(ir::Instruction::opcode(opcode));
     }
 
+    /// Requires the last emitted instruction to stay immediately before the next one.
+    ///
+    /// See [`ir::Metadata::keep_with_next`].
+    pub(crate) fn keep_last_with_next(&mut self) {
+        let block = self.current_block();
+        self.program.blocks[block]
+            .instructions
+            .last_mut()
+            .expect("`keep_last_with_next` needs an emitted instruction")
+            .keep_with_next();
+    }
+
     /// Emits a logical stack operation.
     pub(crate) fn emit_stack_op(&mut self, stack_op: op::StackOp) {
         self.push_ir_instruction(ir::Instruction::stack_op(stack_op));

--- a/crates/codegen/src/backend/evm/ir/display.rs
+++ b/crates/codegen/src/backend/evm/ir/display.rs
@@ -138,6 +138,7 @@ fn display_metadata(
             && spans.is_empty()
             && function_invoke.is_none()
             && function_exit.is_none()
+            && !metadata.keep_with_next
         {
             return Ok(());
         }
@@ -185,6 +186,16 @@ fn display_metadata(
                 DebugFunctionExit::Revert => "revert",
             };
             write!(f, "exit={exit}")?;
+        }
+        if metadata.keep_with_next {
+            if stack.is_some()
+                || !spans.is_empty()
+                || function_invoke.is_some()
+                || function_exit.is_some()
+            {
+                write!(f, ", ")?;
+            }
+            write!(f, "keep_with_next")?;
         }
         write!(f, ")")?;
         Ok(())

--- a/crates/codegen/src/backend/evm/ir/mod.rs
+++ b/crates/codegen/src/backend/evm/ir/mod.rs
@@ -682,10 +682,11 @@ pub(crate) struct Metadata {
     /// the gas consumed between two instructions is observable, such as a pre-EIP-150 call's
     /// `GAS`-relative gas reserve.
     ///
-    /// The flag records only that the pair is glued, not what it is glued to, so verification can
-    /// reject a block that ends with a flagged instruction but cannot tell that a transform
-    /// swapped the successor for another instruction. Transforms therefore check the boundary
-    /// themselves, through `is_split_point`.
+    /// The flag records only that the pair is glued, not what it is glued to, so verification
+    /// checks the reserve by shape instead: a glued `GAS` has to reach a glued `SUB` and a glued
+    /// `SUB` the call itself, which rejects an instruction inserted into the sequence as well as
+    /// a block that ends inside it. Transforms still check the boundary themselves, through
+    /// `is_split_point`, rather than leaving a split for the verifier to catch.
     pub(crate) keep_with_next: bool,
     /// Solidity source span associated with this machine operation.
     source_spans: DebugSpans,

--- a/crates/codegen/src/backend/evm/ir/mod.rs
+++ b/crates/codegen/src/backend/evm/ir/mod.rs
@@ -509,6 +509,19 @@ impl Instruction {
     pub(crate) const fn is_physical_stack_op(&self) -> bool {
         self.stack_op.is_some()
     }
+
+    /// Returns whether the boundary after this instruction may become a block boundary.
+    ///
+    /// See [`Metadata::keep_with_next`].
+    #[must_use]
+    pub(crate) const fn keeps_with_next(&self) -> bool {
+        self.metadata.keep_with_next
+    }
+
+    /// Requires this instruction to stay immediately before the next one in its block.
+    pub(in crate::backend::evm) const fn keep_with_next(&mut self) {
+        self.metadata.keep_with_next = true;
+    }
 }
 
 /// A control-flow terminator.
@@ -660,6 +673,13 @@ enum PushValue {
 pub(crate) struct Metadata {
     /// Optional stack effect.
     pub(crate) stack: Option<StackEffect>,
+    /// Whether this instruction must stay immediately before the next instruction of its block.
+    ///
+    /// Only meaningful on instructions. It forbids every transform from turning the boundary
+    /// after this instruction into a block boundary, so no jump, label, or block-layout decision
+    /// can come between the two. Lowering sets it where the gas consumed between two
+    /// instructions is observable, such as a pre-EIP-150 call's `GAS`-relative gas reserve.
+    pub(crate) keep_with_next: bool,
     /// Solidity source span associated with this machine operation.
     source_spans: DebugSpans,
     /// Function activation entered after this operation.

--- a/crates/codegen/src/backend/evm/ir/mod.rs
+++ b/crates/codegen/src/backend/evm/ir/mod.rs
@@ -683,9 +683,9 @@ pub(crate) struct Metadata {
     /// `GAS`-relative gas reserve.
     ///
     /// The flag records only that the pair is glued, not what it is glued to, so verification can
-    /// reject a block that ends with a flagged instruction but cannot tell that a transform swapped
-    /// the successor for another instruction. Transforms therefore check the boundary themselves,
-    /// through `is_split_point`.
+    /// reject a block that ends with a flagged instruction but cannot tell that a transform
+    /// swapped the successor for another instruction. Transforms therefore check the boundary
+    /// themselves, through `is_split_point`.
     pub(crate) keep_with_next: bool,
     /// Solidity source span associated with this machine operation.
     source_spans: DebugSpans,

--- a/crates/codegen/src/backend/evm/ir/mod.rs
+++ b/crates/codegen/src/backend/evm/ir/mod.rs
@@ -510,7 +510,8 @@ impl Instruction {
         self.stack_op.is_some()
     }
 
-    /// Returns whether the boundary after this instruction may become a block boundary.
+    /// Returns whether this instruction must stay immediately before the next one in its block,
+    /// so the boundary after it may not be disturbed.
     ///
     /// See [`Metadata::keep_with_next`].
     #[must_use]
@@ -675,10 +676,16 @@ pub(crate) struct Metadata {
     pub(crate) stack: Option<StackEffect>,
     /// Whether this instruction must stay immediately before the next instruction of its block.
     ///
-    /// Only meaningful on instructions. It forbids every transform from turning the boundary
+    /// Only meaningful on instructions. It forbids every transform both from turning the boundary
     /// after this instruction into a block boundary, so no jump, label, or block-layout decision
-    /// can come between the two. Lowering sets it where the gas consumed between two
-    /// instructions is observable, such as a pre-EIP-150 call's `GAS`-relative gas reserve.
+    /// can come between the two, and from inserting an instruction there. Lowering sets it where
+    /// the gas consumed between two instructions is observable, such as a pre-EIP-150 call's
+    /// `GAS`-relative gas reserve.
+    ///
+    /// The flag records only that the pair is glued, not what it is glued to, so verification can
+    /// reject a block that ends with a flagged instruction but cannot tell that a transform swapped
+    /// the successor for another instruction. Transforms therefore check the boundary themselves,
+    /// through `is_split_point`.
     pub(crate) keep_with_next: bool,
     /// Solidity source span associated with this machine operation.
     source_spans: DebugSpans,

--- a/crates/codegen/src/backend/evm/ir/parse.rs
+++ b/crates/codegen/src/backend/evm/ir/parse.rs
@@ -498,6 +498,8 @@ impl<'sess, 'ast> Parser<'sess, 'ast> {
                 let depth = u32::try_from(depth)
                     .map_err(|_| self.parser.error("modifier depth does not fit in u32"))?;
                 metadata.set_modifier_depth(depth);
+            } else if key == sym::keep_with_next {
+                metadata.keep_with_next = true;
             } else if self.parser.eat(TokenKind::Eq) {
                 self.skip_metadata_value()?;
             }

--- a/crates/codegen/src/backend/evm/ir/passes/cfg_simplify.rs
+++ b/crates/codegen/src/backend/evm/ir/passes/cfg_simplify.rs
@@ -9,11 +9,13 @@
 //!
 //! Address-taken blocks remain distinct, and block merging requires one reference so changing a
 //! predecessor cannot affect another edge. The pass preserves the condition's stack effect with a
-//! `POP`; later dead-code elimination may remove the pure condition computation.
+//! `POP`; later dead-code elimination may remove the pure condition computation. Replacing the
+//! physical form's `PUSH target; JUMPI` with that `POP` changes what runs after the condition, so
+//! it only applies where `keep_with_next` allows that boundary to be disturbed.
 
 use super::{
     EvmPass,
-    utils::{remap_block_order, retain_blocks},
+    utils::{is_split_point, remap_block_order, retain_blocks},
 };
 use crate::backend::evm::{
     ir::{Block, BlockId, Metadata, Module, PushValue, Terminator, TerminatorKind},
@@ -148,6 +150,7 @@ fn simplify_degenerate_branches(module: &mut Module) -> bool {
             && pushed.value == Some(PushValue::Block(*target))
             && jumpi.has_canonical_stack_effect()
             && jumpi.as_evm_opcode() == Some(op::JUMPI)
+            && is_split_point(&block.instructions, block.instructions.len() - 2)
         {
             let metadata = jumpi.metadata.clone();
             block.instructions.truncate(block.instructions.len() - 2);

--- a/crates/codegen/src/backend/evm/ir/passes/outline.rs
+++ b/crates/codegen/src/backend/evm/ir/passes/outline.rs
@@ -13,6 +13,9 @@
 //! selected without overlap, and new blocks and labels are installed through the normal EVM IR CFG
 //! representation.
 //!
+//! Replacing a site splits its block around the run, so both ends of a candidate run must be
+//! boundaries `keep_with_next` allows to become block boundaries.
+//!
 //! Enumerating all substrings is potentially quadratic, so the implementation cuts runs at unique
 //! instructions, hashes slices from prefix tables, and applies a module-wide candidate budget.
 //! Large modules shorten the maximum considered run rather than allowing unbounded compile time.
@@ -22,7 +25,7 @@
 use super::{
     EvmPass,
     compact_pushes::selected_len,
-    utils::{FreshLabels, MachineInstKey, instruction_size_lower_bound},
+    utils::{FreshLabels, MachineInstKey, instruction_size_lower_bound, is_split_point},
 };
 use crate::backend::evm::{
     ir::{Block, BlockId, Instruction, Module, PushValue, Terminator, TerminatorKind},
@@ -92,7 +95,7 @@ fn outline_machine_runs(gcx: Gcx<'_>, module: &mut Module, state: &mut RunState)
     let mut candidates = FxHashMap::<MachineInstSlice<'_>, SmallVec<[Site; 2]>>::default();
     for (block_id, block) in module.blocks.iter_enumerated() {
         for start in 0..block.instructions.len() {
-            if !hashes.repeats(block_id, start) {
+            if !hashes.repeats(block_id, start) || !is_split_point(&block.instructions, start) {
                 continue;
             }
             let mut delta = 0i32;
@@ -123,7 +126,11 @@ fn outline_machine_runs(gcx: Gcx<'_>, module: &mut Module, state: &mut RunState)
                 // before the shared stub's fixed overhead. A run no larger than that site can
                 // never save bytes regardless of its occurrence count, so do not intern it.
                 let can_amortize = run_size > 7 + inputs as usize;
-                if len >= MIN_MACHINE_RUN && can_amortize && (closed || open_size_run) {
+                if len >= MIN_MACHINE_RUN
+                    && can_amortize
+                    && (closed || open_size_run)
+                    && is_split_point(&block.instructions, end + 1)
+                {
                     let key = MachineInstSlice {
                         hash: hashes.range(block_id, start, end),
                         insts: &block.instructions[start..=end],
@@ -268,6 +275,9 @@ fn outline_parametric_machine_runs(
         FxHashMap::<ParamMachineInstSlice<'_>, SmallVec<[ParamSite; 2]>>::default();
     for (block_id, block) in module.blocks.iter_enumerated() {
         for start in 0..block.instructions.len() {
+            if !is_split_point(&block.instructions, start) {
+                continue;
+            }
             let mut delta = 0i32;
             let mut inputs = 0i32;
             let mut immediate_pushes = 0usize;
@@ -290,6 +300,7 @@ fn outline_parametric_machine_runs(
                     || !matches!(outputs, 0 | 1)
                     || immediate_pushes == 0
                     || immediate_pushes > MAX_PARAMETERS * 2
+                    || !is_split_point(&block.instructions, end + 1)
                 {
                     continue;
                 }
@@ -561,6 +572,8 @@ fn outline_repeated_pushes(gcx: Gcx<'_>, module: &mut Module, state: &mut RunSta
             if inst.is_encoded_push()
                 && inst.deferred_push().is_none()
                 && inst.immutable_push().is_none()
+                && is_split_point(&block.instructions, index)
+                && is_split_point(&block.instructions, index + 1)
                 && let Some(PushValue::Immediate(value)) = &inst.value
             {
                 sites.entry(*value).or_default().push((block_id, index));

--- a/crates/codegen/src/backend/evm/ir/passes/share_reverts.rs
+++ b/crates/codegen/src/backend/evm/ir/passes/share_reverts.rs
@@ -5,8 +5,12 @@
 //! continuation. The pass recognizes both `PUSH0; PUSH0; REVERT` and the legacy `PUSH0; DUP1;
 //! REVERT` spelling. It preserves the original layout when moving a frequently referenced shared
 //! revert could widen its target push and lose more bytes than the removed jump saves.
+//!
+//! Inverting the branch can need an extra `ISZERO` before the branch target, which runs between
+//! the condition and the jump. That boundary must be one `keep_with_next` allows to be disturbed,
+//! so a sequence whose intervening gas is observable is left alone.
 
-use super::EvmPass;
+use super::{EvmPass, utils::is_split_point};
 use crate::backend::evm::{
     ir::{BlockId, Instruction, Module, PushValue, Terminator, TerminatorKind},
     op,
@@ -52,29 +56,39 @@ fn share_reverts(_gcx: Gcx<'_>, module: &mut Module) -> bool {
         if !empty_reverts.contains(revert) {
             continue;
         }
-        let [.., target, jumpi] = block.instructions.as_mut_slice() else { continue };
-        if jumpi.opcode != op::JUMPI || jumpi.is_encoded_push() {
+        let [.., target, jumpi] = block.instructions.as_slice() else { continue };
+        let Some(PushValue::Block(continuation)) = target.value else { continue };
+        if jumpi.opcode != op::JUMPI
+            || jumpi.is_encoded_push()
+            || !target.is_encoded_push()
+            || revert.index() != block_id.index() + 1
+            || continuation.index() != revert.index() + 1
+        {
             continue;
         }
         let branch_metadata = jumpi.metadata.clone();
-        let continuation = match &target.value {
-            Some(PushValue::Block(continuation)) => *continuation,
-            _ => continue,
-        };
-        if !target.is_encoded_push() {
-            continue;
-        }
-        if revert.index() != block_id.index() + 1 || continuation.index() != revert.index() + 1 {
-            continue;
-        }
         let target_metadata = target.metadata.clone();
-        *target = Instruction::push_block(shared);
-        target.metadata.copy_source_debug_from(&target_metadata);
+        // Inverting the branch drops an `ISZERO`, retargets an `EQ`, or inserts an `ISZERO`
+        // before the branch target. Dropping and inserting change what runs at that boundary, so
+        // both need a boundary `keep_with_next` allows to be disturbed.
+        let condition_end = block.instructions.len() - 2;
+        let condition =
+            block.instructions.get(condition_end.wrapping_sub(1)).map(|inst| inst.opcode);
+        let boundary =
+            if condition == Some(op::ISZERO) { condition_end - 1 } else { condition_end };
+        if condition != Some(op::EQ) && !is_split_point(&block.instructions, boundary) {
+            continue;
+        }
+        // <condition>
+        // iszero
+        // push <shared>
+        // jump <continuation>
+        block.instructions[condition_end] = Instruction::push_block(shared);
+        block.instructions[condition_end].metadata.copy_source_debug_from(&target_metadata);
         let mut terminator = Terminator::new(TerminatorKind::Jump(continuation));
         terminator.metadata.copy_source_debug_from(&terminator_metadata);
         block.terminator = Some(terminator);
-        let condition_end = block.instructions.len() - 2;
-        match block.instructions.get(condition_end.wrapping_sub(1)).map(|inst| inst.opcode) {
+        match condition {
             Some(op::ISZERO) => {
                 block.instructions.remove(condition_end - 1);
             }

--- a/crates/codegen/src/backend/evm/ir/passes/tail_merge.rs
+++ b/crates/codegen/src/backend/evm/ir/passes/tail_merge.rs
@@ -8,10 +8,17 @@
 //! otherwise incompatible entries separate. Debug metadata never participates
 //! in equivalence: path-specific function activations stay on the original
 //! blocks or the jumps that replace their instruction suffixes.
+//!
+//! A shared tail starts at a block boundary, so both the merged block and the representative may
+//! only be cut where `keep_with_next` allows a split. That keeps sequences whose intervening gas
+//! is observable, such as a pre-EIP-150 call's `GAS`-relative gas reserve, in one block.
 
 use super::{
     EvmPass,
-    utils::{FreshLabels, MachineInstKey, instruction_size_lower_bound, is_terminal_boundary},
+    utils::{
+        FreshLabels, MachineInstKey, instruction_size_lower_bound, is_split_point,
+        is_terminal_boundary,
+    },
 };
 use crate::backend::evm::{
     ir::{Block, BlockId, Hotness, Module, Terminator, TerminatorKind},
@@ -103,12 +110,18 @@ impl RunState {
         let terminator = &block.terminator.as_ref()?.kind;
         let mut node = *self.tail_roots.get(terminator)?;
         let mut matched = None;
+        let len = block.instructions.len();
         for (common, inst) in block.instructions.iter().rev().enumerate() {
             let Some(&child) = self.tail_nodes[node].children.get(&MachineInstKey::new(inst))
             else {
                 break;
             };
             node = child;
+            // Splitting the tail off leaves a jump at this boundary, so only offer tails that
+            // start at a legal split point. A longer tail may still start at one.
+            if !is_split_point(&block.instructions, len - common - 1) {
+                continue;
+            }
             if let Some(representative) = self.tail_nodes[node].representative {
                 matched = Some((representative, common + 1));
             }
@@ -119,10 +132,17 @@ impl RunState {
     fn insert_tail(&mut self, block_id: BlockId, block: &Block) {
         let terminator = &block.terminator.as_ref().expect("candidate must have a terminator").kind;
         let mut node = self.tail_root(terminator);
-        self.tail_nodes[node].representative.get_or_insert(block_id);
-        for inst in block.instructions.iter().rev() {
-            node = self.tail_child(node, MachineInstKey::new(inst));
-            self.tail_nodes[node].representative.get_or_insert(block_id);
+        let len = block.instructions.len();
+        // The representative is truncated at the shared tail too, so it only represents tails
+        // whose start is a legal split point in its own instruction list.
+        for common in 0..=len {
+            if common > 0 {
+                node =
+                    self.tail_child(node, MachineInstKey::new(&block.instructions[len - common]));
+            }
+            if is_split_point(&block.instructions, len - common) {
+                self.tail_nodes[node].representative.get_or_insert(block_id);
+            }
         }
     }
 

--- a/crates/codegen/src/backend/evm/ir/passes/terminal_dedup.rs
+++ b/crates/codegen/src/backend/evm/ir/passes/terminal_dedup.rs
@@ -91,6 +91,7 @@ fn terminal_block_key(block: &Block) -> Option<TerminalBlockKey> {
             encoding: inst.encoding,
             value: inst.value,
             stack_op: inst.as_stack_op(),
+            keep_with_next: inst.keeps_with_next(),
         })
         .collect();
     Some(TerminalBlockKey { instructions, terminator: terminator.clone() })
@@ -108,4 +109,5 @@ struct TerminalInstructionKey {
     encoding: u8,
     value: Option<PushValue>,
     stack_op: Option<crate::backend::evm::op::StackOp>,
+    keep_with_next: bool,
 }

--- a/crates/codegen/src/backend/evm/ir/passes/terminal_dedup.rs
+++ b/crates/codegen/src/backend/evm/ir/passes/terminal_dedup.rs
@@ -5,6 +5,10 @@
 //! keeps the first body and redirects later copies to it. CFG simplification
 //! then redirects references and removes the temporary jump thunks. Block hotness does not affect
 //! equivalence; a hot redirect promotes the shared body so later layout keeps it on the hot path.
+//!
+//! The body key includes each instruction's `keep_with_next` flag, so the surviving copy cannot
+//! drop a constraint one of the redirected copies carried. A shared body is entered at its own
+//! block boundary, which is legal by construction, so the pass needs no other split check.
 
 use super::{EvmPass, utils::is_terminal_boundary};
 use crate::backend::evm::ir::{

--- a/crates/codegen/src/backend/evm/ir/passes/utils.rs
+++ b/crates/codegen/src/backend/evm/ir/passes/utils.rs
@@ -28,10 +28,10 @@ impl MachineInstKey {
     }
 }
 
-/// Returns whether `index` may become a block boundary in `instructions`.
+/// Returns whether the boundary at `index` in `instructions` may be disturbed.
 ///
 /// The boundary right after a `keep_with_next` instruction is not a legal split point, so no
-/// transform may start a block, outline a run, or share a tail there.
+/// transform may start a block, outline a run, share a tail, or insert an instruction there.
 pub(super) fn is_split_point(instructions: &[Instruction], index: usize) -> bool {
     debug_assert!(index <= instructions.len());
     index == 0 || !instructions[index - 1].keeps_with_next()

--- a/crates/codegen/src/backend/evm/ir/passes/utils.rs
+++ b/crates/codegen/src/backend/evm/ir/passes/utils.rs
@@ -16,13 +16,25 @@ use solar_data_structures::{
 use solar_sema::Gcx;
 
 /// The machine-level identity shared by transforms that compare instructions.
+///
+/// `keep_with_next` is part of the identity: sharing one copy of two otherwise equal instructions
+/// must not drop one copy's constraint on the boundary that follows it.
 #[derive(Clone, Copy, PartialEq, Eq, Hash)]
-pub(super) struct MachineInstKey(u8, u8, Option<PushValue>, Option<op::StackOp>);
+pub(super) struct MachineInstKey(u8, u8, Option<PushValue>, Option<op::StackOp>, bool);
 
 impl MachineInstKey {
     pub(super) fn new(inst: &Instruction) -> Self {
-        Self(inst.opcode, inst.encoding, inst.value, inst.as_stack_op())
+        Self(inst.opcode, inst.encoding, inst.value, inst.as_stack_op(), inst.keeps_with_next())
     }
+}
+
+/// Returns whether `index` may become a block boundary in `instructions`.
+///
+/// The boundary right after a `keep_with_next` instruction is not a legal split point, so no
+/// transform may start a block, outline a run, or share a tail there.
+pub(super) fn is_split_point(instructions: &[Instruction], index: usize) -> bool {
+    debug_assert!(index <= instructions.len());
+    index == 0 || !instructions[index - 1].keeps_with_next()
 }
 
 /// Allocates unused textual block labels without assuming labels are dense.

--- a/crates/codegen/src/backend/evm/ir/verify.rs
+++ b/crates/codegen/src/backend/evm/ir/verify.rs
@@ -155,6 +155,21 @@ impl<'a> Verifier<'a> {
             for inst in &block.instructions {
                 self.verify_instruction_shape(block_id, module, inst);
             }
+            // A `keep_with_next` instruction only constrains the boundary that follows it, so the
+            // block must still hold the instruction it is kept with. This is what makes the
+            // constraint a guarantee: any transform that turns that boundary into a block
+            // boundary is rejected here instead of silently inserting a jump.
+            if let Some(last) = block.instructions.last()
+                && last.keeps_with_next()
+            {
+                self.error_in_block(
+                    block_id,
+                    format_args!(
+                        "`{}` must be followed by the instruction it is kept with",
+                        last.mnemonic()
+                    ),
+                );
+            }
             let Some(term) = &block.terminator else {
                 self.error_in_block(block_id, "missing terminator");
                 continue;
@@ -324,6 +339,12 @@ impl<'a> Verifier<'a> {
     fn verify_terminator_shape(&self, block_id: BlockId, term: &Terminator) {
         if matches!(&term.kind, TerminatorKind::IndexedJump(targets) if targets.is_empty()) {
             self.error_in_block(block_id, "`indexed_jump` must have at least one target");
+        }
+        if term.metadata.keep_with_next {
+            self.error_in_block(
+                block_id,
+                format_args!("terminator `{}` cannot be kept with a next instruction", term.kind),
+            );
         }
         if let TerminatorKind::Op(opcode) = &term.kind
             && !op::is_terminal(*opcode)

--- a/crates/codegen/src/backend/evm/ir/verify.rs
+++ b/crates/codegen/src/backend/evm/ir/verify.rs
@@ -155,21 +155,7 @@ impl<'a> Verifier<'a> {
             for inst in &block.instructions {
                 self.verify_instruction_shape(block_id, module, inst);
             }
-            // A `keep_with_next` instruction only constrains the boundary that follows it, so the
-            // block must still hold the instruction it is kept with. This is what makes the
-            // constraint a guarantee: any transform that turns that boundary into a block
-            // boundary is rejected here instead of silently inserting a jump.
-            if let Some(last) = block.instructions.last()
-                && last.keeps_with_next()
-            {
-                self.error_in_block(
-                    block_id,
-                    format_args!(
-                        "`{}` must be followed by the instruction it is kept with",
-                        last.mnemonic()
-                    ),
-                );
-            }
+            self.verify_keep_with_next(block_id, block);
             let Some(term) = &block.terminator else {
                 self.error_in_block(block_id, "missing terminator");
                 continue;
@@ -186,6 +172,59 @@ impl<'a> Verifier<'a> {
         }
 
         self.dcx.err_count() == errors_before
+    }
+
+    /// Verifies every sequence `keep_with_next` glues together.
+    ///
+    /// The flag forbids both a block boundary and an inserted instruction after the instruction
+    /// carrying it, and neither is any use unless the successor is still the instruction the
+    /// sequence needs. The only sequence lowering glues is a pre-EIP-150 call's `GAS`-relative
+    /// gas reserve, `push <reserve>; gas; sub; <call>`, whose margin pays for the `sub` and the
+    /// call setup alone, so the pair is checked by shape: a glued `gas` is followed by a glued
+    /// `sub`, and a glued `sub` by the call opcode itself. Anything else carrying the flag has no
+    /// rule to check it and is rejected, which keeps a new use of the flag from passing
+    /// verification unverified.
+    fn verify_keep_with_next(&self, block_id: BlockId, block: &Block) {
+        const CALLS: [u8; 4] = [op::CALL, op::CALLCODE, op::DELEGATECALL, op::STATICCALL];
+        for (index, inst) in block.instructions.iter().enumerate() {
+            if !inst.keeps_with_next() {
+                continue;
+            }
+            let Some(next) = block.instructions.get(index + 1) else {
+                self.error_in_block(
+                    block_id,
+                    format_args!(
+                        "`{}` must be followed by the instruction it is kept with",
+                        inst.mnemonic()
+                    ),
+                );
+                continue;
+            };
+            let expected = match inst.opcode {
+                op::GAS if next.opcode == op::SUB && next.keeps_with_next() => continue,
+                op::GAS => "a `sub` kept with the call",
+                op::SUB if CALLS.contains(&next.opcode) => continue,
+                op::SUB => "a call",
+                _ => {
+                    self.error_in_block(
+                        block_id,
+                        format_args!(
+                            "`{}` cannot be kept with a next instruction",
+                            inst.mnemonic()
+                        ),
+                    );
+                    continue;
+                }
+            };
+            self.error_in_block(
+                block_id,
+                format_args!(
+                    "`{}` is kept with the next instruction, which must be {expected}, not `{}`",
+                    inst.mnemonic(),
+                    next.mnemonic()
+                ),
+            );
+        }
     }
 
     fn verify_instruction_shape(&self, block_id: BlockId, module: &Module, inst: &Instruction) {

--- a/crates/codegen/src/lower/function.rs
+++ b/crates/codegen/src/lower/function.rs
@@ -260,6 +260,29 @@ struct FunctionLowerer<'gcx, 'ctx> {
     discarded_exprs: Vec<hir::ExprId>,
 }
 
+/// The lowered `{gas: ..., value: ...}` options of an external call.
+#[derive(Clone, Copy)]
+struct LoweredCallOptions {
+    /// The `gas` operand, or `None` when the call forwards the gas left on a target that predates
+    /// EIP-150.
+    ///
+    /// Such a target aborts a call whose gas argument exceeds the gas left, so the operand has to
+    /// withhold the call's own costs and only [`FunctionLowerer::call_gas`] materializes it,
+    /// immediately before the call. Every other case is materialized here: an explicit
+    /// `{gas: ...}` because its expression must run in source order, and `gas()` because
+    /// EIP-150 caps the forwarded gas anyway.
+    gas: Option<ValueId>,
+    /// The `value` operand, zero when the call sends no value.
+    value: ValueId,
+    /// Whether the call has an explicit `{value: ...}` option.
+    ///
+    /// A pre-EIP-150 call reserves the value-transfer cost whenever the option is there, like
+    /// solc's `valueSet`, because the amount is not known to be zero.
+    value_set: bool,
+    /// A zero immediate, reusable by the caller.
+    zero: ValueId,
+}
+
 #[derive(Clone, Copy)]
 struct CallArgumentParams<'a> {
     count: usize,
@@ -558,28 +581,33 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
         options: Option<&hir::CallOptions<'_>>,
         allow_value: bool,
         diagnostic: &'static str,
-    ) -> Option<(ValueId, ValueId, ValueId)> {
+    ) -> Option<LoweredCallOptions> {
         // zero = 0
         // gas = gas()
         // value = zero
         // for option { gas/value = lower(option.value) }
         let zero = self.builder.imm(U256::ZERO);
-        let mut gas = self.builder.gas();
+        let evm_version = self.cx.gcx.sess.opts.evm_version;
+        let mut gas = evm_version.can_overcharge_gas_for_call().then(|| self.builder.gas());
         let mut value = zero;
+        let mut value_set = false;
         if let Some(options) = options {
             for option in options.args {
                 let option_value =
                     self.lower_typed_expr(&option.value, self.cx.gcx.types.uint(256))?;
                 match option.name.name {
-                    kw::Gas => gas = option_value,
-                    sym::value if allow_value => value = option_value,
+                    kw::Gas => gas = Some(option_value),
+                    sym::value if allow_value => {
+                        value = option_value;
+                        value_set = true;
+                    }
                     _ => {
                         return self.cx.report_unsupported(option.name.span, diagnostic);
                     }
                 }
             }
         }
-        Some((gas, value, zero))
+        Some(LoweredCallOptions { gas, value, value_set, zero })
     }
 
     fn validate_enum(&mut self, ty: Ty<'gcx>, value: ValueId) {

--- a/crates/codegen/src/lower/function.rs
+++ b/crates/codegen/src/lower/function.rs
@@ -179,9 +179,7 @@ pub(super) fn lower(
         }
     }
 
-    let in_creation_code = gcx.contract_creation_functions(context.contract_id).contains(id);
     let mut lowerer = FunctionLowerer::new(context.reborrow(), &mut mir);
-    lowerer.in_creation_code = in_creation_code;
     lowerer.is_getter = hir_function.is_getter();
     lowerer.bind_signature(hir_function);
     if hir_function.kind == hir::FunctionKind::Constructor {
@@ -210,7 +208,6 @@ pub(super) fn lower_synthetic_constructor(
         Function::new(solar_interface::Ident::with_dummy_span(solar_interface::kw::Constructor));
     mir.attributes.is_constructor = true;
     let mut lowerer = FunctionLowerer::new(context.reborrow(), &mut mir);
-    lowerer.in_creation_code = true;
     lowerer.lower_implicit_base_constructors(contract_id)?;
     lowerer.lower_state_initializers(contract_id)?;
     if !lowerer.is_terminated() {
@@ -246,10 +243,6 @@ struct FunctionLowerer<'gcx, 'ctx> {
     is_getter: bool,
     unchecked: bool,
     in_inline_assembly: bool,
-    /// Whether this function's code ends up in the contract's creation object, where the
-    /// contract has no code of its own yet. Functions shared with the runtime object are
-    /// copied into the creation code, so this is `true` for them as well.
-    in_creation_code: bool,
     /// The expressions being lowered whose values nothing observes: a discarded expression
     /// statement, and the tuple declaration and assignment components that have no target.
     ///
@@ -470,7 +463,6 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
             is_getter: false,
             unchecked: false,
             in_inline_assembly: false,
-            in_creation_code: false,
             discarded_exprs: Vec::new(),
         }
     }

--- a/crates/codegen/src/lower/function.rs
+++ b/crates/codegen/src/lower/function.rs
@@ -179,7 +179,9 @@ pub(super) fn lower(
         }
     }
 
+    let in_creation_code = gcx.contract_creation_functions(context.contract_id).contains(id);
     let mut lowerer = FunctionLowerer::new(context.reborrow(), &mut mir);
+    lowerer.in_creation_code = in_creation_code;
     lowerer.is_getter = hir_function.is_getter();
     lowerer.bind_signature(hir_function);
     if hir_function.kind == hir::FunctionKind::Constructor {
@@ -208,6 +210,7 @@ pub(super) fn lower_synthetic_constructor(
         Function::new(solar_interface::Ident::with_dummy_span(solar_interface::kw::Constructor));
     mir.attributes.is_constructor = true;
     let mut lowerer = FunctionLowerer::new(context.reborrow(), &mut mir);
+    lowerer.in_creation_code = true;
     lowerer.lower_implicit_base_constructors(contract_id)?;
     lowerer.lower_state_initializers(contract_id)?;
     if !lowerer.is_terminated() {
@@ -243,6 +246,10 @@ struct FunctionLowerer<'gcx, 'ctx> {
     is_getter: bool,
     unchecked: bool,
     in_inline_assembly: bool,
+    /// Whether this function's code ends up in the contract's creation object, where the
+    /// contract has no code of its own yet. Functions shared with the runtime object are
+    /// copied into the creation code, so this is `true` for them as well.
+    in_creation_code: bool,
     /// The expressions being lowered whose values nothing observes: a discarded expression
     /// statement, and the tuple declaration and assignment components that have no target.
     ///
@@ -440,6 +447,7 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
             is_getter: false,
             unchecked: false,
             in_inline_assembly: false,
+            in_creation_code: false,
             discarded_exprs: Vec::new(),
         }
     }

--- a/crates/codegen/src/lower/function.rs
+++ b/crates/codegen/src/lower/function.rs
@@ -583,7 +583,7 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
         diagnostic: &'static str,
     ) -> Option<LoweredCallOptions> {
         // zero = 0
-        // gas = gas()
+        // gas = gas() if can_overcharge_gas_for_call
         // value = zero
         // for option { gas/value = lower(option.value) }
         let zero = self.builder.imm(U256::ZERO);

--- a/crates/codegen/src/lower/function/builtins.rs
+++ b/crates/codegen/src/lower/function/builtins.rs
@@ -138,13 +138,19 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
                 "codegen cannot bind low-level call returndata before Byzantium",
             );
         }
-        let (gas, value, zero) =
+        let options =
             self.lower_call_options(call_opts, builtin == Builtin::AddressCall, "call option")?;
+        let (value, zero) = (options.value, options.zero);
         // input = materialize_memory(arg)
         let data = self.lower_typed_expr(data, memory_ty)?;
         let data = self.materialize_memory_argument(memory_ty, data, data_span)?;
         let input = self.builder.memory_object_data(data, MemoryObjectKind::Bytes);
         let input_size = self.builder.memory_object_len(data, MemoryObjectKind::Bytes);
+        // A bare call has no `extcodesize` guard, so before EIP-150 it also reserves the cost of
+        // creating the callee's account, which is unknowable here; solc reserves it for all three
+        // kinds too (`appendBareCall`).
+        // gas = gas() | sub(gas(), reserve)
+        let gas = self.call_gas(options.gas, options.value_set, true);
         // ok = call|staticcall|delegatecall(gas, to, value?, input, 0, 0)
         let success = match builtin {
             Builtin::AddressCall => {

--- a/crates/codegen/src/lower/function/calls.rs
+++ b/crates/codegen/src/lower/function/calls.rs
@@ -54,25 +54,12 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
     ///
     /// A call that expects return data needs no check from Byzantium on: a code-less callee
     /// returns nothing, so the return-data length check reverts anyway. Before Byzantium there is
-    /// no `RETURNDATASIZE` and nothing subsumes the check, so every call needs it.
+    /// no `RETURNDATASIZE` and nothing subsumes the check, so every call needs it. This is solc's
+    /// rule, `encodedHeadSize == 0 || !supportsReturndata()`, and it holds for every receiver:
+    /// `this` is no exception, because the executing code and `address(this)` come apart under
+    /// `DELEGATECALL`, where the account may well have no code of its own.
     pub(super) fn needs_code_check(&self, returns: usize) -> bool {
         returns == 0 || !self.cx.gcx.sess.opts.evm_version.supports_returndata()
-    }
-
-    /// Returns `true` if a call to `receiver` expecting `returns` return values must check that
-    /// the callee has code.
-    ///
-    /// A call on `this` needs no check in the runtime object: the contract's own code is running,
-    /// so it exists. The creation object has no such guarantee, because the code is only stored
-    /// once the constructor returns, so every function copied into it keeps the check.
-    pub(super) fn needs_receiver_code_check(
-        &self,
-        receiver: &hir::Expr<'_>,
-        returns: usize,
-    ) -> bool {
-        self.needs_code_check(returns)
-            && (self.in_creation_code
-                || self.cx.gcx.resolved_builtin(receiver) != Some(Builtin::This))
     }
 
     /// Returns the `gas` operand of an external call, materializing the pre-EIP-150 reserve when
@@ -975,11 +962,11 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
             overlay_buffer,
         );
         self.touch_call_output_area(options.gas, &return_plan);
-        if self.needs_receiver_code_check(receiver, returns) {
+        if self.needs_code_check(returns) {
             self.revert_if_no_code(address);
         }
-        // The call cannot create the callee's account: before EIP-150 the code check above is
-        // emitted for every callee but `this`, whose own code is running.
+        // The code check above is emitted at every version that needs the reserve, so the call
+        // cannot create the callee's account.
         // gas = gas() | sub(gas(), reserve)
         let gas = self.call_gas(options.gas, options.value_set, false);
         // ok = CALL|STATICCALL(gas, address, value, input, ret_offset, ret_size)

--- a/crates/codegen/src/lower/function/calls.rs
+++ b/crates/codegen/src/lower/function/calls.rs
@@ -3,7 +3,7 @@
 use super::*;
 
 #[derive(Clone, Copy)]
-struct ExternalReturnPlan {
+pub(super) struct ExternalReturnPlan {
     static_buffer: Option<(ValueId, ValueId, ValueId)>,
     offset: ValueId,
     size: ValueId,
@@ -17,8 +17,15 @@ struct ExternalReturnPlan {
     decode_returndata: bool,
 }
 
+impl ExternalReturnPlan {
+    /// The `(offset, size)` output-area operands of the call the plan was built for.
+    pub(super) fn output_area(&self) -> (ValueId, ValueId) {
+        (self.offset, self.size)
+    }
+}
+
 #[derive(Clone, Copy, PartialEq, Eq)]
-enum ExternalReturnMode {
+pub(super) enum ExternalReturnMode {
     First,
     All,
 }
@@ -1173,7 +1180,7 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
         .then(|| AbiParamLayout::new(types.into_boxed_slice()))
     }
 
-    fn plan_return_buffer(
+    pub(super) fn plan_return_buffer(
         &mut self,
         input: ValueId,
         zero: ValueId,
@@ -1235,7 +1242,11 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
     ///
     /// Nothing is emitted where the gas operand is already materialized: an explicit `{gas: ...}`
     /// is the caller's business, and from EIP-150 on the forwarded gas is capped anyway.
-    fn touch_call_output_area(&mut self, gas: Option<ValueId>, plan: &ExternalReturnPlan) {
+    pub(super) fn touch_call_output_area(
+        &mut self,
+        gas: Option<ValueId>,
+        plan: &ExternalReturnPlan,
+    ) {
         if gas.is_some() || !plan.owns_output_area || plan.size_bytes < 32 {
             return;
         }
@@ -1246,7 +1257,7 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
         self.builder.mstore(last, zero);
     }
 
-    fn finish_external_call(
+    pub(super) fn finish_external_call(
         &mut self,
         plan: ExternalReturnPlan,
         return_tys: &[Ty<'gcx>],

--- a/crates/codegen/src/lower/function/calls.rs
+++ b/crates/codegen/src/lower/function/calls.rs
@@ -7,12 +7,8 @@ pub(super) struct ExternalReturnPlan {
     static_buffer: Option<(ValueId, ValueId, ValueId)>,
     offset: ValueId,
     size: ValueId,
-    /// The output area's size in bytes, zero when the call declares no output area.
-    size_bytes: u64,
     /// Whether the output area overlays the input area, as it does before Byzantium.
     overlays_input: bool,
-    /// The input area's size in bytes, when the argument encoding gives it a constant one.
-    input_size_bytes: Option<u64>,
     decode_returndata: bool,
 }
 
@@ -24,9 +20,7 @@ impl ExternalReturnPlan {
             static_buffer: None,
             offset: zero,
             size: zero,
-            size_bytes: 0,
             overlays_input: false,
-            input_size_bytes: None,
             decode_returndata: true,
         }
     }
@@ -405,20 +399,14 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
         // buffer = alloc_overlay_return_buffer(returns)
         // input = abi_encode(selector, args)
         let overlay_buffer = self.alloc_overlay_return_buffer(&return_tys);
+        // mstore(add(fmp(), ret_size), 0)
+        self.touch_call_output_area(options.gas, &return_tys, overlay_buffer.is_some());
         let layout = Arc::new(AbiLayout::new(types.into_boxed_slice()));
-        let input_size_bytes = Self::static_input_size(&layout);
         let encoded = self.builder.abi_encode(layout, Some(selector), values.into_boxed_slice());
         let input = self.builder.slice_ptr(encoded);
         let input_size = self.builder.slice_len(encoded);
         // ret_offset, ret_size, decode = plan_return_buffer(returns)
-        let return_plan = self.plan_return_buffer(
-            input,
-            input_size_bytes,
-            options.zero,
-            &return_tys,
-            overlay_buffer,
-        );
-        self.touch_call_output_area(options.gas, &return_plan);
+        let return_plan = self.plan_return_buffer(input, options.zero, &return_tys, overlay_buffer);
         if self.needs_code_check(returns) {
             self.revert_if_no_code(address);
         }
@@ -946,22 +934,16 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
         // buffer = alloc_overlay_return_buffer(returns)
         // input = abi_encode(selector, args)
         let overlay_buffer = self.alloc_overlay_return_buffer(&return_tys);
+        // mstore(add(fmp(), ret_size), 0)
+        self.touch_call_output_area(options.gas, &return_tys, overlay_buffer.is_some());
         let selector = self.cx.gcx.function_selector(function_id).0;
         let selector = self.builder.imm(U256::from_be_slice(&selector) << 224);
         let layout = Arc::new(AbiLayout::new(types.into_boxed_slice()));
-        let input_size_bytes = Self::static_input_size(&layout);
         let encoded = self.builder.abi_encode(layout, Some(selector), values.into_boxed_slice());
         let input = self.builder.slice_ptr(encoded);
         let input_size = self.builder.slice_len(encoded);
         // ret_offset, ret_size, decode = plan_return_buffer(returns)
-        let return_plan = self.plan_return_buffer(
-            input,
-            input_size_bytes,
-            options.zero,
-            &return_tys,
-            overlay_buffer,
-        );
-        self.touch_call_output_area(options.gas, &return_plan);
+        let return_plan = self.plan_return_buffer(input, options.zero, &return_tys, overlay_buffer);
         if self.needs_code_check(returns) {
             self.revert_if_no_code(address);
         }
@@ -1144,10 +1126,12 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
         // buffer = alloc_overlay_return_buffer(returns)
         // input = abi_encode(selector, args)
         let overlay_buffer = self.alloc_overlay_return_buffer(&return_types);
+        // A library call takes no call options, so its gas operand is never already materialized.
+        // mstore(add(fmp(), ret_size), 0)
+        self.touch_call_output_area(None, &return_types, overlay_buffer.is_some());
         let selector = self.cx.gcx.function_selector(function_id).0;
         let selector = self.builder.imm(U256::from_be_slice(&selector) << 224);
         let layout = Arc::new(AbiLayout::new(types.into_boxed_slice()));
-        let input_size_bytes = Self::static_input_size(&layout);
         let encoded = self.builder.abi_encode(layout, Some(selector), values.into_boxed_slice());
         let input = self.builder.slice_ptr(encoded);
         let input_size = self.builder.slice_len(encoded);
@@ -1158,19 +1142,10 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
         // delegatecall writes them into an output area overlaying its input and the success path
         // reads them back from there, as solc's static output size does.
         // ret_offset, ret_size = plan_return_buffer(returns)
-        // mstore(ret_offset + ret_size - 32, 0)
         let return_plan = if evm_version.supports_returndata() {
             ExternalReturnPlan::returndata(zero)
         } else {
-            let plan = self.plan_return_buffer(
-                input,
-                input_size_bytes,
-                zero,
-                &return_types,
-                overlay_buffer,
-            );
-            self.touch_call_output_area(gas, &plan);
-            plan
+            self.plan_return_buffer(input, zero, &return_types, overlay_buffer)
         };
         if self.needs_code_check(return_types.len()) {
             self.revert_if_no_code(address);
@@ -1254,15 +1229,6 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
             .collect()
     }
 
-    /// The input area's size in bytes, when the argument encoding gives it a constant one.
-    ///
-    /// The size covers the four selector bytes every call in this module encodes. A dynamically
-    /// encoded argument has a run-time length, so such an input has no constant size.
-    pub(super) fn static_input_size(layout: &AbiLayout) -> Option<u64> {
-        (!layout.types.iter().any(AbiType::is_dynamic))
-            .then(|| layout.head_size().saturating_add(4))
-    }
-
     /// Allocates the buffer a pre-Byzantium call decodes its static aggregate returns from, which
     /// has to be in place before the arguments the output area overlays are encoded.
     ///
@@ -1284,7 +1250,6 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
     pub(super) fn plan_return_buffer(
         &mut self,
         input: ValueId,
-        input_size_bytes: Option<u64>,
         zero: ValueId,
         return_tys: &[Ty<'gcx>],
         overlay_buffer: Option<(ValueId, ValueId, ValueId)>,
@@ -1303,13 +1268,7 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
             // whatever untouched memory a buffer of its own would hold.
             // offset = input
             // size = head_size(static) | returns * 32
-            let size_bytes = match &static_return {
-                Some(layout) => overlay_buffer.and_then(|_| layout.checked_head_size()),
-                // A dynamically encoded return has no size to reserve before Byzantium;
-                // `finish_external_call` reports it.
-                None if decode_returndata => None,
-                None => Some(words),
-            };
+            let size_bytes = self.pre_byzantium_output_size(return_tys, overlay_buffer.is_some());
             let (offset, size, size_bytes) = match size_bytes {
                 Some(size_bytes) => (input, self.builder.imm(size_bytes), size_bytes),
                 None => (zero, zero, 0),
@@ -1318,9 +1277,7 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
                 static_buffer: overlay_buffer.filter(|_| size_bytes != 0),
                 offset,
                 size,
-                size_bytes,
                 overlays_input: true,
-                input_size_bytes,
                 decode_returndata,
             };
         }
@@ -1332,62 +1289,86 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
         let static_return_buffer = static_return
             .as_ref()
             .and_then(|layout| self.alloc_static_return_buffer(layout, false));
-        let (ret_offset, ret_size, size_bytes) = if let Some((_, data, size)) = static_return_buffer
-        {
-            let size_bytes =
-                static_return.as_ref().and_then(AbiParamLayout::checked_head_size).unwrap_or(0);
-            (data, size, size_bytes)
+        let (ret_offset, ret_size) = if let Some((_, data, size)) = static_return_buffer {
+            (data, size)
         } else if decode_returndata {
-            (zero, zero, 0)
+            (zero, zero)
         } else {
             let offset = if returns > 1 { input } else { zero };
-            (offset, self.builder.imm(words), words)
+            (offset, self.builder.imm(words))
         };
         ExternalReturnPlan {
             static_buffer: static_return_buffer,
             offset: ret_offset,
             size: ret_size,
-            size_bytes,
             overlays_input: false,
-            input_size_bytes,
             decode_returndata,
         }
     }
 
-    /// Touches the last word of a call's output area so that the memory the call needs is already
+    /// The size in bytes of the output area a pre-Byzantium call declares, which overlays the
+    /// call's input area.
+    ///
+    /// This is solc's `ReturnInfo::estimatedReturnSize`: the head size of the static return
+    /// values, and nothing for a dynamically encoded one, which `finish_external_call` reports as
+    /// unsupported before Byzantium.
+    fn pre_byzantium_output_size(
+        &mut self,
+        return_tys: &[Ty<'gcx>],
+        has_overlay_buffer: bool,
+    ) -> Option<u64> {
+        let static_return = self.static_aggregate_return_layout(return_tys.iter().copied());
+        match &static_return {
+            Some(layout) => has_overlay_buffer.then(|| layout.checked_head_size()).flatten(),
+            None => {
+                let decode_returndata = return_tys.iter().any(|&ty| {
+                    self.types.abi_return_type(ty).is_some_and(|ty| !matches!(ty, AbiType::Word(_)))
+                });
+                (!decode_returndata).then(|| (return_tys.len() as u64).saturating_mul(32))
+            }
+        }
+    }
+
+    /// Touches the word above a call's output area so that the memory the call needs is already
     /// expanded when its `gas` operand is computed.
     ///
     /// A pre-EIP-150 `CALL` is charged the expansion of its input and output areas out of the gas
     /// left before the forwarded gas is checked against the remainder, and the reserve
-    /// [`crate::utils::pre_tangerine_call_gas`] withholds does not cover it. solc touches the word
-    /// above the area instead (`appendExternalFunctionCall`), before it encodes the arguments the
-    /// area overlays.
+    /// [`crate::utils::pre_tangerine_call_gas`] withholds only leaves seven gas for it. solc
+    /// touches the word above the area in `appendExternalFunctionCall`, and this is the same
+    /// store: the area starts at the free-memory pointer, so writing at that pointer plus the
+    /// output size covers every word the call can expand memory to, whatever the arguments
+    /// encode to.
     ///
-    /// The output area starts where the arguments do, so encoding them already expanded memory to
-    /// their last word, and only an area reaching a word past them needs anything. That word is
-    /// above every argument byte, so zeroing it destroys nothing the call still has to send, and
-    /// the call overwrites it anyway. An input whose size is only known at run time leaves the
-    /// comparison undecidable and is left alone.
+    /// The store has to precede the argument encoding, which is what keeps it from clobbering an
+    /// argument the call still has to send. The word it writes is above the output area, so it is
+    /// either overwritten by the arguments or free memory the call leaves alone.
     ///
-    /// Nothing is emitted where the gas operand is already materialized: an explicit `{gas: ...}`
-    /// is the caller's business, and from EIP-150 on the forwarded gas is capped anyway.
+    /// Nothing is emitted where the gas operand is already materialized: an explicit
+    /// `{gas: ...}` is the caller's business, and from EIP-150 on the forwarded gas is capped
+    /// anyway, so the call cannot be aborted by an overcharge.
     pub(super) fn touch_call_output_area(
         &mut self,
         gas: Option<ValueId>,
-        plan: &ExternalReturnPlan,
+        return_tys: &[Ty<'gcx>],
+        has_overlay_buffer: bool,
     ) {
-        if gas.is_some() || !plan.overlays_input {
+        if gas.is_some() || self.cx.gcx.sess.opts.evm_version.can_overcharge_gas_for_call() {
             return;
         }
-        let Some(input_size) = plan.input_size_bytes else { return };
-        if plan.size_bytes < input_size.saturating_add(32) {
+        let Some(size_bytes) = self.pre_byzantium_output_size(return_tys, has_overlay_buffer)
+        else {
+            return;
+        };
+        if size_bytes == 0 {
             return;
         }
-        // mstore(add(ret_offset, ret_size - 32), 0)
-        let last = self.builder.imm(plan.size_bytes - 32);
-        let last = self.builder.add(plan.offset, last);
+        // mstore(add(fmp(), ret_size), 0)
+        let area = self.builder.fmp();
+        let size = self.builder.imm(size_bytes);
+        let above = self.builder.add(area, size);
         let zero = self.builder.imm(U256::ZERO);
-        self.builder.mstore(last, zero);
+        self.builder.mstore(above, zero);
     }
 
     pub(super) fn finish_external_call(

--- a/crates/codegen/src/lower/function/calls.rs
+++ b/crates/codegen/src/lower/function/calls.rs
@@ -9,11 +9,10 @@ pub(super) struct ExternalReturnPlan {
     size: ValueId,
     /// The output area's size in bytes, zero when the call declares no output area.
     size_bytes: u64,
-    /// Whether `offset` points at memory that holds nothing but the output area.
-    ///
-    /// Only such an area may be touched before the call: a reused input buffer still holds the
-    /// arguments the call is about to send.
-    owns_output_area: bool,
+    /// Whether the output area overlays the input area, as it does before Byzantium.
+    overlays_input: bool,
+    /// The input area's size in bytes, when the argument encoding gives it a constant one.
+    input_size_bytes: Option<u64>,
     decode_returndata: bool,
 }
 
@@ -26,7 +25,8 @@ impl ExternalReturnPlan {
             offset: zero,
             size: zero,
             size_bytes: 0,
-            owns_output_area: false,
+            overlays_input: false,
+            input_size_bytes: None,
             decode_returndata: true,
         }
     }
@@ -413,15 +413,24 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
             },
         )?;
         let (values, types): (Vec<_>, Vec<_>) = values_and_types.into_iter().unzip();
+        let return_tys = self.external_return_types(function.returns);
+        let returns = return_tys.len();
+        // buffer = alloc_overlay_return_buffer(returns)
         // input = abi_encode(selector, args)
+        let overlay_buffer = self.alloc_overlay_return_buffer(&return_tys);
         let layout = Arc::new(AbiLayout::new(types.into_boxed_slice()));
+        let input_size_bytes = Self::static_input_size(&layout);
         let encoded = self.builder.abi_encode(layout, Some(selector), values.into_boxed_slice());
         let input = self.builder.slice_ptr(encoded);
         let input_size = self.builder.slice_len(encoded);
-        let return_tys = self.external_return_types(function.returns);
-        let returns = return_tys.len();
-        // buffer, ret_offset, ret_size, decode = plan_return_buffer(returns)
-        let return_plan = self.plan_return_buffer(input, options.zero, &return_tys);
+        // ret_offset, ret_size, decode = plan_return_buffer(returns)
+        let return_plan = self.plan_return_buffer(
+            input,
+            input_size_bytes,
+            options.zero,
+            &return_tys,
+            overlay_buffer,
+        );
         self.touch_call_output_area(options.gas, &return_plan);
         if self.needs_code_check(returns) {
             self.revert_if_no_code(address);
@@ -940,13 +949,6 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
             "external function argument",
             false,
         )?;
-        // input = abi_encode(selector, args)
-        let selector = self.cx.gcx.function_selector(function_id).0;
-        let selector = self.builder.imm(U256::from_be_slice(&selector) << 224);
-        let layout = Arc::new(AbiLayout::new(types.into_boxed_slice()));
-        let encoded = self.builder.abi_encode(layout, Some(selector), values.into_boxed_slice());
-        let input = self.builder.slice_ptr(encoded);
-        let input_size = self.builder.slice_len(encoded);
         let return_tys = function
             .returns
             .iter()
@@ -954,8 +956,24 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
             .collect::<Vec<_>>();
         let return_tys = self.external_return_types(&return_tys);
         let returns = return_tys.len();
-        // buffer, ret_offset, ret_size, decode = plan_return_buffer(returns)
-        let return_plan = self.plan_return_buffer(input, options.zero, &return_tys);
+        // buffer = alloc_overlay_return_buffer(returns)
+        // input = abi_encode(selector, args)
+        let overlay_buffer = self.alloc_overlay_return_buffer(&return_tys);
+        let selector = self.cx.gcx.function_selector(function_id).0;
+        let selector = self.builder.imm(U256::from_be_slice(&selector) << 224);
+        let layout = Arc::new(AbiLayout::new(types.into_boxed_slice()));
+        let input_size_bytes = Self::static_input_size(&layout);
+        let encoded = self.builder.abi_encode(layout, Some(selector), values.into_boxed_slice());
+        let input = self.builder.slice_ptr(encoded);
+        let input_size = self.builder.slice_len(encoded);
+        // ret_offset, ret_size, decode = plan_return_buffer(returns)
+        let return_plan = self.plan_return_buffer(
+            input,
+            input_size_bytes,
+            options.zero,
+            &return_tys,
+            overlay_buffer,
+        );
         self.touch_call_output_area(options.gas, &return_plan);
         if self.needs_receiver_code_check(receiver, returns) {
             self.revert_if_no_code(address);
@@ -1129,32 +1147,41 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
             types.insert(0, ty);
         }
 
-        // input = abi_encode(selector, args)
-        let selector = self.cx.gcx.function_selector(function_id).0;
-        let selector = self.builder.imm(U256::from_be_slice(&selector) << 224);
-        let layout = Arc::new(AbiLayout::new(types.into_boxed_slice()));
-        let encoded = self.builder.abi_encode(layout, Some(selector), values.into_boxed_slice());
-        let input = self.builder.slice_ptr(encoded);
-        let input_size = self.builder.slice_len(encoded);
-        let zero = self.builder.imm(U256::ZERO);
-        let address = self.builder.imm(address);
         let evm_version = self.cx.gcx.sess.opts.evm_version;
-        let gas = evm_version.can_overcharge_gas_for_call().then(|| self.builder.gas());
         let return_types = function
             .returns
             .iter()
             .map(|&ret| self.cx.gcx.type_of_item(ret.into()))
             .collect::<Vec<_>>();
         let return_types = self.external_return_types(&return_types);
+        // buffer = alloc_overlay_return_buffer(returns)
+        // input = abi_encode(selector, args)
+        let overlay_buffer = self.alloc_overlay_return_buffer(&return_types);
+        let selector = self.cx.gcx.function_selector(function_id).0;
+        let selector = self.builder.imm(U256::from_be_slice(&selector) << 224);
+        let layout = Arc::new(AbiLayout::new(types.into_boxed_slice()));
+        let input_size_bytes = Self::static_input_size(&layout);
+        let encoded = self.builder.abi_encode(layout, Some(selector), values.into_boxed_slice());
+        let input = self.builder.slice_ptr(encoded);
+        let input_size = self.builder.slice_len(encoded);
+        let zero = self.builder.imm(U256::ZERO);
+        let address = self.builder.imm(address);
+        let gas = evm_version.can_overcharge_gas_for_call().then(|| self.builder.gas());
         // From Byzantium on the return values come out of the return data; before it the
-        // delegatecall writes them into an output area of its own and the success path reads them
-        // back from there, as solc's static output size does.
-        // buffer, ret_offset, ret_size = plan_return_buffer(returns)
+        // delegatecall writes them into an output area overlaying its input and the success path
+        // reads them back from there, as solc's static output size does.
+        // ret_offset, ret_size = plan_return_buffer(returns)
         // mstore(ret_offset + ret_size - 32, 0)
         let return_plan = if evm_version.supports_returndata() {
             ExternalReturnPlan::returndata(zero)
         } else {
-            let plan = self.plan_return_buffer(input, zero, &return_types);
+            let plan = self.plan_return_buffer(
+                input,
+                input_size_bytes,
+                zero,
+                &return_types,
+                overlay_buffer,
+            );
             self.touch_call_output_area(gas, &plan);
             plan
         };
@@ -1240,52 +1267,102 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
             .collect()
     }
 
+    /// The input area's size in bytes, when the argument encoding gives it a constant one.
+    ///
+    /// The size covers the four selector bytes every call in this module encodes. A dynamically
+    /// encoded argument has a run-time length, so such an input has no constant size.
+    pub(super) fn static_input_size(layout: &AbiLayout) -> Option<u64> {
+        (!layout.types.iter().any(AbiType::is_dynamic))
+            .then(|| layout.head_size().saturating_add(4))
+    }
+
+    /// Allocates the buffer a pre-Byzantium call decodes its static aggregate returns from, which
+    /// has to be in place before the arguments the output area overlays are encoded.
+    ///
+    /// Every allocation the encoding and the decoding make lands above the arguments, so it can
+    /// land inside the output area as well. A buffer taken before them sits below the arguments
+    /// instead, which keeps it disjoint from the area it is copied out of.
+    pub(super) fn alloc_overlay_return_buffer(
+        &mut self,
+        return_tys: &[Ty<'gcx>],
+    ) -> Option<(ValueId, ValueId, ValueId)> {
+        if self.cx.gcx.sess.opts.evm_version.supports_returndata() {
+            return None;
+        }
+        // buffer = bytes(head_size(static))
+        let layout = self.static_aggregate_return_layout(return_tys.iter().copied())?;
+        self.alloc_static_return_buffer(&layout, true)
+    }
+
     pub(super) fn plan_return_buffer(
         &mut self,
         input: ValueId,
+        input_size_bytes: Option<u64>,
         zero: ValueId,
         return_tys: &[Ty<'gcx>],
+        overlay_buffer: Option<(ValueId, ValueId, ValueId)>,
     ) -> ExternalReturnPlan {
+        let returns = return_tys.len();
+        let static_return = self.static_aggregate_return_layout(return_tys.iter().copied());
+        let decode_returndata = return_tys.iter().any(|&ty| {
+            self.types.abi_return_type(ty).is_some_and(|ty| !matches!(ty, AbiType::Word(_)))
+        });
+        let words = (returns as u64).saturating_mul(32);
+        if !self.cx.gcx.sess.opts.evm_version.supports_returndata() {
+            // Before Byzantium the output area overlays the input area, as solc's
+            // `appendExternalFunctionCall` lays out an ordinary call: a code-bearing callee that
+            // returns fewer bytes than it declares cannot be detected without `RETURNDATASIZE`,
+            // so the decoding reads the selector and arguments the call left behind rather than
+            // whatever untouched memory a buffer of its own would hold.
+            // offset = input
+            // size = head_size(static) | returns * 32
+            let size_bytes = match &static_return {
+                Some(layout) => overlay_buffer.and_then(|_| layout.checked_head_size()),
+                // A dynamically encoded return has no size to reserve before Byzantium;
+                // `finish_external_call` reports it.
+                None if decode_returndata => None,
+                None => Some(words),
+            };
+            let (offset, size, size_bytes) = match size_bytes {
+                Some(size_bytes) => (input, self.builder.imm(size_bytes), size_bytes),
+                None => (zero, zero, 0),
+            };
+            return ExternalReturnPlan {
+                static_buffer: overlay_buffer.filter(|_| size_bytes != 0),
+                offset,
+                size,
+                size_bytes,
+                overlays_input: true,
+                input_size_bytes,
+                decode_returndata,
+            };
+        }
         // static = static_aggregate_layout(returns)
         // buffer = static ? alloc_static_buffer(static) : none
         // decode = any_return_is_nonword
         // offset = static.data ? static.data : (!decode && returns > 1 ? input : zero)
         // size = static.size ? static.size : (decode ? 0 : returns * 32)
-        let returns = return_tys.len();
-        let static_return = self.static_aggregate_return_layout(return_tys.iter().copied());
-        let static_return_buffer =
-            static_return.as_ref().and_then(|layout| self.alloc_static_return_buffer(layout));
-        let decode_returndata = return_tys.iter().any(|&ty| {
-            self.types.abi_return_type(ty).is_some_and(|ty| !matches!(ty, AbiType::Word(_)))
-        });
-        let words = (returns as u64).saturating_mul(32);
-        let (ret_offset, ret_size, size_bytes, owns_output_area) = if let Some((_, data, size)) =
-            static_return_buffer
+        let static_return_buffer = static_return
+            .as_ref()
+            .and_then(|layout| self.alloc_static_return_buffer(layout, false));
+        let (ret_offset, ret_size, size_bytes) = if let Some((_, data, size)) = static_return_buffer
         {
             let size_bytes =
                 static_return.as_ref().and_then(AbiParamLayout::checked_head_size).unwrap_or(0);
-            (data, size, size_bytes, true)
+            (data, size, size_bytes)
         } else if decode_returndata {
-            (zero, zero, 0, false)
-        } else if returns > 1 && !self.cx.gcx.sess.opts.evm_version.can_overcharge_gas_for_call() {
-            // Before EIP-150 the output area gets a buffer of its own instead of reusing the
-            // input: the words the call would write above the arguments are untouched memory, and
-            // the expansion the call is charged for them comes out of the gas the caller has to
-            // withhold from the forwarded gas.
-            // buffer = alloc raw(returns * 32)
-            let size = self.builder.imm(words);
-            let buffer = self.builder.alloc_raw(size, AllocationSemantics::INTERNAL);
-            (buffer, size, words, true)
+            (zero, zero, 0)
         } else {
             let offset = if returns > 1 { input } else { zero };
-            (offset, self.builder.imm(words), words, false)
+            (offset, self.builder.imm(words), words)
         };
         ExternalReturnPlan {
             static_buffer: static_return_buffer,
             offset: ret_offset,
             size: ret_size,
             size_bytes,
-            owns_output_area,
+            overlays_input: false,
+            input_size_bytes,
             decode_returndata,
         }
     }
@@ -1295,10 +1372,15 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
     ///
     /// A pre-EIP-150 `CALL` is charged the expansion of its input and output areas out of the gas
     /// left before the forwarded gas is checked against the remainder, and the reserve
-    /// [`crate::utils::pre_tangerine_call_gas`] withholds does not cover it. The area's contents
-    /// are dead until the call overwrites them, so zeroing its last word has no other effect, and
-    /// it expands memory exactly as far as the call needs. solc touches the word above the area
-    /// instead (`appendExternalFunctionCall`), one word more than it needs.
+    /// [`crate::utils::pre_tangerine_call_gas`] withholds does not cover it. solc touches the word
+    /// above the area instead (`appendExternalFunctionCall`), before it encodes the arguments the
+    /// area overlays.
+    ///
+    /// The output area starts where the arguments do, so encoding them already expanded memory to
+    /// their last word, and only an area reaching a word past them needs anything. That word is
+    /// above every argument byte, so zeroing it destroys nothing the call still has to send, and
+    /// the call overwrites it anyway. An input whose size is only known at run time leaves the
+    /// comparison undecidable and is left alone.
     ///
     /// Nothing is emitted where the gas operand is already materialized: an explicit `{gas: ...}`
     /// is the caller's business, and from EIP-150 on the forwarded gas is capped anyway.
@@ -1307,7 +1389,11 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
         gas: Option<ValueId>,
         plan: &ExternalReturnPlan,
     ) {
-        if gas.is_some() || !plan.owns_output_area || plan.size_bytes < 32 {
+        if gas.is_some() || !plan.overlays_input {
+            return;
+        }
+        let Some(input_size) = plan.input_size_bytes else { return };
+        if plan.size_bytes < input_size.saturating_add(32) {
             return;
         }
         // mstore(add(ret_offset, ret_size - 32), 0)
@@ -1330,8 +1416,14 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
         if returns == 0 {
             return Some(Vec::new());
         }
-        let data = if let Some((data, _, size)) = static_buffer {
+        let data = if let Some((data, buffer, size)) = static_buffer {
             self.revert_if_short_returndata(size);
+            if plan.overlays_input {
+                // The output area overlays the arguments, so the values move out of it before the
+                // decoding allocates over them.
+                // mcopy(buffer, ret_offset, ret_size)
+                self.builder.mcopy(buffer, offset, size);
+            }
             Some(data)
         } else if decode_returndata {
             if !self.cx.gcx.sess.opts.evm_version.supports_returndata() {
@@ -1384,15 +1476,21 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
         Some(values.into_iter().next().expect("external return list is not empty"))
     }
 
+    /// Allocates the buffer a call decodes its static aggregate return values from.
+    ///
+    /// `as_bytes` allocates a bytes object, which the decoding reads in place; a single return
+    /// value otherwise decodes out of a raw buffer, which the decoding copies into a bytes object
+    /// of its own.
     fn alloc_static_return_buffer(
         &mut self,
         layout: &AbiParamLayout,
+        as_bytes: bool,
     ) -> Option<(ValueId, ValueId, ValueId)> {
         // size = head_size(layout)
         // buffer = bytes(size) if multiple_returns else raw(size)
         // return (buffer, data, size)
         let size = layout.checked_head_size()?;
-        if layout.types.len() != 1 {
+        if as_bytes || layout.types.len() != 1 {
             let object_size = self.builder.imm(size.checked_add(EvmMemoryLayout::WORD_SIZE)?);
             let object = self.builder.alloc_object(
                 object_size,

--- a/crates/codegen/src/lower/function/calls.rs
+++ b/crates/codegen/src/lower/function/calls.rs
@@ -1071,7 +1071,17 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
         let source = self.cx.gcx.hir.source(contract.source).file.name.display().to_string();
 
         let name = contract.name.as_str_in(self.cx.gcx.sess).to_string();
-        let hash = keccak256(format!("{source}:{name}"));
+        // The source map keeps absolute file names under `-Zui-testing` (the UI runner relies
+        // on them), so hash only the file name there; otherwise the placeholder would change
+        // with the checkout path and no blessed output could pin it.
+        let hashed_source = if self.cx.gcx.sess.opts.unstable.ui_testing
+            && let Some(file_name) = std::path::Path::new(&source).file_name()
+        {
+            file_name.to_string_lossy().into_owned()
+        } else {
+            source.clone()
+        };
+        let hash = keccak256(format!("{hashed_source}:{name}"));
         let mut placeholder = <[u8; 20]>::try_from(&hash[..20]).unwrap();
         placeholder[0] |= 0x80;
         self.cx.module.add_library_link(LibraryLink { source, name, placeholder });

--- a/crates/codegen/src/lower/function/calls.rs
+++ b/crates/codegen/src/lower/function/calls.rs
@@ -1384,15 +1384,15 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
         if returns == 0 {
             return Some(Vec::new());
         }
-        let data = if let Some((data, buffer, size)) = static_buffer {
+        let source = if let Some((object, data, size)) = static_buffer {
             self.revert_if_short_returndata(size);
             if plan.overlays_input {
                 // The output area overlays the arguments, so the values move out of it before the
                 // decoding allocates over them.
-                // mcopy(buffer, ret_offset, ret_size)
-                self.builder.mcopy(buffer, offset, size);
+                // mcopy(data, ret_offset, ret_size)
+                self.builder.mcopy(data, offset, size);
             }
-            Some(data)
+            Some(object)
         } else if decode_returndata {
             if !self.cx.gcx.sess.opts.evm_version.supports_returndata() {
                 return report_error(self.cx.gcx, span, unsupported_returndata);
@@ -1401,11 +1401,11 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
         } else {
             None
         };
-        if let Some(data) = data {
+        if let Some(source) = source {
             return if mode == ExternalReturnMode::All {
-                self.lower_abi_decode_values(data, return_tys, span)
+                self.lower_abi_decode_values(source, return_tys, span)
             } else {
-                self.lower_decoded_return_value(data, return_tys, span).map(|value| vec![value])
+                self.lower_decoded_return_value(source, return_tys, span).map(|value| vec![value])
             };
         }
         self.validate_static_returndata(offset, return_tys);

--- a/crates/codegen/src/lower/function/calls.rs
+++ b/crates/codegen/src/lower/function/calls.rs
@@ -7,6 +7,13 @@ struct ExternalReturnPlan {
     static_buffer: Option<(ValueId, ValueId, ValueId)>,
     offset: ValueId,
     size: ValueId,
+    /// The output area's size in bytes, zero when the call declares no output area.
+    size_bytes: u64,
+    /// Whether `offset` points at memory that holds nothing but the output area.
+    ///
+    /// Only such an area may be touched before the call: a reused input buffer still holds the
+    /// arguments the call is about to send.
+    owns_output_area: bool,
     decode_returndata: bool,
 }
 
@@ -46,6 +53,23 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
         self.needs_code_check(returns)
             && (self.in_creation_code
                 || self.cx.gcx.resolved_builtin(receiver) != Some(Builtin::This))
+    }
+
+    /// Returns the `gas` operand of an external call, materializing the pre-EIP-150 reserve when
+    /// [`LoweredCallOptions::gas`] left it to the call site.
+    ///
+    /// `may_create_account` says whether the call can create the callee's account, which a
+    /// pre-EIP-150 `CALL` charges the caller for. Emit this immediately before the call: on such
+    /// a target everything after the `GAS` runs on the withheld gas.
+    pub(super) fn call_gas(
+        &mut self,
+        gas: Option<ValueId>,
+        sends_value: bool,
+        may_create_account: bool,
+    ) -> ValueId {
+        gas.unwrap_or_else(|| {
+            crate::utils::pre_tangerine_call_gas(&mut self.builder, sends_value, may_create_account)
+        })
     }
 
     pub(super) fn lower_user_operator(
@@ -359,7 +383,7 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
         // address, selector = split_function_pointer(function)
         let (address, selector) = self.split_external_function_pointer(function_value);
 
-        let (gas, call_value, zero) = self.lower_call_options(call_opts, true, "call option")?;
+        let options = self.lower_call_options(call_opts, true, "call option")?;
 
         let values_and_types = self.lower_argument_exprs(
             CallArgumentParams { count: arg_exprs.len(), names: None, reverse: false },
@@ -377,10 +401,15 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
         let return_tys = function.returns;
         let returns = return_tys.len();
         // buffer, ret_offset, ret_size, decode = plan_return_buffer(returns)
-        let return_plan = self.plan_return_buffer(input, zero, return_tys);
+        let return_plan = self.plan_return_buffer(input, options.zero, return_tys);
+        self.touch_call_output_area(options.gas, &return_plan);
         if self.needs_code_check(returns) {
             self.revert_if_no_code(address);
         }
+        // The code check above is emitted at every version that needs the reserve, so the call
+        // cannot create the callee's account.
+        // gas = gas() | sub(gas(), reserve)
+        let gas = self.call_gas(options.gas, options.value_set, false);
         // ok = CALL|STATICCALL(gas, address, value, input, ret_offset, ret_size)
         let success = if self.uses_static_call(function.state_mutability) {
             self.builder.staticcall(
@@ -395,7 +424,7 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
             self.builder.call(
                 gas,
                 address,
-                call_value,
+                options.value,
                 input,
                 input_size,
                 return_plan.offset,
@@ -875,7 +904,7 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
             return self.cx.report_unsupported(expr.span, "external function argument list");
         }
         let address = self.lower_expr(receiver)?;
-        let (gas, call_value, zero) = self.lower_call_options(call_opts, true, "call option")?;
+        let options = self.lower_call_options(call_opts, true, "call option")?;
         let parameter_names = self.cx.gcx.callable_param_names(CallableParamSource::Function {
             id: function_id,
             skips_receiver: false,
@@ -905,10 +934,15 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
             .collect::<Vec<_>>();
         let returns = return_tys.len();
         // buffer, ret_offset, ret_size, decode = plan_return_buffer(returns)
-        let return_plan = self.plan_return_buffer(input, zero, &return_tys);
+        let return_plan = self.plan_return_buffer(input, options.zero, &return_tys);
+        self.touch_call_output_area(options.gas, &return_plan);
         if self.needs_receiver_code_check(receiver, returns) {
             self.revert_if_no_code(address);
         }
+        // The call cannot create the callee's account: before EIP-150 the code check above is
+        // emitted for every callee but `this`, whose own code is running.
+        // gas = gas() | sub(gas(), reserve)
+        let gas = self.call_gas(options.gas, options.value_set, false);
         // ok = CALL|STATICCALL(gas, address, value, input, ret_offset, ret_size)
         let success = if self.uses_static_call(function.state_mutability) {
             self.builder.staticcall(
@@ -923,7 +957,7 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
             self.builder.call(
                 gas,
                 address,
-                call_value,
+                options.value,
                 input,
                 input_size,
                 return_plan.offset,
@@ -940,7 +974,7 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
             ExternalReturnMode::First,
             "codegen cannot decode external function returndata before Byzantium",
         )?;
-        Some(values.into_iter().next().unwrap_or(zero))
+        Some(values.into_iter().next().unwrap_or(options.zero))
     }
 
     pub(super) fn lower_abi_call_arguments(
@@ -1073,10 +1107,15 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
         let input_size = self.builder.slice_len(encoded);
         let zero = self.builder.imm(U256::ZERO);
         let address = self.builder.imm(address);
-        let gas = self.builder.gas();
+        let evm_version = self.cx.gcx.sess.opts.evm_version;
+        let gas = evm_version.can_overcharge_gas_for_call().then(|| self.builder.gas());
         if self.needs_code_check(function.returns.len()) {
             self.revert_if_no_code(address);
         }
+        // A delegatecall transfers no value and creates no account, so the pre-EIP-150 reserve is
+        // the call's base cost alone.
+        // gas = gas() | sub(gas(), reserve)
+        let gas = self.call_gas(gas, false, false);
         // ok = delegatecall(gas, library, input, 0, 0)
         let success = self.builder.delegatecall(gas, address, input, input_size, zero, zero);
         // if !ok { revert(0, returndatasize()) }
@@ -1095,6 +1134,8 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
                 static_buffer: None,
                 offset: zero,
                 size: zero,
+                size_bytes: 0,
+                owns_output_area: false,
                 decode_returndata: true,
             },
             &return_types,
@@ -1150,23 +1191,59 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
         let decode_returndata = return_tys.iter().any(|&ty| {
             self.types.abi_return_type(ty).is_some_and(|ty| !matches!(ty, AbiType::Word(_)))
         });
-        let ret_offset = static_return_buffer.as_ref().map_or_else(
-            || if !decode_returndata && returns > 1 { input } else { zero },
-            |(_, data, _)| *data,
-        );
-        let ret_size = if let Some((_, _, size)) = static_return_buffer.as_ref() {
-            *size
+        let words = (returns as u64).saturating_mul(32);
+        let (ret_offset, ret_size, size_bytes, owns_output_area) = if let Some((_, data, size)) =
+            static_return_buffer
+        {
+            let size_bytes =
+                static_return.as_ref().and_then(AbiParamLayout::checked_head_size).unwrap_or(0);
+            (data, size, size_bytes, true)
         } else if decode_returndata {
-            zero
+            (zero, zero, 0, false)
+        } else if returns > 1 && !self.cx.gcx.sess.opts.evm_version.can_overcharge_gas_for_call() {
+            // Before EIP-150 the output area gets a buffer of its own instead of reusing the
+            // input: the words the call would write above the arguments are untouched memory, and
+            // the expansion the call is charged for them comes out of the gas the caller has to
+            // withhold from the forwarded gas.
+            // buffer = alloc raw(returns * 32)
+            let size = self.builder.imm(words);
+            let buffer = self.builder.alloc_raw(size, AllocationSemantics::INTERNAL);
+            (buffer, size, words, true)
         } else {
-            self.builder.imm((returns as u64).saturating_mul(32))
+            let offset = if returns > 1 { input } else { zero };
+            (offset, self.builder.imm(words), words, false)
         };
         ExternalReturnPlan {
             static_buffer: static_return_buffer,
             offset: ret_offset,
             size: ret_size,
+            size_bytes,
+            owns_output_area,
             decode_returndata,
         }
+    }
+
+    /// Touches the last word of a call's output area so that the memory the call needs is already
+    /// expanded when its `gas` operand is computed.
+    ///
+    /// A pre-EIP-150 `CALL` is charged the expansion of its input and output areas out of the gas
+    /// left before the forwarded gas is checked against the remainder, and the reserve
+    /// [`crate::utils::pre_tangerine_call_gas`] withholds does not cover it. The area's contents
+    /// are dead until the call overwrites them, so zeroing its last word has no other effect, and
+    /// it expands memory exactly as far as the call needs. solc touches the word above the area
+    /// instead (`appendExternalFunctionCall`), one word more than it needs.
+    ///
+    /// Nothing is emitted where the gas operand is already materialized: an explicit `{gas: ...}`
+    /// is the caller's business, and from EIP-150 on the forwarded gas is capped anyway.
+    fn touch_call_output_area(&mut self, gas: Option<ValueId>, plan: &ExternalReturnPlan) {
+        if gas.is_some() || !plan.owns_output_area || plan.size_bytes < 32 {
+            return;
+        }
+        // mstore(add(ret_offset, ret_size - 32), 0)
+        let last = self.builder.imm(plan.size_bytes - 32);
+        let last = self.builder.add(plan.offset, last);
+        let zero = self.builder.imm(U256::ZERO);
+        self.builder.mstore(last, zero);
     }
 
     fn finish_external_call(

--- a/crates/codegen/src/lower/function/calls.rs
+++ b/crates/codegen/src/lower/function/calls.rs
@@ -418,10 +418,10 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
         let encoded = self.builder.abi_encode(layout, Some(selector), values.into_boxed_slice());
         let input = self.builder.slice_ptr(encoded);
         let input_size = self.builder.slice_len(encoded);
-        let return_tys = function.returns;
+        let return_tys = self.external_return_types(function.returns);
         let returns = return_tys.len();
         // buffer, ret_offset, ret_size, decode = plan_return_buffer(returns)
-        let return_plan = self.plan_return_buffer(input, options.zero, return_tys);
+        let return_plan = self.plan_return_buffer(input, options.zero, &return_tys);
         self.touch_call_output_area(options.gas, &return_plan);
         if self.needs_code_check(returns) {
             self.revert_if_no_code(address);
@@ -456,7 +456,7 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
         // results = decode_buffer | decode_returndata | load_words(ret_offset)
         self.finish_external_call(
             return_plan,
-            return_tys,
+            &return_tys,
             callee.span,
             ExternalReturnMode::All,
             "codegen cannot decode external function-pointer returndata before Byzantium",
@@ -952,6 +952,7 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
             .iter()
             .map(|&ret| self.cx.gcx.type_of_item(ret.into()))
             .collect::<Vec<_>>();
+        let return_tys = self.external_return_types(&return_tys);
         let returns = return_tys.len();
         // buffer, ret_offset, ret_size, decode = plan_return_buffer(returns)
         let return_plan = self.plan_return_buffer(input, options.zero, &return_tys);
@@ -1134,6 +1135,7 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
             .iter()
             .map(|&ret| self.cx.gcx.type_of_item(ret.into()))
             .collect::<Vec<_>>();
+        let return_types = self.external_return_types(&return_types);
         // From Byzantium on the return values come out of the return data; before it the
         // delegatecall writes them into an output area of its own and the success path reads them
         // back from there, as solc's static output size does.
@@ -1203,6 +1205,29 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
             && types.iter().all(|ty| !ty.is_dynamic())
             && types.iter().any(|ty| !ty.is_scalar_word()))
         .then(|| AbiParamLayout::new(types.into_boxed_slice()))
+    }
+
+    /// Replaces every dynamically encoded return type with a word before Byzantium.
+    ///
+    /// Without `RETURNDATASIZE` the size of such a value is unknowable, so solc types it as an
+    /// inaccessible dynamic type whose decoding type is `uint256`
+    /// (`FunctionType::returnParameterTypesWithoutDynamicTypes`): the call reserves a word for it
+    /// in its output area and nothing decodes it, because the type checker rejects every use of
+    /// the value. The remaining return values stay accessible, as in solc.
+    pub(super) fn external_return_types(&mut self, return_tys: &[Ty<'gcx>]) -> Vec<Ty<'gcx>> {
+        if self.cx.gcx.sess.opts.evm_version.supports_returndata() {
+            return return_tys.to_vec();
+        }
+        return_tys
+            .iter()
+            .map(|&ty| {
+                if self.types.abi_return_type(ty).is_some_and(|abi| abi.is_dynamic()) {
+                    self.cx.gcx.types.uint(256)
+                } else {
+                    ty
+                }
+            })
+            .collect()
     }
 
     pub(super) fn plan_return_buffer(

--- a/crates/codegen/src/lower/function/calls.rs
+++ b/crates/codegen/src/lower/function/calls.rs
@@ -18,6 +18,19 @@ pub(super) struct ExternalReturnPlan {
 }
 
 impl ExternalReturnPlan {
+    /// A plan for a call that declares no output area and decodes its return values from the
+    /// return data, which only exists from Byzantium on.
+    fn returndata(zero: ValueId) -> Self {
+        Self {
+            static_buffer: None,
+            offset: zero,
+            size: zero,
+            size_bytes: 0,
+            owns_output_area: false,
+            decode_returndata: true,
+        }
+    }
+
     /// The `(offset, size)` output-area operands of the call the plan was built for.
     pub(super) fn output_area(&self) -> (ValueId, ValueId) {
         (self.offset, self.size)
@@ -1116,35 +1129,47 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
         let address = self.builder.imm(address);
         let evm_version = self.cx.gcx.sess.opts.evm_version;
         let gas = evm_version.can_overcharge_gas_for_call().then(|| self.builder.gas());
-        if self.needs_code_check(function.returns.len()) {
+        let return_types = function
+            .returns
+            .iter()
+            .map(|&ret| self.cx.gcx.type_of_item(ret.into()))
+            .collect::<Vec<_>>();
+        // From Byzantium on the return values come out of the return data; before it the
+        // delegatecall writes them into an output area of its own and the success path reads them
+        // back from there, as solc's static output size does.
+        // buffer, ret_offset, ret_size = plan_return_buffer(returns)
+        // mstore(ret_offset + ret_size - 32, 0)
+        let return_plan = if evm_version.supports_returndata() {
+            ExternalReturnPlan::returndata(zero)
+        } else {
+            let plan = self.plan_return_buffer(input, zero, &return_types);
+            self.touch_call_output_area(gas, &plan);
+            plan
+        };
+        if self.needs_code_check(return_types.len()) {
             self.revert_if_no_code(address);
         }
         // A delegatecall transfers no value and creates no account, so the pre-EIP-150 reserve is
         // the call's base cost alone.
         // gas = gas() | sub(gas(), reserve)
         let gas = self.call_gas(gas, false, false);
-        // ok = delegatecall(gas, library, input, 0, 0)
-        let success = self.builder.delegatecall(gas, address, input, input_size, zero, zero);
+        // ok = delegatecall(gas, library, input, ret_offset, ret_size)
+        let success = self.builder.delegatecall(
+            gas,
+            address,
+            input,
+            input_size,
+            return_plan.offset,
+            return_plan.size,
+        );
         // if !ok { revert(0, returndatasize()) }
         self.revert_external_call(success);
-        if function.returns.is_empty() {
+        if return_types.is_empty() {
             return Some(zero);
         }
-        // result = abi_decode(returndata)
-        let return_types = function
-            .returns
-            .iter()
-            .map(|&ret| self.cx.gcx.type_of_item(ret.into()))
-            .collect::<Vec<_>>();
+        // result = load_words(ret_offset) | abi_decode(buffer) | abi_decode(returndata)
         let values = self.finish_external_call(
-            ExternalReturnPlan {
-                static_buffer: None,
-                offset: zero,
-                size: zero,
-                size_bytes: 0,
-                owns_output_area: false,
-                decode_returndata: true,
-            },
+            return_plan,
             &return_types,
             expr.span,
             ExternalReturnMode::First,

--- a/crates/codegen/src/lower/function/calls.rs
+++ b/crates/codegen/src/lower/function/calls.rs
@@ -22,6 +22,16 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
             && self.cx.gcx.sess.opts.evm_version.has_static_call()
     }
 
+    /// Returns `true` if a call expecting `returns` return values must check that the callee has
+    /// code.
+    ///
+    /// A call that expects return data needs no check from Byzantium on: a code-less callee
+    /// returns nothing, so the return-data length check reverts anyway. Before Byzantium there is
+    /// no `RETURNDATASIZE` and nothing subsumes the check, so every call needs it.
+    pub(super) fn needs_code_check(&self, returns: usize) -> bool {
+        returns == 0 || !self.cx.gcx.sess.opts.evm_version.supports_returndata()
+    }
+
     pub(super) fn lower_user_operator(
         &mut self,
         span: Span,
@@ -352,7 +362,7 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
         let returns = return_tys.len();
         // buffer, ret_offset, ret_size, decode = plan_return_buffer(returns)
         let return_plan = self.plan_return_buffer(input, zero, return_tys);
-        if returns == 0 {
+        if self.needs_code_check(returns) {
             self.revert_if_no_code(address);
         }
         // ok = CALL|STATICCALL(gas, address, value, input, ret_offset, ret_size)
@@ -880,7 +890,7 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
         let returns = return_tys.len();
         // buffer, ret_offset, ret_size, decode = plan_return_buffer(returns)
         let return_plan = self.plan_return_buffer(input, zero, &return_tys);
-        if returns == 0
+        if self.needs_code_check(returns)
             && (self.builder.func().attributes.is_constructor
                 || self.cx.gcx.resolved_builtin(receiver) != Some(Builtin::This))
         {
@@ -1051,7 +1061,7 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
         let zero = self.builder.imm(U256::ZERO);
         let address = self.builder.imm(address);
         let gas = self.builder.gas();
-        if function.returns.is_empty() {
+        if self.needs_code_check(function.returns.len()) {
             self.revert_if_no_code(address);
         }
         // ok = delegatecall(gas, library, input, 0, 0)
@@ -1177,9 +1187,7 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
                 self.lower_decoded_return_value(data, return_tys, span).map(|value| vec![value])
             };
         }
-        if self.cx.gcx.sess.opts.evm_version.supports_returndata() {
-            self.validate_static_returndata(offset, return_tys);
-        }
+        self.validate_static_returndata(offset, return_tys);
         if returns > 1 {
             self.builder.frame_store(0, FrameMode::MultiReturn, FrameSlotKind::Word, offset);
         }
@@ -1241,6 +1249,11 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
     }
 
     fn revert_if_short_returndata(&mut self, expected: ValueId) {
+        // Before Byzantium the returned length is unobservable, so there is nothing to compare
+        // against; `revert_if_no_code` guards the code-less callee instead.
+        if !self.cx.gcx.sess.opts.evm_version.supports_returndata() {
+            return;
+        }
         let actual = self.current_returndata_size();
         let short = self.builder.lt(actual, expected);
         self.builder.revert_if(short);

--- a/crates/codegen/src/lower/function/calls.rs
+++ b/crates/codegen/src/lower/function/calls.rs
@@ -32,6 +32,22 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
         returns == 0 || !self.cx.gcx.sess.opts.evm_version.supports_returndata()
     }
 
+    /// Returns `true` if a call to `receiver` expecting `returns` return values must check that
+    /// the callee has code.
+    ///
+    /// A call on `this` needs no check in the runtime object: the contract's own code is running,
+    /// so it exists. The creation object has no such guarantee, because the code is only stored
+    /// once the constructor returns, so every function copied into it keeps the check.
+    pub(super) fn needs_receiver_code_check(
+        &self,
+        receiver: &hir::Expr<'_>,
+        returns: usize,
+    ) -> bool {
+        self.needs_code_check(returns)
+            && (self.in_creation_code
+                || self.cx.gcx.resolved_builtin(receiver) != Some(Builtin::This))
+    }
+
     pub(super) fn lower_user_operator(
         &mut self,
         span: Span,
@@ -890,10 +906,7 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
         let returns = return_tys.len();
         // buffer, ret_offset, ret_size, decode = plan_return_buffer(returns)
         let return_plan = self.plan_return_buffer(input, zero, &return_tys);
-        if self.needs_code_check(returns)
-            && (self.builder.func().attributes.is_constructor
-                || self.cx.gcx.resolved_builtin(receiver) != Some(Builtin::This))
-        {
+        if self.needs_receiver_code_check(receiver, returns) {
             self.revert_if_no_code(address);
         }
         // ok = CALL|STATICCALL(gas, address, value, input, ret_offset, ret_size)

--- a/crates/codegen/src/lower/function/control_flow.rs
+++ b/crates/codegen/src/lower/function/control_flow.rs
@@ -399,15 +399,15 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
             let input_size = self.builder.slice_len(encoded);
             let ret_offset = zero;
             let ret_size = self.builder.imm(0);
-            let check_code = self.needs_code_check(target.return_types.len())
-                && match target.callee {
-                    TryCallee::Member { receiver, .. } => {
-                        self.builder.func().attributes.is_constructor
-                            || self.cx.gcx.resolved_builtin(receiver) != Some(Builtin::This)
-                    }
-                    TryCallee::LinkedLibrary { .. } | TryCallee::FunctionPointer { .. } => true,
-                    TryCallee::Creation { .. } => unreachable!(),
-                };
+            let check_code = match target.callee {
+                TryCallee::Member { receiver, .. } => {
+                    self.needs_receiver_code_check(receiver, target.return_types.len())
+                }
+                TryCallee::LinkedLibrary { .. } | TryCallee::FunctionPointer { .. } => {
+                    self.needs_code_check(target.return_types.len())
+                }
+                TryCallee::Creation { .. } => unreachable!(),
+            };
             if check_code {
                 self.revert_if_no_code(address);
             }

--- a/crates/codegen/src/lower/function/control_flow.rs
+++ b/crates/codegen/src/lower/function/control_flow.rs
@@ -441,16 +441,7 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
             } else {
                 (zero, self.builder.imm(0))
             };
-            let check_code = match target.callee {
-                TryCallee::Member { receiver, .. } => {
-                    self.needs_receiver_code_check(receiver, return_types.len())
-                }
-                TryCallee::LinkedLibrary { .. } | TryCallee::FunctionPointer { .. } => {
-                    self.needs_code_check(return_types.len())
-                }
-                TryCallee::Creation { .. } => unreachable!(),
-            };
-            if check_code {
+            if self.needs_code_check(return_types.len()) {
                 self.revert_if_no_code(address);
             }
             // The code check above is emitted at every version that needs the reserve, so the

--- a/crates/codegen/src/lower/function/control_flow.rs
+++ b/crates/codegen/src/lower/function/control_flow.rs
@@ -340,12 +340,14 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
             }
         }
         // Before Byzantium only a bare `catch { }` is lowerable: there is no return data for a
-        // typed clause to match or bind, and the type checker already rejected one.
+        // typed clause to match or bind. The type checker rejects one, so this reports rather
+        // than bailing silently, which would leave the caller without a diagnostic.
         let supports_returndata = self.cx.gcx.sess.opts.evm_version.supports_returndata();
         if !supports_returndata
-            && catch_clauses.iter().any(|clause| clause.name.is_some() || !clause.args.is_empty())
+            && let Some(clause) =
+                catch_clauses.iter().find(|clause| clause.name.is_some() || !clause.args.is_empty())
         {
-            return None;
+            return self.cx.report_unsupported(clause.span, "typed catch clause");
         }
         if args.len() != target.parameter_types.len() {
             return self.cx.report_unsupported(args.span, "try argument list");

--- a/crates/codegen/src/lower/function/control_flow.rs
+++ b/crates/codegen/src/lower/function/control_flow.rs
@@ -350,6 +350,7 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
         if args.len() != target.parameter_types.len() {
             return self.cx.report_unsupported(args.span, "try argument list");
         }
+        let return_types = self.external_return_types(&target.return_types);
 
         let (success, creation_value, ret_plan) = if let TryCallee::Creation { ty, contract_id } =
             target.callee
@@ -421,8 +422,8 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
             // and the success path reads them back from there.
             // buffer, ret_offset, ret_size = plan_return_buffer(returns)
             // mstore(ret_offset + ret_size - 32, 0)
-            let ret_plan = (!supports_returndata)
-                .then(|| self.plan_return_buffer(input, zero, &target.return_types));
+            let ret_plan =
+                (!supports_returndata).then(|| self.plan_return_buffer(input, zero, &return_types));
             let (ret_offset, ret_size) = if let Some(plan) = &ret_plan {
                 self.touch_call_output_area(options.gas, plan);
                 plan.output_area()
@@ -431,10 +432,10 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
             };
             let check_code = match target.callee {
                 TryCallee::Member { receiver, .. } => {
-                    self.needs_receiver_code_check(receiver, target.return_types.len())
+                    self.needs_receiver_code_check(receiver, return_types.len())
                 }
                 TryCallee::LinkedLibrary { .. } | TryCallee::FunctionPointer { .. } => {
-                    self.needs_code_check(target.return_types.len())
+                    self.needs_code_check(return_types.len())
                 }
                 TryCallee::Creation { .. } => unreachable!(),
             };
@@ -476,12 +477,12 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
                 return self.cx.report_unsupported(returns_clause.span, "try return binding list");
             };
             self.values.insert(binding, value);
-        } else if !target.return_types.is_empty() {
+        } else if !return_types.is_empty() {
             let values = if let Some(plan) = ret_plan {
                 // success.returns = load_words(ret_offset) | abi_decode(buffer)
                 self.finish_external_call(
                     plan,
-                    &target.return_types,
+                    &return_types,
                     returns_clause.span,
                     ExternalReturnMode::All,
                     "codegen cannot decode try/catch returndata before Byzantium",
@@ -489,7 +490,7 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
             } else {
                 // success.returns = abi_decode(returndata)
                 let data = self.materialize_returndata_bytes();
-                self.lower_abi_decode_values(data, &target.return_types, returns_clause.span)?
+                self.lower_abi_decode_values(data, &return_types, returns_clause.span)?
             };
             for (&binding, value) in returns_clause.args.iter().zip(values) {
                 self.values.insert(binding, value);

--- a/crates/codegen/src/lower/function/control_flow.rs
+++ b/crates/codegen/src/lower/function/control_flow.rs
@@ -415,8 +415,9 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
             // buffer = alloc_overlay_return_buffer(returns)
             // input = abi_encode(selector, args)
             let overlay_buffer = self.alloc_overlay_return_buffer(&return_types);
+            // mstore(add(fmp(), ret_size), 0)
+            self.touch_call_output_area(options.gas, &return_types, overlay_buffer.is_some());
             let layout = Arc::new(AbiLayout::new(types.into_boxed_slice()));
-            let input_size_bytes = Self::static_input_size(&layout);
             let encoded =
                 self.builder.abi_encode(layout, Some(selector), values.into_boxed_slice());
             let input = self.builder.slice_ptr(encoded);
@@ -425,21 +426,11 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
             // clauses need anyway; before it the call writes them into an output area overlaying
             // its input and the success path reads them back from there.
             // ret_offset, ret_size = plan_return_buffer(returns)
-            // mstore(ret_offset + ret_size - 32, 0)
-            let ret_plan = (!supports_returndata).then(|| {
-                self.plan_return_buffer(
-                    input,
-                    input_size_bytes,
-                    zero,
-                    &return_types,
-                    overlay_buffer,
-                )
-            });
-            let (ret_offset, ret_size) = if let Some(plan) = &ret_plan {
-                self.touch_call_output_area(options.gas, plan);
-                plan.output_area()
-            } else {
-                (zero, self.builder.imm(0))
+            let ret_plan = (!supports_returndata)
+                .then(|| self.plan_return_buffer(input, zero, &return_types, overlay_buffer));
+            let (ret_offset, ret_size) = match &ret_plan {
+                Some(plan) => plan.output_area(),
+                None => (zero, self.builder.imm(0)),
             };
             if self.needs_code_check(return_types.len()) {
                 self.revert_if_no_code(address);

--- a/crates/codegen/src/lower/function/control_flow.rs
+++ b/crates/codegen/src/lower/function/control_flow.rs
@@ -399,7 +399,7 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
             let input_size = self.builder.slice_len(encoded);
             let ret_offset = zero;
             let ret_size = self.builder.imm(0);
-            let check_code = target.return_types.is_empty()
+            let check_code = self.needs_code_check(target.return_types.len())
                 && match target.callee {
                     TryCallee::Member { receiver, .. } => {
                         self.builder.func().attributes.is_constructor

--- a/crates/codegen/src/lower/function/control_flow.rs
+++ b/crates/codegen/src/lower/function/control_flow.rs
@@ -348,8 +348,8 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
                 TryCallee::FunctionPointer { address, .. } => address,
                 TryCallee::Creation { .. } => unreachable!(),
             };
-            let (gas, call_value, zero) =
-                self.lower_call_options(*call_opts, true, "try call option")?;
+            let options = self.lower_call_options(*call_opts, true, "try call option")?;
+            let (call_value, zero) = (options.value, options.zero);
             let (mut values, mut types) =
                 if let TryCallee::LinkedLibrary { function, receiver, .. } = target.callee {
                     let capacity = args.len() + usize::from(receiver.is_some());
@@ -411,6 +411,10 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
             if check_code {
                 self.revert_if_no_code(address);
             }
+            // The code check above is emitted at every version that needs the reserve, so the
+            // call cannot create the callee's account.
+            // gas = gas() | sub(gas(), reserve)
+            let gas = self.call_gas(options.gas, options.value_set, false);
             // ok = delegatecall|staticcall|call(gas, address, input, 0, 0)
             let success = match target.callee {
                 TryCallee::LinkedLibrary { .. } => {

--- a/crates/codegen/src/lower/function/control_flow.rs
+++ b/crates/codegen/src/lower/function/control_flow.rs
@@ -1,6 +1,6 @@
 //! Branch, loop, ternary, and state-merge lowering.
 
-use super::*;
+use super::{calls::ExternalReturnMode, *};
 
 /// A `try` statement target resolved to the callee shape needed for lowering.
 #[derive(Clone, Copy)]
@@ -9,6 +9,24 @@ enum TryCallee<'a> {
     Member { receiver: &'a hir::Expr<'a>, selector: [u8; 4] },
     LinkedLibrary { address: U256, function: hir::FunctionId, receiver: Option<&'a hir::Expr<'a>> },
     FunctionPointer { address: ValueId, selector: ValueId },
+}
+
+/// The failed call's return data, which the catch clauses match on and bind.
+///
+/// Absent before Byzantium, where the only lowerable clause is a bare `catch { }` and there is no
+/// `RETURNDATACOPY` to read the data with.
+#[derive(Clone, Copy)]
+struct TryCatchData {
+    /// The `bytes` object holding the return data.
+    object: ValueId,
+    /// Pointer to the object's first data byte.
+    data: ValueId,
+    /// The data's length in bytes.
+    len: ValueId,
+    /// Whether the data is an `Error(string)` payload a `catch Error` clause can decode.
+    error_matches: ValueId,
+    /// Whether the data is a `Panic(uint256)` payload a `catch Panic` clause can decode.
+    panic_matches: ValueId,
 }
 
 struct TryTarget<'a, 'gcx> {
@@ -319,20 +337,21 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
                 if ty.peel_refs().kind != expected {
                     return self.cx.report_unsupported(catch_clause.span, "try catch clause");
                 }
-                if !self.cx.gcx.sess.opts.evm_version.supports_returndata() {
-                    return report_error(
-                        self.cx.gcx,
-                        try_stmt.expr.span,
-                        "codegen cannot bind try/catch returndata before Byzantium",
-                    );
-                }
             }
+        }
+        // Before Byzantium only a bare `catch { }` is lowerable: there is no return data for a
+        // typed clause to match or bind, and the type checker already rejected one.
+        let supports_returndata = self.cx.gcx.sess.opts.evm_version.supports_returndata();
+        if !supports_returndata
+            && catch_clauses.iter().any(|clause| clause.name.is_some() || !clause.args.is_empty())
+        {
+            return None;
         }
         if args.len() != target.parameter_types.len() {
             return self.cx.report_unsupported(args.span, "try argument list");
         }
 
-        let (success, creation_value) = if let TryCallee::Creation { ty, contract_id } =
+        let (success, creation_value, ret_plan) = if let TryCallee::Creation { ty, contract_id } =
             target.callee
         {
             // address = create(...)
@@ -340,7 +359,7 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
             let created = self.lower_create_contract(ty, contract_id, *args, *call_opts)?;
             let zero = self.builder.imm(U256::ZERO);
             let failed = self.builder.eq(created, zero);
-            (self.builder.iszero(failed), Some(created))
+            (self.builder.iszero(failed), Some(created), None)
         } else {
             let address = match target.callee {
                 TryCallee::Member { receiver, .. } => self.lower_expr(receiver)?,
@@ -397,8 +416,19 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
                 self.builder.abi_encode(layout, Some(selector), values.into_boxed_slice());
             let input = self.builder.slice_ptr(encoded);
             let input_size = self.builder.slice_len(encoded);
-            let ret_offset = zero;
-            let ret_size = self.builder.imm(0);
+            // From Byzantium on the return values come out of the return data, which the catch
+            // clauses need anyway; before it the call writes them into an output area of its own
+            // and the success path reads them back from there.
+            // buffer, ret_offset, ret_size = plan_return_buffer(returns)
+            // mstore(ret_offset + ret_size - 32, 0)
+            let ret_plan = (!supports_returndata)
+                .then(|| self.plan_return_buffer(input, zero, &target.return_types));
+            let (ret_offset, ret_size) = if let Some(plan) = &ret_plan {
+                self.touch_call_output_area(options.gas, plan);
+                plan.output_area()
+            } else {
+                (zero, self.builder.imm(0))
+            };
             let check_code = match target.callee {
                 TryCallee::Member { receiver, .. } => {
                     self.needs_receiver_code_check(receiver, target.return_types.len())
@@ -415,7 +445,7 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
             // call cannot create the callee's account.
             // gas = gas() | sub(gas(), reserve)
             let gas = self.call_gas(options.gas, options.value_set, false);
-            // ok = delegatecall|staticcall|call(gas, address, input, 0, 0)
+            // ok = delegatecall|staticcall|call(gas, address, input, ret_offset, ret_size)
             let success = match target.callee {
                 TryCallee::LinkedLibrary { .. } => {
                     self.builder.delegatecall(gas, address, input, input_size, ret_offset, ret_size)
@@ -427,7 +457,7 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
                     .builder
                     .call(gas, address, call_value, input, input_size, ret_offset, ret_size),
             };
-            (success, None)
+            (success, None, ret_plan)
         };
 
         let success_block = self.builder.create_block();
@@ -447,10 +477,20 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
             };
             self.values.insert(binding, value);
         } else if !target.return_types.is_empty() {
-            // success.returns = abi_decode(returndata)
-            let data = self.materialize_returndata_bytes();
-            let values =
-                self.lower_abi_decode_values(data, &target.return_types, returns_clause.span)?;
+            let values = if let Some(plan) = ret_plan {
+                // success.returns = load_words(ret_offset) | abi_decode(buffer)
+                self.finish_external_call(
+                    plan,
+                    &target.return_types,
+                    returns_clause.span,
+                    ExternalReturnMode::All,
+                    "codegen cannot decode try/catch returndata before Byzantium",
+                )?
+            } else {
+                // success.returns = abi_decode(returndata)
+                let data = self.materialize_returndata_bytes();
+                self.lower_abi_decode_values(data, &target.return_types, returns_clause.span)?
+            };
             for (&binding, value) in returns_clause.args.iter().zip(values) {
                 self.values.insert(binding, value);
             }
@@ -475,39 +515,43 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
         self.values = before.clone();
         self.storage_refs = before_storage_refs.clone();
         self.builder.switch_to_block(catch_block);
+        // Only from Byzantium on; before it the bare clause matches unconditionally and there is
+        // no data to bind or forward.
         // data = returndata()
         // selector = data.length >= 4 ? mload(data) >> 224 : 0
         // error_matches = selector == Error(string) && valid_error_payload(data)
         // panic_matches = selector == Panic(uint256) && data.length >= 36
-        let catch_data = self.materialize_returndata_bytes();
-        let catch_data_ptr = self.builder.memory_object_data(catch_data, MemoryObjectKind::Bytes);
-        let catch_data_len = self.builder.memory_object_len(catch_data, MemoryObjectKind::Bytes);
-        let zero = self.builder.imm(U256::ZERO);
-        let selector_slice =
-            self.builder.make_slice(catch_data_ptr, catch_data_len, SliceLocation::Memory);
-        let selector_word = self.builder.memory_slice_load_word(selector_slice, zero);
-        let four = self.builder.imm(4);
-        let selector_short = self.builder.lt(catch_data_len, four);
-        let has_selector = self.builder.iszero(selector_short);
-        let selector_shift = self.builder.imm(224);
-        let selector = self.builder.shr(selector_shift, selector_word);
-        let error_selector =
-            self.builder.imm(U256::from_be_slice(&keccak256("Error(string)")[..4]));
-        let panic_selector = self.builder.imm(0x4e48_7b71_u64);
-        let error_selector_matches = self.builder.eq(selector, error_selector);
-        let error_matches = if catch_clauses
-            .iter()
-            .any(|clause| clause.name.is_some_and(|name| name.name == sym::Error))
-        {
-            self.lower_error_catch_match(catch_data_ptr, catch_data_len, error_selector_matches)
-        } else {
-            self.builder.and(has_selector, error_selector_matches)
-        };
-        let panic_size = self.builder.imm(36);
-        let panic_short = self.builder.lt(catch_data_len, panic_size);
-        let panic_has_payload = self.builder.iszero(panic_short);
-        let panic_selector_matches = self.builder.eq(selector, panic_selector);
-        let panic_matches = self.builder.and(panic_has_payload, panic_selector_matches);
+        let catch_data = supports_returndata.then(|| {
+            let object = self.materialize_returndata_bytes();
+            let data = self.builder.memory_object_data(object, MemoryObjectKind::Bytes);
+            let len = self.builder.memory_object_len(object, MemoryObjectKind::Bytes);
+            let zero = self.builder.imm(U256::ZERO);
+            let selector_slice = self.builder.make_slice(data, len, SliceLocation::Memory);
+            let selector_word = self.builder.memory_slice_load_word(selector_slice, zero);
+            let four = self.builder.imm(4);
+            let selector_short = self.builder.lt(len, four);
+            let has_selector = self.builder.iszero(selector_short);
+            let selector_shift = self.builder.imm(224);
+            let selector = self.builder.shr(selector_shift, selector_word);
+            let error_selector =
+                self.builder.imm(U256::from_be_slice(&keccak256("Error(string)")[..4]));
+            let panic_selector = self.builder.imm(0x4e48_7b71_u64);
+            let error_selector_matches = self.builder.eq(selector, error_selector);
+            let error_matches = if catch_clauses
+                .iter()
+                .any(|clause| clause.name.is_some_and(|name| name.name == sym::Error))
+            {
+                self.lower_error_catch_match(data, len, error_selector_matches)
+            } else {
+                self.builder.and(has_selector, error_selector_matches)
+            };
+            let panic_size = self.builder.imm(36);
+            let panic_short = self.builder.lt(len, panic_size);
+            let panic_has_payload = self.builder.iszero(panic_short);
+            let panic_selector_matches = self.builder.eq(selector, panic_selector);
+            let panic_matches = self.builder.and(panic_has_payload, panic_selector_matches);
+            TryCatchData { object, data, len, error_matches, panic_matches }
+        });
         let mut next_catch = self.builder.current_block();
         for catch_clause in catch_clauses {
             // if catch_matches(clause, data) { lower(clause) } else { next_catch }
@@ -516,10 +560,11 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
             let next_block = self.builder.create_block();
             let catch_error = catch_clause.name.is_some_and(|name| name.name == sym::Error);
             let catch_panic = catch_clause.name.is_some_and(|name| name.name == sym::Panic);
+            // A typed clause is rejected before Byzantium, so its data is always there.
             let condition = if catch_error {
-                error_matches
+                catch_data?.error_matches
             } else if catch_panic {
-                panic_matches
+                catch_data?.panic_matches
             } else {
                 self.builder.imm_bool(true)
             };
@@ -529,12 +574,13 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
             self.storage_refs = before_storage_refs.clone();
             self.builder.switch_to_block(clause_block);
             if let Some(&binding) = catch_clause.args.first() {
+                let object = catch_data?.object;
                 let value = if catch_error {
-                    self.lower_error_catch_string(catch_data)?
+                    self.lower_error_catch_string(object)?
                 } else if catch_panic {
-                    self.lower_panic_catch_word(catch_data)
+                    self.lower_panic_catch_word(object)
                 } else {
-                    catch_data
+                    object
                 };
                 self.values.insert(binding, value);
             }
@@ -552,8 +598,16 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
             next_catch = next_block;
         }
         self.builder.switch_to_block(next_catch);
-        // revert(data.data, data.length)
-        self.builder.revert(catch_data_ptr, catch_data_len);
+        match catch_data {
+            // revert(data.data, data.length)
+            Some(data) => self.builder.revert(data.data, data.len),
+            // Unreachable: a pre-Byzantium `try` only has a bare clause, which always matches.
+            // revert(0, 0)
+            None => {
+                let zero = self.builder.imm(U256::ZERO);
+                self.builder.revert(zero, zero);
+            }
+        }
 
         // values, storage_refs = phi(success, catches)
         self.builder.switch_to_block(merge_block);

--- a/crates/codegen/src/lower/function/control_flow.rs
+++ b/crates/codegen/src/lower/function/control_flow.rs
@@ -412,18 +412,29 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
                 TryCallee::FunctionPointer { selector, .. } => selector,
                 TryCallee::Creation { .. } => unreachable!(),
             };
+            // buffer = alloc_overlay_return_buffer(returns)
+            // input = abi_encode(selector, args)
+            let overlay_buffer = self.alloc_overlay_return_buffer(&return_types);
             let layout = Arc::new(AbiLayout::new(types.into_boxed_slice()));
+            let input_size_bytes = Self::static_input_size(&layout);
             let encoded =
                 self.builder.abi_encode(layout, Some(selector), values.into_boxed_slice());
             let input = self.builder.slice_ptr(encoded);
             let input_size = self.builder.slice_len(encoded);
             // From Byzantium on the return values come out of the return data, which the catch
-            // clauses need anyway; before it the call writes them into an output area of its own
-            // and the success path reads them back from there.
-            // buffer, ret_offset, ret_size = plan_return_buffer(returns)
+            // clauses need anyway; before it the call writes them into an output area overlaying
+            // its input and the success path reads them back from there.
+            // ret_offset, ret_size = plan_return_buffer(returns)
             // mstore(ret_offset + ret_size - 32, 0)
-            let ret_plan =
-                (!supports_returndata).then(|| self.plan_return_buffer(input, zero, &return_types));
+            let ret_plan = (!supports_returndata).then(|| {
+                self.plan_return_buffer(
+                    input,
+                    input_size_bytes,
+                    zero,
+                    &return_types,
+                    overlay_buffer,
+                )
+            });
             let (ret_offset, ret_size) = if let Some(plan) = &ret_plan {
                 self.touch_call_output_area(options.gas, plan);
                 plan.output_area()

--- a/crates/codegen/src/utils/mod.rs
+++ b/crates/codegen/src/utils/mod.rs
@@ -7,9 +7,6 @@ use std::fmt;
 
 pub(crate) mod eval;
 
-/// Covers Homestead's call and new-account costs plus setup emitted after `GAS`.
-const PRE_TANGERINE_PRECOMPILE_GAS_RESERVE: u64 = 25_100;
-
 /// Homestead's `CALL` base cost plus the `SUB` and the call setup emitted after `GAS`.
 ///
 /// Mirrors solc's `GasCosts::callGas(homestead) + 10`.
@@ -24,6 +21,14 @@ const PRE_TANGERINE_VALUE_TRANSFER_GAS_RESERVE: u64 = 9_000;
 ///
 /// Mirrors solc's `GasCosts::callNewAccountGas`.
 const PRE_TANGERINE_NEW_ACCOUNT_GAS_RESERVE: u64 = 25_000;
+
+/// The reserve of a pre-Tangerine precompile call.
+///
+/// A precompile call sends no value and is not guarded by `extcodesize`, so it reserves the base
+/// cost and the account-creation cost, like solc's `gasNeededByCaller` for `ECRecover`, `SHA256`
+/// and `RIPEMD160`.
+const PRE_TANGERINE_PRECOMPILE_GAS_RESERVE: u64 =
+    PRE_TANGERINE_CALL_GAS_RESERVE + PRE_TANGERINE_NEW_ACCOUNT_GAS_RESERVE;
 
 pub(crate) fn display_data_name(name: Symbol, index: usize) -> impl fmt::Display {
     fmt::from_fn(move |f| write!(f, "{name}_{index}"))

--- a/crates/codegen/src/utils/mod.rs
+++ b/crates/codegen/src/utils/mod.rs
@@ -9,7 +9,11 @@ pub(crate) mod eval;
 
 /// Homestead's `CALL` base cost plus the `SUB` and the call setup emitted after `GAS`.
 ///
-/// Mirrors solc's `GasCosts::callGas(homestead) + 10`.
+/// Mirrors solc's `GasCosts::callGas(homestead) + 10`: 40 for the call itself and 10 for the
+/// three-gas `SUB` and the pushes between the `GAS` and the `CALL`. That leaves seven gas of the
+/// reserve for the call's own memory expansion, at most two words, so the output area has to be
+/// touched before the reserve is computed; see
+/// [`FunctionLowerer::touch_call_output_area`](crate::lower::FunctionLowerer).
 const PRE_TANGERINE_CALL_GAS_RESERVE: u64 = 50;
 
 /// Extra gas a pre-Tangerine call is charged for transferring value.

--- a/crates/codegen/src/utils/mod.rs
+++ b/crates/codegen/src/utils/mod.rs
@@ -13,7 +13,7 @@ pub(crate) mod eval;
 /// three-gas `SUB` and the pushes between the `GAS` and the `CALL`. That leaves seven gas of the
 /// reserve for the call's own memory expansion, at most two words, so the output area has to be
 /// touched before the reserve is computed; see
-/// [`FunctionLowerer::touch_call_output_area`](crate::lower::FunctionLowerer).
+/// `FunctionLowerer::touch_call_output_area` in the function lowering.
 const PRE_TANGERINE_CALL_GAS_RESERVE: u64 = 50;
 
 /// Extra gas a pre-Tangerine call is charged for transferring value.

--- a/crates/codegen/src/utils/mod.rs
+++ b/crates/codegen/src/utils/mod.rs
@@ -10,6 +10,21 @@ pub(crate) mod eval;
 /// Covers Homestead's call and new-account costs plus setup emitted after `GAS`.
 const PRE_TANGERINE_PRECOMPILE_GAS_RESERVE: u64 = 25_100;
 
+/// Homestead's `CALL` base cost plus the `SUB` and the call setup emitted after `GAS`.
+///
+/// Mirrors solc's `GasCosts::callGas(homestead) + 10`.
+const PRE_TANGERINE_CALL_GAS_RESERVE: u64 = 50;
+
+/// Extra gas a pre-Tangerine call is charged for transferring value.
+///
+/// Mirrors solc's `GasCosts::callValueTransferGas`.
+const PRE_TANGERINE_VALUE_TRANSFER_GAS_RESERVE: u64 = 9_000;
+
+/// Extra gas a pre-Tangerine call is charged for creating the callee's account.
+///
+/// Mirrors solc's `GasCosts::callNewAccountGas`.
+const PRE_TANGERINE_NEW_ACCOUNT_GAS_RESERVE: u64 = 25_000;
+
 pub(crate) fn display_data_name(name: Symbol, index: usize) -> impl fmt::Display {
     fmt::from_fn(move |f| write!(f, "{name}_{index}"))
 }
@@ -45,4 +60,33 @@ pub(crate) fn precompile_gas(
         let reserved = builder.imm(PRE_TANGERINE_PRECOMPILE_GAS_RESERVE);
         builder.sub(gas, reserved)
     }
+}
+
+/// Returns the `gas` operand of an external call that forwards the gas left, on a target that
+/// predates EIP-150.
+///
+/// There a gas argument larger than the gas left aborts the call instead of being capped at all
+/// but a 64th of it, so the operand withholds everything the `CALL` itself is charged, like
+/// solc's `gasNeededByCaller`: the call base cost, the value-transfer cost when the call sends
+/// value, and the account-creation cost when the callee is not already known to exist.
+///
+/// Everything emitted between the `GAS` and the call runs on the withheld gas, so the caller must
+/// materialize this immediately before the call, with the argument encoding and the memory the
+/// call needs already done.
+pub(crate) fn pre_tangerine_call_gas(
+    builder: &mut FunctionBuilder<'_>,
+    sends_value: bool,
+    may_create_account: bool,
+) -> ValueId {
+    // gas = sub(gas(), reserve)
+    let mut reserve = PRE_TANGERINE_CALL_GAS_RESERVE;
+    if sends_value {
+        reserve += PRE_TANGERINE_VALUE_TRANSFER_GAS_RESERVE;
+    }
+    if may_create_account {
+        reserve += PRE_TANGERINE_NEW_ACCOUNT_GAS_RESERVE;
+    }
+    let gas = builder.gas();
+    let reserve = builder.imm(reserve);
+    builder.sub(gas, reserve)
 }

--- a/crates/interface/src/symbol.rs
+++ b/crates/interface/src/symbol.rs
@@ -1094,6 +1094,7 @@ symbols! {
         jump,
         jumpi,
         keccak256_bytes,
+        keep_with_next,
         layout,
         length,
         literal,

--- a/crates/sema/src/ty/mod.rs
+++ b/crates/sema/src/ty/mod.rs
@@ -1406,19 +1406,6 @@ impl<'gcx> Gcx<'gcx> {
         self.alloc(errors)
     }
 
-    /// Returns the functions whose code is emitted into the contract's creation object: the
-    /// constructors of the contract and its bases, the callees of the state variable
-    /// initializers, and everything those reach.
-    ///
-    /// A function that the runtime object also contains appears in this set too, because the
-    /// creation object gets its own copy of it.
-    pub fn contract_creation_functions(
-        self,
-        id: hir::ContractId,
-    ) -> &'gcx DenseBitSet<hir::FunctionId> {
-        &self.interface_items(id).creation.functions
-    }
-
     /// Returns the functions reachable during contract creation or at runtime.
     pub fn contract_reachable_functions(
         self,

--- a/crates/sema/src/ty/mod.rs
+++ b/crates/sema/src/ty/mod.rs
@@ -1406,6 +1406,19 @@ impl<'gcx> Gcx<'gcx> {
         self.alloc(errors)
     }
 
+    /// Returns the functions whose code is emitted into the contract's creation object: the
+    /// constructors of the contract and its bases, the callees of the state variable
+    /// initializers, and everything those reach.
+    ///
+    /// A function that the runtime object also contains appears in this set too, because the
+    /// creation object gets its own copy of it.
+    pub fn contract_creation_functions(
+        self,
+        id: hir::ContractId,
+    ) -> &'gcx DenseBitSet<hir::FunctionId> {
+        &self.interface_items(id).creation.functions
+    }
+
     /// Returns the functions reachable during contract creation or at runtime.
     pub fn contract_reachable_functions(
         self,

--- a/crates/sema/src/ty/ty.rs
+++ b/crates/sema/src/ty/ty.rs
@@ -542,14 +542,20 @@ impl<'gcx> Ty<'gcx> {
         )
     }
 
+    /// Returns `true` if the type's ABI encoding carries a tail, as solc's
+    /// `Type::isDynamicallyEncoded`.
+    ///
+    /// Only the encoded type matters, so references are looked through: a struct's own fields and
+    /// an array's element type are reference types wherever they are aggregates themselves.
     pub fn is_dynamically_encoded(self, gcx: Gcx<'gcx>) -> bool {
-        match self.kind {
+        let this = self.peel_refs();
+        match this.kind {
             TyKind::Struct(id) => {
-                self.is_recursive(gcx)
+                this.is_recursive(gcx)
                     || gcx.struct_field_types(id).iter().any(|ty| ty.is_dynamically_encoded(gcx))
             }
             TyKind::Array(element, _) => element.is_dynamically_encoded(gcx),
-            _ => self.is_dynamically_sized(),
+            _ => this.is_dynamically_sized(),
         }
     }
 

--- a/crates/sema/src/typeck/checker/mod.rs
+++ b/crates/sema/src/typeck/checker/mod.rs
@@ -2961,26 +2961,40 @@ impl<'gcx> hir::Visit<'gcx> for TypeChecker<'gcx> {
                 return ControlFlow::Continue(());
             }
             hir::StmtKind::Try(try_) => {
-                if !self.gcx.sess.opts.evm_version.supports_returndata() {
-                    for clause in &try_.clauses[1..] {
-                        // A bare `catch { }` needs no return data and stays accepted; solc
-                        // reports 1812 for `catch Error`/`catch Panic` and 9908 for
-                        // `catch (bytes memory)`.
-                        let code = if clause.name.is_some() {
-                            error_code!(1812)
-                        } else if !clause.args.is_empty() {
-                            error_code!(9908)
-                        } else {
-                            continue;
-                        };
-                        self.evm_version_error(
-                            clause.span,
-                            "typed catch clause",
-                            EvmVersion::Byzantium,
-                        )
+                let supports_returndata = self.gcx.sess.opts.evm_version.supports_returndata();
+                for clause in &try_.clauses[1..] {
+                    // `Error` and `Panic` are the only clause names there are, at every EVM
+                    // version.
+                    if let Some(name) = clause.name
+                        && name.name != sym::Error
+                        && name.name != sym::Panic
+                    {
+                        self.dcx()
+                            .err("invalid catch clause name")
+                            .code(error_code!(3542))
+                            .span(clause.span)
+                            .help(
+                                "expected `catch (...)`, `catch Error(...)`, or `catch Panic(...)`",
+                            )
+                            .emit();
+                        continue;
+                    }
+                    if supports_returndata {
+                        continue;
+                    }
+                    // A bare `catch { }` needs no return data and stays accepted; solc
+                    // reports 1812 for `catch Error`/`catch Panic` and 9908 for
+                    // `catch (bytes memory)`.
+                    let code = if clause.name.is_some() {
+                        error_code!(1812)
+                    } else if !clause.args.is_empty() {
+                        error_code!(9908)
+                    } else {
+                        continue;
+                    };
+                    self.evm_version_error(clause.span, "typed catch clause", EvmVersion::Byzantium)
                         .code(code)
                         .emit();
-                    }
                 }
             }
             hir::StmtKind::Emit(call_expr) | hir::StmtKind::Revert(call_expr) => {

--- a/crates/sema/src/typeck/checker/mod.rs
+++ b/crates/sema/src/typeck/checker/mod.rs
@@ -15,7 +15,7 @@ use solar_data_structures::{Never, bit_set::DenseBitSet, pluralize, smallvec::Sm
 use solar_interface::{
     Ident, Symbol,
     config::EvmVersion,
-    diagnostics::{DiagCtxt, ErrorGuaranteed},
+    diagnostics::{DiagBuilder, DiagCtxt, ErrorGuaranteed},
     error_code, kw, sym,
 };
 use std::ops::ControlFlow;
@@ -102,11 +102,21 @@ impl<'gcx> TypeChecker<'gcx> {
     }
 
     fn emit_evm_version_error(&self, span: Span, feature: &str, required: EvmVersion) {
+        self.evm_version_error(span, feature, required).emit();
+    }
+
+    /// Builds the diagnostic for a feature the target EVM version does not have. Callers that
+    /// mirror a solc diagnostic attach its code before emitting.
+    fn evm_version_error(
+        &self,
+        span: Span,
+        feature: &str,
+        required: EvmVersion,
+    ) -> DiagBuilder<'gcx, ErrorGuaranteed> {
         self.dcx()
             .err(format!("{feature} requires {required:?}-compatible EVM"))
             .span(span)
             .help(format!("compile with `--evm-version {required}` or newer"))
-            .emit();
     }
 
     fn check_res_evm_version(&self, res: hir::Res, span: Span) {
@@ -2953,13 +2963,23 @@ impl<'gcx> hir::Visit<'gcx> for TypeChecker<'gcx> {
             hir::StmtKind::Try(try_) => {
                 if !self.gcx.sess.opts.evm_version.supports_returndata() {
                     for clause in &try_.clauses[1..] {
-                        if clause.name.is_some() || !clause.args.is_empty() {
-                            self.emit_evm_version_error(
-                                clause.span,
-                                "typed catch clause",
-                                EvmVersion::Byzantium,
-                            );
-                        }
+                        // A bare `catch { }` needs no return data and stays accepted; solc
+                        // reports 1812 for `catch Error`/`catch Panic` and 9908 for
+                        // `catch (bytes memory)`.
+                        let code = if clause.name.is_some() {
+                            error_code!(1812)
+                        } else if !clause.args.is_empty() {
+                            error_code!(9908)
+                        } else {
+                            continue;
+                        };
+                        self.evm_version_error(
+                            clause.span,
+                            "typed catch clause",
+                            EvmVersion::Byzantium,
+                        )
+                        .code(code)
+                        .emit();
                     }
                 }
             }

--- a/crates/sema/src/typeck/checker/mod.rs
+++ b/crates/sema/src/typeck/checker/mod.rs
@@ -3096,9 +3096,13 @@ impl<'gcx> hir::Visit<'gcx> for TypeChecker<'gcx> {
                     } else {
                         continue;
                     };
-                    self.evm_version_error(clause.span, "typed catch clause", EvmVersion::Byzantium)
-                        .code(code)
-                        .emit();
+                    self.evm_version_error(
+                        clause.span,
+                        "typed catch clause",
+                        EvmVersion::Byzantium,
+                    )
+                    .code(code)
+                    .emit();
                 }
                 // A `returns` clause binds the call's values; without one they are discarded.
                 if try_.clauses[0].args.is_empty() {

--- a/crates/sema/src/typeck/checker/mod.rs
+++ b/crates/sema/src/typeck/checker/mod.rs
@@ -75,6 +75,28 @@ struct TypeChecker<'gcx> {
     /// Only populated before Byzantium, where a dynamically encoded external return value is
     /// inaccessible and only a discarded one is legal.
     discarded: FxHashMap<hir::ExprId, Discarded>,
+    /// Where the value of the expression being checked is used.
+    value_position: ValuePosition,
+}
+
+/// Where an expression's value is used, which selects the error code of a use of a pre-Byzantium
+/// call's inaccessible dynamically encoded return value.
+///
+/// solc gives such a call an inaccessible dynamic type and then reports the ordinary conversion
+/// error of the position the value is used in, and every position has a code of its own.
+#[derive(Clone, Copy, Default, PartialEq, Eq)]
+enum ValuePosition {
+    /// Any other expression, a member access on the value included, which solc reports as 7407.
+    #[default]
+    Expression,
+    /// A variable declaration's initializer, which solc reports as 9574.
+    VariableDeclaration,
+    /// A `return` statement's value, which solc reports as 6359.
+    Return,
+    /// A call argument, which solc reports as 9553.
+    Argument,
+    /// A `try ... returns` clause's binding, which solc reports as 6509.
+    TryReturns,
 }
 
 /// The components of an expression's value that a statement discards.
@@ -110,6 +132,7 @@ impl<'gcx> TypeChecker<'gcx> {
             in_revert: false,
             in_yul: false,
             discarded: FxHashMap::default(),
+            value_position: ValuePosition::default(),
         }
     }
 
@@ -1251,6 +1274,9 @@ impl<'gcx> TypeChecker<'gcx> {
     /// inaccessible dynamic type (`FunctionType::returnParameterTypesWithoutDynamicTypes`): the
     /// call itself is legal and only reading the value is not. The other return values stay
     /// accessible, so a tuple destructuring that drops the dynamic ones is legal too.
+    ///
+    /// solc reports the ordinary conversion error of the position the value is used in, so the
+    /// code comes from [`ValuePosition`] rather than being one code for every use.
     fn check_inaccessible_dynamic_return(
         &self,
         expr: &'gcx hir::Expr<'gcx>,
@@ -1271,10 +1297,17 @@ impl<'gcx> TypeChecker<'gcx> {
             {
                 continue;
             }
+            let code = match self.value_position {
+                ValuePosition::Expression => error_code!(7407),
+                ValuePosition::VariableDeclaration => error_code!(9574),
+                ValuePosition::Return => error_code!(6359),
+                ValuePosition::Argument => error_code!(9553),
+                ValuePosition::TryReturns => error_code!(6509),
+            };
             return Err(self
                 .dcx()
                 .err("cannot use the dynamically encoded return value of an external call")
-                .code(error_code!(6509))
+                .code(code)
                 .span(expr.span)
                 .note(format!(
                     "the call returns `{}`, whose size is unknowable without `RETURNDATASIZE`",
@@ -1301,14 +1334,18 @@ impl<'gcx> TypeChecker<'gcx> {
         param_tys: &[Ty<'gcx>],
         param_names: Option<CallableParamSource>,
     ) -> Result<(), ErrorGuaranteed> {
-        match args.kind {
+        // An argument's conversion error is solc's 9553, whichever position the call itself is in.
+        let prev = std::mem::replace(&mut self.value_position, ValuePosition::Argument);
+        let result = match args.kind {
             hir::CallArgsKind::Unnamed(exprs) => {
                 self.check_positional_call_args(call_span, args.span, exprs, param_tys)
             }
             hir::CallArgsKind::Named(named_args) => {
                 self.check_named_call_args(call_span, args.span, named_args, param_tys, param_names)
             }
-        }
+        };
+        self.value_position = prev;
+        result
     }
 
     /// Rejects a base constructor whose arguments two contracts of the
@@ -2154,6 +2191,18 @@ impl<'gcx> TypeChecker<'gcx> {
         param_tys: &[Ty<'gcx>],
         param_names: Option<CallableParamSource>,
     ) -> bool {
+        let prev = std::mem::replace(&mut self.value_position, ValuePosition::Argument);
+        let matches = self.call_args_match_inner(args, param_tys, param_names);
+        self.value_position = prev;
+        matches
+    }
+
+    fn call_args_match_inner(
+        &mut self,
+        args: &hir::CallArgs<'gcx>,
+        param_tys: &[Ty<'gcx>],
+        param_names: Option<CallableParamSource>,
+    ) -> bool {
         match args.kind {
             hir::CallArgsKind::Unnamed(exprs) => self.positional_call_args_match(exprs, param_tys),
             hir::CallArgsKind::Named(named_args) => {
@@ -2598,7 +2647,10 @@ impl<'gcx> TypeChecker<'gcx> {
             }
             self.discard(init, Discarded::Components(dropped));
         }
+        // A declaration's conversion error is solc's 9574.
+        let prev = std::mem::replace(&mut self.value_position, ValuePosition::VariableDeclaration);
         let ty = self.check_expr_with_noexpect(init, expected);
+        self.value_position = prev;
         let value_types =
             if let TyKind::Tuple(types) = ty.kind { types } else { std::slice::from_ref(&ty) };
 
@@ -3037,6 +3089,9 @@ impl<'gcx> hir::Visit<'gcx> for TypeChecker<'gcx> {
     }
 
     fn visit_stmt(&mut self, stmt: &'gcx hir::Stmt<'gcx>) -> ControlFlow<Self::BreakValue> {
+        // Every statement sets the position of the values it uses itself, so no position outlives
+        // the statement that set it.
+        self.value_position = ValuePosition::Expression;
         match stmt.kind {
             hir::StmtKind::DeclSingle(var) => {
                 let init = self.gcx.hir.variable(var).initializer;
@@ -3105,8 +3160,12 @@ impl<'gcx> hir::Visit<'gcx> for TypeChecker<'gcx> {
                     .emit();
                 }
                 // A `returns` clause binds the call's values; without one they are discarded.
+                // Binding an inaccessible one is the mismatch solc reports as 6509, and the
+                // walk below checks the call expression before any clause body.
                 if try_.clauses[0].args.is_empty() {
                     self.discard(&try_.expr, Discarded::All);
+                } else {
+                    self.value_position = ValuePosition::TryReturns;
                 }
             }
             hir::StmtKind::Emit(call_expr) | hir::StmtKind::Revert(call_expr) => {
@@ -3181,7 +3240,10 @@ impl<'gcx> hir::Visit<'gcx> for TypeChecker<'gcx> {
                                 ids.iter().map(|&id| self.gcx.type_of_item(id.into())),
                             )),
                         };
+                    // A return value's conversion error is solc's 6359.
+                    let prev = std::mem::replace(&mut self.value_position, ValuePosition::Return);
                     let actual = self.check_expr_with_noexpect(expr, Some(expected));
+                    self.value_position = prev;
                     let _ = self.check_return_expected(expr, actual, expected);
                 } else if !returns.is_empty() {
                     self.dcx().emit_err(stmt.span, "return arguments required");

--- a/crates/sema/src/typeck/checker/mod.rs
+++ b/crates/sema/src/typeck/checker/mod.rs
@@ -11,7 +11,9 @@ use alloy_primitives::U256;
 use solar_ast::{
     DataLocation, ElementaryType, LitKind, Span, StateMutability, TypeSize, UserDefinableOperator,
 };
-use solar_data_structures::{Never, bit_set::DenseBitSet, pluralize, smallvec::SmallVec};
+use solar_data_structures::{
+    Never, bit_set::DenseBitSet, map::FxHashMap, pluralize, smallvec::SmallVec,
+};
 use solar_interface::{
     Ident, Symbol,
     config::EvmVersion,
@@ -68,6 +70,19 @@ struct TypeChecker<'gcx> {
     in_revert: bool,
     /// Whether we're checking expressions lowered from inline assembly.
     in_yul: bool,
+    /// The value components the enclosing statement discards, by expression.
+    ///
+    /// Only populated before Byzantium, where a dynamically encoded external return value is
+    /// inaccessible and only a discarded one is legal.
+    discarded: FxHashMap<hir::ExprId, Discarded>,
+}
+
+/// The components of an expression's value that a statement discards.
+enum Discarded {
+    /// The whole value, as in an expression statement or a `try` without a `returns` clause.
+    All,
+    /// The components a tuple destructuring drops, by index.
+    Components(DenseBitSet<usize>),
 }
 
 #[derive(Clone, Copy)]
@@ -94,6 +109,7 @@ impl<'gcx> TypeChecker<'gcx> {
             in_emit: false,
             in_revert: false,
             in_yul: false,
+            discarded: FxHashMap::default(),
         }
     }
 
@@ -373,6 +389,9 @@ impl<'gcx> TypeChecker<'gcx> {
                         if let Some(builtin) = builtin {
                             let _ = self.check_builtin_call_args(expr.span, args, builtin);
                         }
+                        // Keep the declared return type: the value is unusable, but an error
+                        // type here would only hide the checks its uses still go through.
+                        let _ = self.check_inaccessible_dynamic_return(expr, f);
                         self.fn_call_return_type(f.returns)
                     }
                     TyKind::Type(to) => self.check_explicit_cast(expr.span, to, args),
@@ -833,6 +852,15 @@ impl<'gcx> TypeChecker<'gcx> {
         lhs_ty: Ty<'gcx>,
         rhs: &'gcx hir::Expr<'gcx>,
     ) {
+        if let hir::ExprKind::Tuple(components) = lhs.peel_parens().kind {
+            let mut dropped = DenseBitSet::new_empty(components.len());
+            for (index, component) in components.iter().enumerate() {
+                if component.is_none() {
+                    dropped.insert(index);
+                }
+            }
+            self.discard(rhs, Discarded::Components(dropped));
+        }
         let rhs_ty = self.check_expr(rhs);
         self.check_tuple_assign_rhs_components(lhs, lhs_ty, rhs, rhs_ty);
     }
@@ -1189,6 +1217,72 @@ impl<'gcx> TypeChecker<'gcx> {
         }
 
         Err(err)
+    }
+
+    /// Records the components of `expr`'s value that the enclosing statement discards.
+    ///
+    /// Does nothing from Byzantium on, where every return value is accessible.
+    fn discard(&mut self, expr: &'gcx hir::Expr<'gcx>, discarded: Discarded) {
+        if self.gcx.sess.opts.evm_version.supports_returndata() {
+            return;
+        }
+        let expr = expr.peel_parens();
+        // The components of a tuple expression are values of their own, so a dropped one is
+        // discarded whole.
+        if let hir::ExprKind::Tuple(exprs) = expr.kind
+            && let Discarded::Components(components) = &discarded
+        {
+            for (index, expr) in exprs.iter().enumerate() {
+                if let Some(expr) = expr
+                    && components.contains(index)
+                {
+                    self.discarded.insert(expr.peel_parens().id, Discarded::All);
+                }
+            }
+            return;
+        }
+        self.discarded.insert(expr.id, discarded);
+    }
+
+    /// Rejects a use of an external call's dynamically encoded return value before Byzantium.
+    ///
+    /// Without `RETURNDATASIZE` the size of such a value is unknowable, so solc gives it an
+    /// inaccessible dynamic type (`FunctionType::returnParameterTypesWithoutDynamicTypes`): the
+    /// call itself is legal and only reading the value is not. The other return values stay
+    /// accessible, so a tuple destructuring that drops the dynamic ones is legal too.
+    fn check_inaccessible_dynamic_return(
+        &self,
+        expr: &'gcx hir::Expr<'gcx>,
+        f: &'gcx TyFn<'gcx>,
+    ) -> Result<(), ErrorGuaranteed> {
+        if self.gcx.sess.opts.evm_version.supports_returndata()
+            || !matches!(f.kind, TyFnKind::External | TyFnKind::DelegateCall)
+        {
+            return Ok(());
+        }
+        let discarded = self.discarded.get(&expr.id);
+        if matches!(discarded, Some(Discarded::All)) {
+            return Ok(());
+        }
+        for (index, ty) in f.returns.iter().enumerate() {
+            if !ty.is_dynamically_encoded(self.gcx)
+                || matches!(discarded, Some(Discarded::Components(components)) if components.contains(index))
+            {
+                continue;
+            }
+            return Err(self
+                .dcx()
+                .err("cannot use the dynamically encoded return value of an external call")
+                .code(error_code!(6509))
+                .span(expr.span)
+                .note(format!(
+                    "the call returns `{}`, whose size is unknowable without `RETURNDATASIZE`",
+                    ty.display(self.gcx)
+                ))
+                .help("discard the value, or compile with `--evm-version byzantium` or newer")
+                .emit());
+        }
+        Ok(())
     }
 
     fn fn_call_return_type(&self, returns: &'gcx [Ty<'gcx>]) -> Ty<'gcx> {
@@ -2494,6 +2588,15 @@ impl<'gcx> TypeChecker<'gcx> {
 
         let expected =
             if let &[Some(id)] = decls { Some(self.gcx.type_of_item(id.into())) } else { None };
+        if decls.len() > 1 {
+            let mut dropped = DenseBitSet::new_empty(decls.len());
+            for (index, decl) in decls.iter().enumerate() {
+                if decl.is_none() {
+                    dropped.insert(index);
+                }
+            }
+            self.discard(init, Discarded::Components(dropped));
+        }
         let ty = self.check_expr_with_noexpect(init, expected);
         let value_types =
             if let TyKind::Tuple(types) = ty.kind { types } else { std::slice::from_ref(&ty) };
@@ -2996,6 +3099,10 @@ impl<'gcx> hir::Visit<'gcx> for TypeChecker<'gcx> {
                         .code(code)
                         .emit();
                 }
+                // A `returns` clause binds the call's values; without one they are discarded.
+                if try_.clauses[0].args.is_empty() {
+                    self.discard(&try_.expr, Discarded::All);
+                }
             }
             hir::StmtKind::Emit(call_expr) | hir::StmtKind::Revert(call_expr) => {
                 let is_emit = matches!(stmt.kind, hir::StmtKind::Emit(_));
@@ -3052,6 +3159,10 @@ impl<'gcx> hir::Visit<'gcx> for TypeChecker<'gcx> {
                     );
                 }
                 return ControlFlow::Continue(());
+            }
+            hir::StmtKind::Expr(expr) => {
+                // An expression statement discards its value.
+                self.discard(expr, Discarded::All);
             }
             hir::StmtKind::Return(expr) if !self.in_yul => {
                 let returns =

--- a/crates/sema/src/typeck/checker/mod.rs
+++ b/crates/sema/src/typeck/checker/mod.rs
@@ -1227,16 +1227,17 @@ impl<'gcx> TypeChecker<'gcx> {
             return;
         }
         let expr = expr.peel_parens();
-        // The components of a tuple expression are values of their own, so a dropped one is
-        // discarded whole.
-        if let hir::ExprKind::Tuple(exprs) = expr.kind
-            && let Discarded::Components(components) = &discarded
-        {
+        // The components of a tuple expression are values of their own, so a discarded one is
+        // discarded whole, however deeply the tuples nest.
+        if let hir::ExprKind::Tuple(exprs) = expr.kind {
             for (index, expr) in exprs.iter().enumerate() {
                 if let Some(expr) = expr
-                    && components.contains(index)
+                    && match &discarded {
+                        Discarded::All => true,
+                        Discarded::Components(components) => components.contains(index),
+                    }
                 {
-                    self.discarded.insert(expr.peel_parens().id, Discarded::All);
+                    self.discard(expr, Discarded::All);
                 }
             }
             return;

--- a/tests/ui/codegen/evm-ir/tail-merge/keep_with_next.evmir
+++ b/tests/ui/codegen/evm-ir/tail-merge/keep_with_next.evmir
@@ -1,0 +1,90 @@
+//@compile-flags: -Ogas -Zevm-ir-pipeline=tail-merge --evm-version homestead
+//@filecheck:
+@module KeepWithNextTailMerge
+
+// A shared tail is entered by a jump, so a tail may only start where `keep_with_next` allows a
+// block boundary. Splitting after such an instruction would put a `JUMP` and a `JUMPDEST` inside
+// a sequence whose intervening gas is observable, like a pre-EIP-150 call's `sub(gas(), 50)`
+// reserve.
+
+bb0:
+  push 1
+  push bb1
+  jumpi
+  jump bb1
+
+// The longest equal suffix of `bb1` and `bb2` starts at `push 11`, but in `bb1` that boundary
+// follows the glued `sub`. The tail shrinks to the next legal boundary instead, so `push 11`
+// stays in both blocks and the reserve keeps its own `gas` and `sub`.
+// CHECK-LABEL: {{^[ +].*}}bb1:
+// CHECK: {{^[ +].*}}push 71
+// CHECK-NEXT: {{^[ +].*}}gas !meta(keep_with_next)
+// CHECK-NEXT: {{^[ +].*}}sub !meta(keep_with_next)
+// CHECK-NEXT: {{^[ +].*}}push 11
+// CHECK: + jump [[SHORT:bb[0-9]+]]
+bb1:
+  push 71
+  gas !meta(keep_with_next)
+  sub !meta(keep_with_next)
+  push 11
+  push 12
+  push 13
+  pop
+  pop
+  pop
+  pop
+  stop
+
+// CHECK-LABEL: {{^[ +].*}}bb2:
+// CHECK: {{^[ +].*}}push 72
+// CHECK-NEXT: {{^[ +].*}}push 73
+// CHECK-NEXT: {{^[ +].*}}push 11
+// CHECK: + jump [[SHORT]]
+bb2:
+  push 72
+  push 73
+  push 11
+  push 12
+  push 13
+  pop
+  pop
+  pop
+  pop
+  stop
+
+// Here the equal suffix reaches past the glued pair, so the boundary before `gas` is legal and
+// the whole reserve moves into the shared tail with its metadata intact.
+// CHECK-LABEL: {{^[ +].*}}bb3:
+// CHECK: {{^[ +].*}}push 81
+// CHECK: + jump [[WHOLE:bb[0-9]+]]
+bb3:
+  push 81
+  gas !meta(keep_with_next)
+  sub !meta(keep_with_next)
+  push 21
+  push 22
+  push 23
+  pop
+  pop
+  revert
+
+// CHECK-LABEL: {{^[ +].*}}bb4:
+// CHECK: {{^[ +].*}}push 82
+// CHECK: + jump [[WHOLE]]
+bb4:
+  push 82
+  gas !meta(keep_with_next)
+  sub !meta(keep_with_next)
+  push 21
+  push 22
+  push 23
+  pop
+  pop
+  revert
+
+// CHECK: + [[SHORT]]:
+// CHECK: {{^[ +].*}}push 12
+// CHECK: + [[WHOLE]]:
+// CHECK: {{^[ +].*}}gas !meta(keep_with_next)
+// CHECK-NEXT: {{^[ +].*}}sub !meta(keep_with_next)
+// CHECK-NEXT: {{^[ +].*}}push 21

--- a/tests/ui/codegen/evm-ir/tail-merge/keep_with_next.evmir
+++ b/tests/ui/codegen/evm-ir/tail-merge/keep_with_next.evmir
@@ -18,8 +18,8 @@ bb0:
 // stays in both blocks and the reserve keeps its own `gas` and `sub`.
 // CHECK-LABEL: {{^[ +].*}}bb1:
 // CHECK: {{^[ +].*}}push 71
-// CHECK-NEXT: {{^[ +].*}}gas !meta(keep_with_next)
-// CHECK-NEXT: {{^[ +].*}}sub !meta(keep_with_next)
+// CHECK-NEXT: {{^[ +].*}}gas !metadata(keep_with_next)
+// CHECK-NEXT: {{^[ +].*}}sub !metadata(keep_with_next)
 // CHECK-NEXT: {{^[ +].*}}push 11
 // CHECK: + jump [[SHORT:bb[0-9]+]]
 bb1:
@@ -85,6 +85,6 @@ bb4:
 // CHECK: + [[SHORT]]:
 // CHECK: {{^[ +].*}}push 12
 // CHECK: + [[WHOLE]]:
-// CHECK: {{^[ +].*}}gas !meta(keep_with_next)
-// CHECK-NEXT: {{^[ +].*}}sub !meta(keep_with_next)
+// CHECK: {{^[ +].*}}gas !metadata(keep_with_next)
+// CHECK-NEXT: {{^[ +].*}}sub !metadata(keep_with_next)
 // CHECK-NEXT: {{^[ +].*}}push 21

--- a/tests/ui/codegen/evm-ir/tail-merge/keep_with_next.evmir
+++ b/tests/ui/codegen/evm-ir/tail-merge/keep_with_next.evmir
@@ -5,7 +5,7 @@
 // A shared tail is entered by a jump, so a tail may only start where `keep_with_next` allows a
 // block boundary. Splitting after such an instruction would put a `JUMP` and a `JUMPDEST` inside
 // a sequence whose intervening gas is observable, like a pre-EIP-150 call's `sub(gas(), 50)`
-// reserve.
+// reserve, which the verifier requires to reach its `call` unbroken.
 
 bb0:
   push 1
@@ -13,19 +13,26 @@ bb0:
   jumpi
   jump bb1
 
-// The longest equal suffix of `bb1` and `bb2` starts at `push 11`, but in `bb1` that boundary
-// follows the glued `sub`. The tail shrinks to the next legal boundary instead, so `push 11`
-// stays in both blocks and the reserve keeps its own `gas` and `sub`.
+// The longest equal suffix of `bb1` and `bb2` starts at `call`, but in `bb1` that boundary
+// follows the glued `sub`. The tail shrinks to the next legal boundary instead, so `call` stays
+// in both blocks and the reserve keeps its own `gas` and `sub`.
 // CHECK-LABEL: {{^[ +].*}}bb1:
 // CHECK: {{^[ +].*}}push 71
 // CHECK-NEXT: {{^[ +].*}}gas !metadata(keep_with_next)
 // CHECK-NEXT: {{^[ +].*}}sub !metadata(keep_with_next)
-// CHECK-NEXT: {{^[ +].*}}push 11
+// CHECK-NEXT: {{^[ +].*}}call
 // CHECK: + jump [[SHORT:bb[0-9]+]]
 bb1:
+  push 0
+  push 0
+  push 0
+  push 0
+  push 0
+  push 0
   push 71
   gas !meta(keep_with_next)
   sub !meta(keep_with_next)
+  call
   push 11
   push 12
   push 13
@@ -37,12 +44,17 @@ bb1:
 
 // CHECK-LABEL: {{^[ +].*}}bb2:
 // CHECK: {{^[ +].*}}push 72
-// CHECK-NEXT: {{^[ +].*}}push 73
-// CHECK-NEXT: {{^[ +].*}}push 11
+// CHECK-NEXT: {{^[ +].*}}call
 // CHECK: + jump [[SHORT]]
 bb2:
+  push 0
+  push 0
+  push 0
+  push 0
+  push 0
+  push 0
   push 72
-  push 73
+  call
   push 11
   push 12
   push 13
@@ -52,18 +64,24 @@ bb2:
   pop
   stop
 
-// Here the equal suffix reaches past the glued pair, so the boundary before `gas` is legal and
-// the whole reserve moves into the shared tail with its metadata intact.
+// Here the equal suffix reaches past the glued pair, so the boundary before the call's operands
+// is legal and the whole reserve moves into the shared tail with its metadata intact.
 // CHECK-LABEL: {{^[ +].*}}bb3:
 // CHECK: {{^[ +].*}}push 81
 // CHECK: + jump [[WHOLE:bb[0-9]+]]
 bb3:
   push 81
+  push 0
+  push 0
+  push 0
+  push 0
+  push 0
+  push 0
   gas !meta(keep_with_next)
   sub !meta(keep_with_next)
+  call
   push 21
   push 22
-  push 23
   pop
   pop
   revert
@@ -73,18 +91,24 @@ bb3:
 // CHECK: + jump [[WHOLE]]
 bb4:
   push 82
+  push 0
+  push 0
+  push 0
+  push 0
+  push 0
+  push 0
   gas !meta(keep_with_next)
   sub !meta(keep_with_next)
+  call
   push 21
   push 22
-  push 23
   pop
   pop
   revert
 
 // CHECK: + [[SHORT]]:
-// CHECK: {{^[ +].*}}push 12
+// CHECK: {{^[ +].*}}push 11
 // CHECK: + [[WHOLE]]:
 // CHECK: {{^[ +].*}}gas !metadata(keep_with_next)
 // CHECK-NEXT: {{^[ +].*}}sub !metadata(keep_with_next)
-// CHECK-NEXT: {{^[ +].*}}push 21
+// CHECK-NEXT: {{^[ +].*}}call

--- a/tests/ui/codegen/evm-ir/tail-merge/keep_with_next.stdout
+++ b/tests/ui/codegen/evm-ir/tail-merge/keep_with_next.stdout
@@ -7,10 +7,17 @@
     jumpi
     jump bb1
   bb1:
+    push 0
+    push 0
+    push 0
+    push 0
+    push 0
+    push 0
     push 71
     gas !metadata(keep_with_next)
     sub !metadata(keep_with_next)
-    push 11
+    call
+-   push 11
 -   push 12
 -   push 13
 -   pop
@@ -20,9 +27,14 @@
 -   stop
 +   jump bb5
   bb2:
+    push 0
+    push 0
+    push 0
+    push 0
+    push 0
+    push 0
     push 72
-    push 73
-    push 11
+    call
 +   jump bb5
 + bb3:
 +   push 81
@@ -31,6 +43,7 @@
 +   push 82
 +   jump bb6
 + bb5:
+    push 11
     push 12
     push 13
     pop
@@ -40,22 +53,34 @@
     stop
 - bb3:
 -   push 81
+-   push 0
+-   push 0
+-   push 0
+-   push 0
+-   push 0
+-   push 0
 -   gas !metadata(keep_with_next)
 -   sub !metadata(keep_with_next)
+-   call
 -   push 21
 -   push 22
--   push 23
 -   pop
 -   pop
 -   revert
 - bb4:
 -   push 82
 + bb6:
+    push 0
+    push 0
+    push 0
+    push 0
+    push 0
+    push 0
     gas !metadata(keep_with_next)
     sub !metadata(keep_with_next)
+    call
     push 21
     push 22
-    push 23
     pop
     pop
     revert

--- a/tests/ui/codegen/evm-ir/tail-merge/keep_with_next.stdout
+++ b/tests/ui/codegen/evm-ir/tail-merge/keep_with_next.stdout
@@ -8,8 +8,8 @@
     jump bb1
   bb1:
     push 71
-    gas !meta(keep_with_next)
-    sub !meta(keep_with_next)
+    gas !metadata(keep_with_next)
+    sub !metadata(keep_with_next)
     push 11
 -   push 12
 -   push 13
@@ -40,8 +40,8 @@
     stop
 - bb3:
 -   push 81
--   gas !meta(keep_with_next)
--   sub !meta(keep_with_next)
+-   gas !metadata(keep_with_next)
+-   sub !metadata(keep_with_next)
 -   push 21
 -   push 22
 -   push 23
@@ -51,8 +51,8 @@
 - bb4:
 -   push 82
 + bb6:
-    gas !meta(keep_with_next)
-    sub !meta(keep_with_next)
+    gas !metadata(keep_with_next)
+    sub !metadata(keep_with_next)
     push 21
     push 22
     push 23

--- a/tests/ui/codegen/evm-ir/tail-merge/keep_with_next.stdout
+++ b/tests/ui/codegen/evm-ir/tail-merge/keep_with_next.stdout
@@ -1,0 +1,62 @@
+- // === ROOT/tests/ui/codegen/evm-ir/tail-merge/keep_with_next.evmir (before tail-merge) ===
++ // === ROOT/tests/ui/codegen/evm-ir/tail-merge/keep_with_next.evmir (after tail-merge) ===
+  @module KeepWithNextTailMerge
+  bb0:
+    push 1
+    push bb1
+    jumpi
+    jump bb1
+  bb1:
+    push 71
+    gas !meta(keep_with_next)
+    sub !meta(keep_with_next)
+    push 11
+-   push 12
+-   push 13
+-   pop
+-   pop
+-   pop
+-   pop
+-   stop
++   jump bb5
+  bb2:
+    push 72
+    push 73
+    push 11
++   jump bb5
++ bb3:
++   push 81
++   jump bb6
++ bb4:
++   push 82
++   jump bb6
++ bb5:
+    push 12
+    push 13
+    pop
+    pop
+    pop
+    pop
+    stop
+- bb3:
+-   push 81
+-   gas !meta(keep_with_next)
+-   sub !meta(keep_with_next)
+-   push 21
+-   push 22
+-   push 23
+-   pop
+-   pop
+-   revert
+- bb4:
+-   push 82
++ bb6:
+    gas !meta(keep_with_next)
+    sub !meta(keep_with_next)
+    push 21
+    push 22
+    push 23
+    pop
+    pop
+    revert
+  

--- a/tests/ui/codegen/evm-ir/validation/keep_with_next_at_block_end.evmir
+++ b/tests/ui/codegen/evm-ir/validation/keep_with_next_at_block_end.evmir
@@ -1,0 +1,10 @@
+//~? ERROR: EVM IR verification failed: block 0: `gas` must be followed by the instruction it is kept with
+@module module
+
+// `keep_with_next` glues an instruction to the next one in its own block, so a block that ends
+// with one lost the instruction it was kept with. Rejecting that turns the constraint every
+// transform honors into a checked guarantee.
+bb0:
+  push 50
+  gas !meta(keep_with_next)
+  stop

--- a/tests/ui/codegen/evm-ir/validation/keep_with_next_at_block_end.stderr
+++ b/tests/ui/codegen/evm-ir/validation/keep_with_next_at_block_end.stderr
@@ -1,0 +1,4 @@
+error: EVM IR verification failed: block 0: `gas` must be followed by the instruction it is kept with
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/codegen/evm-ir/validation/keep_with_next_terminator.evmir
+++ b/tests/ui/codegen/evm-ir/validation/keep_with_next_terminator.evmir
@@ -1,0 +1,8 @@
+//~? ERROR: EVM IR verification failed: block 0: terminator `stop` cannot be kept with a next instruction
+@module module
+
+// Nothing follows a terminator inside its block, so `keep_with_next` is meaningless there.
+bb0:
+  push 50
+  pop
+  stop !meta(keep_with_next)

--- a/tests/ui/codegen/evm-ir/validation/keep_with_next_terminator.stderr
+++ b/tests/ui/codegen/evm-ir/validation/keep_with_next_terminator.stderr
@@ -1,0 +1,4 @@
+error: EVM IR verification failed: block 0: terminator `stop` cannot be kept with a next instruction
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/codegen/evm-ir/validation/keep_with_next_wrong_successor.evmir
+++ b/tests/ui/codegen/evm-ir/validation/keep_with_next_wrong_successor.evmir
@@ -1,0 +1,40 @@
+//~? ERROR: EVM IR verification failed: block 0: `sub` is kept with the next instruction, which must be a call, not `dup`
+//~? ERROR: EVM IR verification failed: block 1: `gas` is kept with the next instruction, which must be a `sub` kept with the call, not `dup`
+//~? ERROR: EVM IR verification failed: block 2: `mload` cannot be kept with a next instruction
+@module module
+
+// The only sequence `keep_with_next` glues is a pre-EIP-150 call's `GAS`-relative reserve,
+// `push <reserve>; gas; sub; <call>`, whose margin pays for the `sub` and the call setup alone.
+// Forbidding the boundary is no use unless the successor is still the call, so an instruction
+// inserted anywhere inside the sequence is rejected, and so is the flag on an instruction the
+// verifier has no rule for.
+bb0:
+  push 0
+  push 0
+  push 0
+  push 0
+  push 0
+  push 0
+  push 50
+  gas !meta(keep_with_next)
+  sub !meta(keep_with_next)
+  dup1
+  call
+  pop
+  pop
+  stop
+
+bb1:
+  push 50
+  gas !meta(keep_with_next)
+  dup1
+  sub
+  pop
+  pop
+  stop
+
+bb2:
+  push 0
+  mload !meta(keep_with_next)
+  pop
+  stop

--- a/tests/ui/codegen/evm-ir/validation/keep_with_next_wrong_successor.stderr
+++ b/tests/ui/codegen/evm-ir/validation/keep_with_next_wrong_successor.stderr
@@ -1,0 +1,8 @@
+error: EVM IR verification failed: block 0: `sub` is kept with the next instruction, which must be a call, not `dup`
+
+error: EVM IR verification failed: block 1: `gas` is kept with the next instruction, which must be a `sub` kept with the call, not `dup`
+
+error: EVM IR verification failed: block 2: `mload` cannot be kept with a next instruction
+
+error: aborting due to 3 previous errors
+

--- a/tests/ui/codegen/lowering/call_reserve_block.gas.stdout
+++ b/tests/ui/codegen/lowering/call_reserve_block.gas.stdout
@@ -147,8 +147,8 @@ bb9:
   push 0
   dup 6
   push 50
-  gas !meta(keep_with_next)
-  sub !meta(keep_with_next)
+  gas !metadata(keep_with_next)
+  sub !metadata(keep_with_next)
   call
   swap 1
   pop

--- a/tests/ui/codegen/lowering/call_reserve_block.gas.stdout
+++ b/tests/ui/codegen/lowering/call_reserve_block.gas.stdout
@@ -1,0 +1,149 @@
+// === ROOT/tests/ui/codegen/lowering/call_reserve_block.sol:ReserveCallee (runtime) ===
+@module ReserveCallee_runtime
+bb0:
+  callvalue
+  push bb3
+  jumpi
+  push 0x100000000000000000000000000000000000000000000000000000000
+  push 0
+  calldataload
+  div
+  dup 1
+  push 0x3fa4f245
+  sub
+  push bb3
+  jumpi
+  push 42
+  push 128
+  mstore
+  push 32
+  push 128
+  return
+bb3 [cold]:
+  push 0
+  dup 1
+  invalid
+// === ROOT/tests/ui/codegen/lowering/call_reserve_block.sol:ReserveBlock (runtime) ===
+@module ReserveBlock_runtime
+bb0:
+  callvalue
+  push bb4
+  jumpi
+  push 0x100000000000000000000000000000000000000000000000000000000
+  push 0
+  calldataload
+  div
+  dup 1
+  push 0x2f5f3b3c
+  eq
+  push bb9
+  jumpi
+  dup 1
+  push 0x9a1f63d8
+  sub
+  push bb4
+  jumpi
+  push 224
+  push 64
+  mstore
+  push 0
+  sload
+  push 0xffffffffffffffffffffffffffffffffffffffff
+  and
+  push 64
+  mload
+  push 32
+  dup 2
+  add
+  push 64
+  mstore
+  push 0x3fa4f24500000000000000000000000000000000000000000000000000000000
+  dup 2
+  mstore
+  dup 2
+  extcodesize
+  iszero
+  push bb4
+  jumpi
+  push 32
+  push 0
+  push 4
+  dup 4
+  push 0
+  dup 7
+  push 0xc350
+  call
+  jump bb10
+bb10:
+  swap 2
+  pop
+  pop
+  iszero
+  push bb4
+  jumpi
+  push 0
+  mload
+  push 128
+  mstore
+  push 32
+  push 128
+  return
+bb4 [cold]:
+  push 0
+  dup 1
+  invalid
+bb9:
+  push 224
+  push 64
+  mstore
+  push 0
+  sload
+  push 0xffffffffffffffffffffffffffffffffffffffff
+  and
+  push 32
+  push 2
+  exp
+  mul
+  push 0x3fa4f245
+  or
+  push 0xffffffff
+  dup 2
+  and
+  push 224
+  push 2
+  exp
+  mul
+  swap 1
+  push 32
+  push 2
+  exp
+  swap 1
+  div
+  push 64
+  mload
+  push 32
+  dup 2
+  add
+  push 64
+  mstore
+  dup 3
+  dup 2
+  mstore
+  swap 2
+  pop
+  dup 1
+  extcodesize
+  iszero
+  push bb4
+  jumpi
+  push 32
+  push 0
+  push 4
+  dup 5
+  push 0
+  dup 6
+  push 50
+  gas !meta(keep_with_next)
+  sub !meta(keep_with_next)
+  call
+  jump bb10

--- a/tests/ui/codegen/lowering/call_reserve_block.gas.stdout
+++ b/tests/ui/codegen/lowering/call_reserve_block.gas.stdout
@@ -97,7 +97,7 @@ bb4 [cold]:
   dup 1
   invalid
 bb9:
-  push 224
+  push 256
   push 64
   mstore
   push 0
@@ -123,6 +123,16 @@ bb9:
   exp
   swap 1
   div
+  push 64
+  mload
+  dup 1
+  push 160
+  mstore
+  push 32
+  add
+  push 0
+  swap 1
+  mstore
   push 64
   mload
   push 32

--- a/tests/ui/codegen/lowering/call_reserve_block.gas.stdout
+++ b/tests/ui/codegen/lowering/call_reserve_block.gas.stdout
@@ -65,23 +65,27 @@ bb0:
   iszero
   push bb4
   jumpi
+  dup 1
+  push 160
+  mstore
   push 32
-  push 0
+  dup 2
   push 4
-  dup 4
+  dup 2
   push 0
   dup 7
   push 0xc350
   call
-  jump bb10
-bb10:
   swap 2
   pop
   pop
   iszero
   push bb4
   jumpi
-  push 0
+  push 160
+  mload
+  jump bb10
+bb10:
   mload
   push 128
   mstore
@@ -137,13 +141,18 @@ bb9:
   push bb4
   jumpi
   push 32
-  push 0
+  dup 3
   push 4
-  dup 5
+  dup 2
   push 0
   dup 6
   push 50
   gas !meta(keep_with_next)
   sub !meta(keep_with_next)
   call
+  swap 1
+  pop
+  iszero
+  push bb4
+  jumpi
   jump bb10

--- a/tests/ui/codegen/lowering/call_reserve_block.size.stdout
+++ b/tests/ui/codegen/lowering/call_reserve_block.size.stdout
@@ -147,8 +147,8 @@ bb9:
   push 0
   dup 6
   push 50
-  gas !meta(keep_with_next)
-  sub !meta(keep_with_next)
+  gas !metadata(keep_with_next)
+  sub !metadata(keep_with_next)
   call
   swap 1
   pop

--- a/tests/ui/codegen/lowering/call_reserve_block.size.stdout
+++ b/tests/ui/codegen/lowering/call_reserve_block.size.stdout
@@ -1,0 +1,149 @@
+// === ROOT/tests/ui/codegen/lowering/call_reserve_block.sol:ReserveCallee (runtime) ===
+@module ReserveCallee_runtime
+bb0:
+  callvalue
+  push bb3
+  jumpi
+  push 0x100000000000000000000000000000000000000000000000000000000
+  push 0
+  calldataload
+  div
+  dup 1
+  push 0x3fa4f245
+  sub
+  push bb3
+  jumpi
+  push 42
+  push 128
+  mstore
+  push 32
+  push 128
+  return
+bb3 [cold]:
+  push 0
+  dup 1
+  invalid
+// === ROOT/tests/ui/codegen/lowering/call_reserve_block.sol:ReserveBlock (runtime) ===
+@module ReserveBlock_runtime
+bb0:
+  callvalue
+  push bb4
+  jumpi
+  push 0x100000000000000000000000000000000000000000000000000000000
+  push 0
+  calldataload
+  div
+  dup 1
+  push 0x2f5f3b3c
+  eq
+  push bb9
+  jumpi
+  dup 1
+  push 0x9a1f63d8
+  sub
+  push bb4
+  jumpi
+  push 224
+  push 64
+  mstore
+  push 0
+  sload
+  push 0xffffffffffffffffffffffffffffffffffffffff
+  and
+  push 64
+  mload
+  push 32
+  dup 2
+  add
+  push 64
+  mstore
+  push 0x3fa4f24500000000000000000000000000000000000000000000000000000000
+  dup 2
+  mstore
+  dup 2
+  extcodesize
+  iszero
+  push bb4
+  jumpi
+  push 32
+  push 0
+  push 4
+  dup 4
+  push 0
+  dup 7
+  push 0xc350
+  call
+  jump bb10
+bb10:
+  swap 2
+  pop
+  pop
+  iszero
+  push bb4
+  jumpi
+  push 0
+  mload
+  push 128
+  mstore
+  push 32
+  push 128
+  return
+bb4 [cold]:
+  push 0
+  dup 1
+  invalid
+bb9:
+  push 224
+  push 64
+  mstore
+  push 0
+  sload
+  push 0xffffffffffffffffffffffffffffffffffffffff
+  and
+  push 32
+  push 2
+  exp
+  mul
+  push 0x3fa4f245
+  or
+  push 0xffffffff
+  dup 2
+  and
+  push 224
+  push 2
+  exp
+  mul
+  swap 1
+  push 32
+  push 2
+  exp
+  swap 1
+  div
+  push 64
+  mload
+  push 32
+  dup 2
+  add
+  push 64
+  mstore
+  dup 3
+  dup 2
+  mstore
+  swap 2
+  pop
+  dup 1
+  extcodesize
+  iszero
+  push bb4
+  jumpi
+  push 32
+  push 0
+  push 4
+  dup 5
+  push 0
+  dup 6
+  push 50
+  gas !meta(keep_with_next)
+  sub !meta(keep_with_next)
+  call
+  jump bb10

--- a/tests/ui/codegen/lowering/call_reserve_block.size.stdout
+++ b/tests/ui/codegen/lowering/call_reserve_block.size.stdout
@@ -97,7 +97,7 @@ bb4 [cold]:
   dup 1
   invalid
 bb9:
-  push 224
+  push 256
   push 64
   mstore
   push 0
@@ -123,6 +123,16 @@ bb9:
   exp
   swap 1
   div
+  push 64
+  mload
+  dup 1
+  push 160
+  mstore
+  push 32
+  add
+  push 0
+  swap 1
+  mstore
   push 64
   mload
   push 32

--- a/tests/ui/codegen/lowering/call_reserve_block.size.stdout
+++ b/tests/ui/codegen/lowering/call_reserve_block.size.stdout
@@ -65,23 +65,27 @@ bb0:
   iszero
   push bb4
   jumpi
+  dup 1
+  push 160
+  mstore
   push 32
-  push 0
+  dup 2
   push 4
-  dup 4
+  dup 2
   push 0
   dup 7
   push 0xc350
   call
-  jump bb10
-bb10:
   swap 2
   pop
   pop
   iszero
   push bb4
   jumpi
-  push 0
+  push 160
+  mload
+  jump bb10
+bb10:
   mload
   push 128
   mstore
@@ -137,13 +141,18 @@ bb9:
   push bb4
   jumpi
   push 32
-  push 0
+  dup 3
   push 4
-  dup 5
+  dup 2
   push 0
   dup 6
   push 50
   gas !meta(keep_with_next)
   sub !meta(keep_with_next)
   call
+  swap 1
+  pop
+  iszero
+  push bb4
+  jumpi
   jump bb10

--- a/tests/ui/codegen/lowering/call_reserve_block.sol
+++ b/tests/ui/codegen/lowering/call_reserve_block.sol
@@ -35,8 +35,8 @@ contract ReserveBlock {
     // block boundary. The implicit check-not covers every other `gas` in the runtime object, so a
     // pass that splits this sequence fails the test. From EIP-150 on the gas is capped instead of
     // rejected, the reserve is gone, and the plain `gas` read carries no metadata.
-    // RESERVE: gas !meta(keep_with_next)
-    // RESERVE-NEXT: sub !meta(keep_with_next)
+    // RESERVE: gas !metadata(keep_with_next)
+    // RESERVE-NEXT: sub !metadata(keep_with_next)
     // RESERVE-NEXT: call
     // TANGERINE-NOT: keep_with_next
     function fixedGas() external returns (uint256) {

--- a/tests/ui/codegen/lowering/call_reserve_block.sol
+++ b/tests/ui/codegen/lowering/call_reserve_block.sol
@@ -1,0 +1,50 @@
+//@ revisions: gas size tangerineWhistle
+//@[gas] compile-flags: -O gas --evm-version homestead -Zdump=evm-ir-runtime
+//@[gas] filecheck: --check-prefix=RESERVE --implicit-check-not=gas
+//@[size] compile-flags: -O size --evm-version homestead -Zdump=evm-ir-runtime
+//@[size] filecheck: --check-prefix=RESERVE --implicit-check-not=gas
+//@[tangerineWhistle] compile-flags: -O gas --evm-version tangerineWhistle -Zdump=evm-ir-runtime
+//@[tangerineWhistle] filecheck: --check-prefix=TANGERINE
+
+// Before EIP-150 a `CALL` asking for more gas than is left throws, so a call that forwards the
+// gas left withholds its own cost plus solc's 10-gas margin, `sub(gas(), 50)`. The margin only
+// pays for the `SUB`, so the reserve is only correct while the `GAS` read and the call stay in
+// one block: a `JUMP` (8) and a `JUMPDEST` (1) in between overrun it and the call throws. A
+// forwarded-gas call next to a `{gas: ...}` call of the same shape is exactly the pair of equal
+// call tails the backend wants to share, and merging them used to cut the block between the
+// `SUB` and the `CALL`.
+
+interface ReserveTarget {
+    function value() external returns (uint256);
+}
+
+contract ReserveCallee {
+    function value() external pure returns (uint256) {
+        return 42;
+    }
+}
+
+contract ReserveBlock {
+    ReserveTarget internal callee;
+
+    constructor() {
+        callee = ReserveTarget(address(new ReserveCallee()));
+    }
+
+    // `keep_with_next` pins the reserve to the call, so nothing can turn either boundary into a
+    // block boundary. The implicit check-not covers every other `gas` in the runtime object, so a
+    // pass that splits this sequence fails the test. From EIP-150 on the gas is capped instead of
+    // rejected, the reserve is gone, and the plain `gas` read carries no metadata.
+    // RESERVE: gas !meta(keep_with_next)
+    // RESERVE-NEXT: sub !meta(keep_with_next)
+    // RESERVE-NEXT: call
+    // TANGERINE-NOT: keep_with_next
+    function fixedGas() external returns (uint256) {
+        return callee.value{gas: 50000}();
+    }
+
+    function pointer() external returns (uint256) {
+        function() external returns (uint256) f = callee.value;
+        return f();
+    }
+}

--- a/tests/ui/codegen/lowering/call_reserve_block.tangerineWhistle.stdout
+++ b/tests/ui/codegen/lowering/call_reserve_block.tangerineWhistle.stdout
@@ -1,0 +1,150 @@
+// === ROOT/tests/ui/codegen/lowering/call_reserve_block.sol:ReserveCallee (runtime) ===
+@module ReserveCallee_runtime
+bb0:
+  callvalue
+  push bb3
+  jumpi
+  push 0x100000000000000000000000000000000000000000000000000000000
+  push 0
+  calldataload
+  div
+  dup 1
+  push 0x3fa4f245
+  sub
+  push bb3
+  jumpi
+  push 42
+  push 128
+  mstore
+  push 32
+  push 128
+  return
+bb3 [cold]:
+  push 0
+  dup 1
+  invalid
+// === ROOT/tests/ui/codegen/lowering/call_reserve_block.sol:ReserveBlock (runtime) ===
+@module ReserveBlock_runtime
+bb0:
+  callvalue
+  push bb4
+  jumpi
+  push 0x100000000000000000000000000000000000000000000000000000000
+  push 0
+  calldataload
+  div
+  dup 1
+  push 0x2f5f3b3c
+  eq
+  push bb9
+  jumpi
+  dup 1
+  push 0x9a1f63d8
+  sub
+  push bb4
+  jumpi
+  push 224
+  push 64
+  mstore
+  push 0
+  sload
+  push 0xffffffffffffffffffffffffffffffffffffffff
+  and
+  push 64
+  mload
+  push 32
+  dup 2
+  add
+  push 64
+  mstore
+  push 0x3fa4f24500000000000000000000000000000000000000000000000000000000
+  dup 2
+  mstore
+  dup 2
+  extcodesize
+  iszero
+  push bb4
+  jumpi
+  push 32
+  push 0
+  push 4
+  dup 4
+  push 0
+  dup 7
+  push 0xc350
+  call
+  swap 2
+  jump bb10
+bb10:
+  pop
+  pop
+  iszero
+  push bb4
+  jumpi
+  push 0
+  mload
+  push 128
+  mstore
+  push 32
+  push 128
+  return
+bb4 [cold]:
+  push 0
+  dup 1
+  invalid
+bb9:
+  push 256
+  push 64
+  mstore
+  push 0
+  sload
+  push 0xffffffffffffffffffffffffffffffffffffffff
+  and
+  push 32
+  push 2
+  exp
+  mul
+  push 0x3fa4f245
+  or
+  push 0xffffffff
+  dup 2
+  and
+  push 224
+  push 2
+  exp
+  mul
+  swap 1
+  push 32
+  push 2
+  exp
+  swap 1
+  div
+  gas
+  push 64
+  mload
+  push 32
+  dup 2
+  add
+  push 64
+  mstore
+  dup 4
+  dup 2
+  mstore
+  swap 3
+  pop
+  dup 2
+  extcodesize
+  iszero
+  push bb4
+  jumpi
+  push 32
+  push 0
+  push 4
+  dup 6
+  push 0
+  dup 7
+  dup 7
+  call
+  swap 3
+  pop
+  jump bb10

--- a/tests/ui/codegen/lowering/call_reserve_block.tangerineWhistle.stdout
+++ b/tests/ui/codegen/lowering/call_reserve_block.tangerineWhistle.stdout
@@ -65,23 +65,27 @@ bb0:
   iszero
   push bb4
   jumpi
+  dup 1
+  push 160
+  mstore
   push 32
-  push 0
+  dup 2
   push 4
-  dup 4
+  dup 2
   push 0
   dup 7
   push 0xc350
   call
   swap 2
-  jump bb10
-bb10:
   pop
   pop
   iszero
   push bb4
   jumpi
-  push 0
+  push 160
+  mload
+  jump bb10
+bb10:
   mload
   push 128
   mstore
@@ -138,13 +142,17 @@ bb9:
   push bb4
   jumpi
   push 32
-  push 0
+  dup 4
   push 4
-  dup 6
+  dup 2
   push 0
   dup 7
   dup 7
   call
-  swap 3
+  swap 2
   pop
+  pop
+  iszero
+  push bb4
+  jumpi
   jump bb10

--- a/tests/ui/codegen/lowering/empty_code_external_call.mir.stdout
+++ b/tests/ui/codegen/lowering/empty_code_external_call.mir.stdout
@@ -253,45 +253,51 @@ fn @trySelf() -> bool [selector=0xf948cf5e, abi_params=[], abi_returns=[word<boo
     v2 = abi_encode [], selector 0x5dfc2e4a00000000000000000000000000000000000000000000000000000000
     v3 = slice_ptr v2
     v4 = slice_len v2
-    v5 = call v1, v0, 0, v3, v4, 0, 0
-    jumpi v5, bb1, bb2
+    v5 = extcodesize v0
+    v6 = iszero v5
+    jumpi v6, bb1, bb2
   bb2:
-    v6 = returndatasize
-    v7 = add v6, 63
-    v8 = lt v7, v6
-    jumpi v8, bb4, bb5
-  bb5:
-    v9 = not 31
-    v10 = and v7, v9
-    v11 = alloc memorybytes, exact, uninitialized, infallible, v10
-    set_memory_object_len memorybytes, v11, v6
-    v12 = make_returndata_slice 0, v6
-    memory_object_copy_from_slice memorybytes, v11, v12
-    v13 = memory_object_data memorybytes, v11
-    v14 = memory_object_len memorybytes, v11
-    v15 = make_memory_slice v13, v14
-    v16 = memory_slice_load_word memory, v15, 0
-    v17 = lt v14, 4
-    v18 = iszero v17
-    v19 = shr 224, v16
-    v20 = eq v19, 0x8c379a0
-    v21 = and v18, v20
-    v22 = lt v14, 36
-    v23 = iszero v22
-    v24 = eq v19, 0x4e487b71
-    v25 = and v23, v24
-    jumpi 1, bb6, bb7
-  bb7:
-    revert v13, v14
-  bb6:
-    ret 0
+    v7 = call v1, v0, 0, v3, v4, 0, 0
+    jumpi v7, bb3, bb4
   bb4:
+    v8 = returndatasize
+    v9 = add v8, 63
+    v10 = lt v9, v8
+    jumpi v10, bb6, bb7
+  bb7:
+    v11 = not 31
+    v12 = and v9, v11
+    v13 = alloc memorybytes, exact, uninitialized, infallible, v12
+    set_memory_object_len memorybytes, v13, v8
+    v14 = make_returndata_slice 0, v8
+    memory_object_copy_from_slice memorybytes, v13, v14
+    v15 = memory_object_data memorybytes, v13
+    v16 = memory_object_len memorybytes, v13
+    v17 = make_memory_slice v15, v16
+    v18 = memory_slice_load_word memory, v17, 0
+    v19 = lt v16, 4
+    v20 = iszero v19
+    v21 = shr 224, v18
+    v22 = eq v21, 0x8c379a0
+    v23 = and v20, v22
+    v24 = lt v16, 36
+    v25 = iszero v24
+    v26 = eq v21, 0x4e487b71
+    v27 = and v25, v26
+    jumpi 1, bb8, bb9
+  bb9:
+    revert v15, v16
+  bb8:
+    ret 0
+  bb6:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 65 !metadata(memory=scratch)
     revert 0, 36
-  bb1:
-    ret 1
   bb3:
+    ret 1
+  bb1:
+    revert 0, 0
+  bb5:
     ret 0
 }
 
@@ -314,12 +320,18 @@ fn @selfCall() -> bool [selector=0x8dae0159, abi_params=[], abi_returns=[word<bo
     v2 = abi_encode [], selector 0x5dfc2e4a00000000000000000000000000000000000000000000000000000000
     v3 = slice_ptr v2
     v4 = slice_len v2
-    v5 = call v1, v0, 0, v3, v4, 0, 0
-    jumpi v5, bb2, bb1
-  bb1:
-    revert_returndata
+    v5 = extcodesize v0
+    v6 = iszero v5
+    jumpi v6, bb1, bb2
   bb2:
+    v7 = call v1, v0, 0, v3, v4, 0, 0
+    jumpi v7, bb4, bb3
+  bb3:
+    revert_returndata
+  bb4:
     ret 1
+  bb1:
+    revert 0, 0
 }
 
 fn @noop() [selector=0x5dfc2e4a, abi_params=[], abi_returns=[]] {

--- a/tests/ui/codegen/lowering/external_view_call_evm_version.homestead.stdout
+++ b/tests/ui/codegen/lowering/external_view_call_evm_version.homestead.stdout
@@ -2,25 +2,28 @@
 @module Caller
 fn @read(arg0: address) -> u256 [selector=0xa087a87e, view, abi_params=[address], abi_returns=[word]] {
   bb0:
-    v0 = abi_encode [], selector 0x57de26a400000000000000000000000000000000000000000000000000000000
-    v1 = slice_ptr v0
-    v2 = slice_len v0
-    v3 = extcodesize arg0
-    v4 = iszero v3
-    jumpi v4, bb1, bb2
+    v0 = fmp
+    v1 = add v0, 32
+    mstore v1, 0
+    v2 = abi_encode [], selector 0x57de26a400000000000000000000000000000000000000000000000000000000
+    v3 = slice_ptr v2
+    v4 = slice_len v2
+    v5 = extcodesize arg0
+    v6 = iszero v5
+    jumpi v6, bb1, bb2
   bb2:
-    v5 = gas
-    v6 = sub v5, 50
-    v7 = call v6, arg0, 0, v1, v2, v1, 32
-    jumpi v7, bb4, bb3
+    v7 = gas
+    v8 = sub v7, 50
+    v9 = call v8, arg0, 0, v3, v4, v3, 32
+    jumpi v9, bb4, bb3
   bb3:
     revert_returndata
   bb4:
-    v8 = add v1, 0
-    v9 = mload v8
-    v10 = add v1, 0
+    v10 = add v3, 0
     v11 = mload v10
-    ret v11
+    v12 = add v3, 0
+    v13 = mload v12
+    ret v13
   bb1:
     revert 0, 0
 }
@@ -30,25 +33,28 @@ fn @readPointer(arg0: function) -> u256 [selector=0x92528617, view, abi_params=[
     v0 = and arg0, 0xffffffff
     v1 = shl 224, v0
     v2 = shr 32, arg0
-    v3 = abi_encode [], selector v1
-    v4 = slice_ptr v3
-    v5 = slice_len v3
-    v6 = extcodesize v2
-    v7 = iszero v6
-    jumpi v7, bb1, bb2
+    v3 = fmp
+    v4 = add v3, 32
+    mstore v4, 0
+    v5 = abi_encode [], selector v1
+    v6 = slice_ptr v5
+    v7 = slice_len v5
+    v8 = extcodesize v2
+    v9 = iszero v8
+    jumpi v9, bb1, bb2
   bb2:
-    v8 = gas
-    v9 = sub v8, 50
-    v10 = call v9, v2, 0, v4, v5, v4, 32
-    jumpi v10, bb4, bb3
+    v10 = gas
+    v11 = sub v10, 50
+    v12 = call v11, v2, 0, v6, v7, v6, 32
+    jumpi v12, bb4, bb3
   bb3:
     revert_returndata
   bb4:
-    v11 = add v4, 0
-    v12 = mload v11
-    v13 = add v4, 0
+    v13 = add v6, 0
     v14 = mload v13
-    ret v14
+    v15 = add v6, 0
+    v16 = mload v15
+    ret v16
   bb1:
     revert 0, 0
 }

--- a/tests/ui/codegen/lowering/external_view_call_evm_version.homestead.stdout
+++ b/tests/ui/codegen/lowering/external_view_call_evm_version.homestead.stdout
@@ -6,14 +6,22 @@ fn @read(arg0: address) -> u256 [selector=0xa087a87e, view, abi_params=[address]
     v1 = abi_encode [], selector 0x57de26a400000000000000000000000000000000000000000000000000000000
     v2 = slice_ptr v1
     v3 = slice_len v1
-    v4 = call v0, arg0, 0, v2, v3, 0, 32
-    jumpi v4, bb2, bb1
-  bb1:
-    revert_returndata
+    v4 = extcodesize arg0
+    v5 = iszero v4
+    jumpi v5, bb1, bb2
   bb2:
-    v5 = add 0, 0
-    v6 = mload v5
-    ret v6
+    v6 = call v0, arg0, 0, v2, v3, 0, 32
+    jumpi v6, bb4, bb3
+  bb3:
+    revert_returndata
+  bb4:
+    v7 = add 0, 0
+    v8 = mload v7
+    v9 = add 0, 0
+    v10 = mload v9
+    ret v10
+  bb1:
+    revert 0, 0
 }
 
 fn @readPointer(arg0: function) -> u256 [selector=0x92528617, view, abi_params=[function], abi_returns=[word]] {
@@ -25,12 +33,20 @@ fn @readPointer(arg0: function) -> u256 [selector=0x92528617, view, abi_params=[
     v4 = abi_encode [], selector v1
     v5 = slice_ptr v4
     v6 = slice_len v4
-    v7 = call v3, v2, 0, v5, v6, 0, 32
-    jumpi v7, bb2, bb1
-  bb1:
-    revert_returndata
+    v7 = extcodesize v2
+    v8 = iszero v7
+    jumpi v8, bb1, bb2
   bb2:
-    v8 = add 0, 0
-    v9 = mload v8
-    ret v9
+    v9 = call v3, v2, 0, v5, v6, 0, 32
+    jumpi v9, bb4, bb3
+  bb3:
+    revert_returndata
+  bb4:
+    v10 = add 0, 0
+    v11 = mload v10
+    v12 = add 0, 0
+    v13 = mload v12
+    ret v13
+  bb1:
+    revert 0, 0
 }

--- a/tests/ui/codegen/lowering/external_view_call_evm_version.homestead.stdout
+++ b/tests/ui/codegen/lowering/external_view_call_evm_version.homestead.stdout
@@ -2,24 +2,25 @@
 @module Caller
 fn @read(arg0: address) -> u256 [selector=0xa087a87e, view, abi_params=[address], abi_returns=[word]] {
   bb0:
-    v0 = gas
-    v1 = abi_encode [], selector 0x57de26a400000000000000000000000000000000000000000000000000000000
-    v2 = slice_ptr v1
-    v3 = slice_len v1
-    v4 = extcodesize arg0
-    v5 = iszero v4
-    jumpi v5, bb1, bb2
+    v0 = abi_encode [], selector 0x57de26a400000000000000000000000000000000000000000000000000000000
+    v1 = slice_ptr v0
+    v2 = slice_len v0
+    v3 = extcodesize arg0
+    v4 = iszero v3
+    jumpi v4, bb1, bb2
   bb2:
-    v6 = call v0, arg0, 0, v2, v3, 0, 32
-    jumpi v6, bb4, bb3
+    v5 = gas
+    v6 = sub v5, 50
+    v7 = call v6, arg0, 0, v1, v2, 0, 32
+    jumpi v7, bb4, bb3
   bb3:
     revert_returndata
   bb4:
-    v7 = add 0, 0
-    v8 = mload v7
-    v9 = add 0, 0
-    v10 = mload v9
-    ret v10
+    v8 = add 0, 0
+    v9 = mload v8
+    v10 = add 0, 0
+    v11 = mload v10
+    ret v11
   bb1:
     revert 0, 0
 }
@@ -29,24 +30,25 @@ fn @readPointer(arg0: function) -> u256 [selector=0x92528617, view, abi_params=[
     v0 = and arg0, 0xffffffff
     v1 = shl 224, v0
     v2 = shr 32, arg0
-    v3 = gas
-    v4 = abi_encode [], selector v1
-    v5 = slice_ptr v4
-    v6 = slice_len v4
-    v7 = extcodesize v2
-    v8 = iszero v7
-    jumpi v8, bb1, bb2
+    v3 = abi_encode [], selector v1
+    v4 = slice_ptr v3
+    v5 = slice_len v3
+    v6 = extcodesize v2
+    v7 = iszero v6
+    jumpi v7, bb1, bb2
   bb2:
-    v9 = call v3, v2, 0, v5, v6, 0, 32
-    jumpi v9, bb4, bb3
+    v8 = gas
+    v9 = sub v8, 50
+    v10 = call v9, v2, 0, v4, v5, 0, 32
+    jumpi v10, bb4, bb3
   bb3:
     revert_returndata
   bb4:
-    v10 = add 0, 0
-    v11 = mload v10
-    v12 = add 0, 0
-    v13 = mload v12
-    ret v13
+    v11 = add 0, 0
+    v12 = mload v11
+    v13 = add 0, 0
+    v14 = mload v13
+    ret v14
   bb1:
     revert 0, 0
 }

--- a/tests/ui/codegen/lowering/external_view_call_evm_version.homestead.stdout
+++ b/tests/ui/codegen/lowering/external_view_call_evm_version.homestead.stdout
@@ -11,14 +11,14 @@ fn @read(arg0: address) -> u256 [selector=0xa087a87e, view, abi_params=[address]
   bb2:
     v5 = gas
     v6 = sub v5, 50
-    v7 = call v6, arg0, 0, v1, v2, 0, 32
+    v7 = call v6, arg0, 0, v1, v2, v1, 32
     jumpi v7, bb4, bb3
   bb3:
     revert_returndata
   bb4:
-    v8 = add 0, 0
+    v8 = add v1, 0
     v9 = mload v8
-    v10 = add 0, 0
+    v10 = add v1, 0
     v11 = mload v10
     ret v11
   bb1:
@@ -39,14 +39,14 @@ fn @readPointer(arg0: function) -> u256 [selector=0x92528617, view, abi_params=[
   bb2:
     v8 = gas
     v9 = sub v8, 50
-    v10 = call v9, v2, 0, v4, v5, 0, 32
+    v10 = call v9, v2, 0, v4, v5, v4, 32
     jumpi v10, bb4, bb3
   bb3:
     revert_returndata
   bb4:
-    v11 = add 0, 0
+    v11 = add v4, 0
     v12 = mload v11
-    v13 = add 0, 0
+    v13 = add v4, 0
     v14 = mload v13
     ret v14
   bb1:

--- a/tests/ui/codegen/lowering/external_view_call_evm_version.sol
+++ b/tests/ui/codegen/lowering/external_view_call_evm_version.sol
@@ -10,11 +10,13 @@ interface Target {
 
 contract Caller {
     // HOMESTEAD-LABEL: fn @read
+    // HOMESTEAD: extcodesize
     // HOMESTEAD: call
     // HOMESTEAD-NOT: staticcall
     // HOMESTEAD-NOT: returndatasize
     // HOMESTEAD: revert_returndata
     // BYZANTIUM-LABEL: fn @read
+    // BYZANTIUM-NOT: extcodesize
     // BYZANTIUM: staticcall
     // BYZANTIUM: revert_returndata
     function read(Target target) external view returns (uint256) {
@@ -22,11 +24,13 @@ contract Caller {
     }
 
     // HOMESTEAD-LABEL: fn @readPointer
+    // HOMESTEAD: extcodesize
     // HOMESTEAD: call
     // HOMESTEAD-NOT: staticcall
     // HOMESTEAD-NOT: returndatasize
     // HOMESTEAD: revert_returndata
     // BYZANTIUM-LABEL: fn @readPointer
+    // BYZANTIUM-NOT: extcodesize
     // BYZANTIUM: staticcall
     // BYZANTIUM: revert_returndata
     // BYZANTIUM: returndatasize

--- a/tests/ui/codegen/lowering/library_call_evm_version.byzantium.stdout
+++ b/tests/ui/codegen/lowering/library_call_evm_version.byzantium.stdout
@@ -1,0 +1,170 @@
+// === ROOT/tests/ui/codegen/lowering/library_call_evm_version.sol:Lib ===
+@module Lib
+fn @dbl(arg0: u256) -> u256 [selector=0x5d2a6863, pure, abi_params=[u256], abi_returns=[word]] {
+  bb0:
+    v0 = mul 2, arg0
+    v1 = iszero arg0
+    v2 = div v0, arg0
+    v3 = eq v2, 2
+    v4 = or v1, v3
+    v5 = iszero v4
+    jumpi v5, bb1, bb2
+  bb2:
+    ret v0
+  bb1:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 17 !metadata(memory=scratch)
+    revert 0, 36
+}
+
+fn @pair(arg0: u256) -> (u256, u256) [selector=0x645751af, pure, abi_params=[u256], abi_returns=[word, word]] {
+  bb0:
+    v0 = add arg0, 1
+    v1 = lt v0, arg0
+    jumpi v1, bb1, bb2
+  bb2:
+    ret arg0, v0
+  bb1:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 17 !metadata(memory=scratch)
+    revert 0, 36
+}
+
+fn @arr(arg0: u256) -> memoryfixedarray [selector=0x71e5ee5f, pure, abi_params=[u256], abi_returns=[array<2, word>]] {
+  bb0:
+    v0 = alloc memoryfixedarray<2, 1>, exact, uninitialized, infallible, 64
+    memory_zero v0, 64
+    v1 = alloc memoryfixedarray<2, 1>, exact, uninitialized, infallible, 64
+    memory_object_store_element memoryfixedarray<2, 1>, v1, 0, arg0
+    memory_object_store_element memoryfixedarray<2, 1>, v1, 1, arg0
+    ret v1
+}
+
+fn @noret(arg0: u256) [selector=0x089b9644, pure, abi_params=[u256], abi_returns=[]] {
+  bb0:
+    stop
+}
+
+// === ROOT/tests/ui/codegen/lowering/library_call_evm_version.sol:C ===
+@module C
+fn @one(arg0: u256) -> u256 [selector=0xef56f928, pure, abi_params=[u256], abi_returns=[word]] {
+  bb0:
+    v0 = abi_encode [word], selector 0x5d2a686300000000000000000000000000000000000000000000000000000000, args arg0
+    v1 = slice_ptr v0
+    v2 = slice_len v0
+    v3 = gas
+    v4 = delegatecall v3, 0x1111111111111111111111111111111111111111, v1, v2, 0, 0
+    jumpi v4, bb2, bb1
+  bb1:
+    revert_returndata
+  bb2:
+    v5 = returndatasize
+    v6 = add v5, 63
+    v7 = lt v6, v5
+    jumpi v7, bb3, bb4
+  bb4:
+    v8 = not 31
+    v9 = and v6, v8
+    v10 = alloc memorybytes, exact, uninitialized, infallible, v9
+    set_memory_object_len memorybytes, v10, v5
+    v11 = make_returndata_slice 0, v5
+    memory_object_copy_from_slice memorybytes, v10, v11
+    v12 = abi_decode [u256], v10
+    ret v12
+  bb3:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 65 !metadata(memory=scratch)
+    revert 0, 36
+}
+
+fn @two(arg0: u256) -> (u256, u256) [selector=0xcf2a8612, pure, abi_params=[u256], abi_returns=[word, word]] {
+  bb0:
+    v0 = abi_encode [word], selector 0x645751af00000000000000000000000000000000000000000000000000000000, args arg0
+    v1 = slice_ptr v0
+    v2 = slice_len v0
+    v3 = gas
+    v4 = delegatecall v3, 0x1111111111111111111111111111111111111111, v1, v2, 0, 0
+    jumpi v4, bb2, bb1
+  bb1:
+    revert_returndata
+  bb2:
+    v5 = returndatasize
+    v6 = add v5, 63
+    v7 = lt v6, v5
+    jumpi v7, bb3, bb4
+  bb4:
+    v8 = not 31
+    v9 = and v6, v8
+    v10 = alloc memorybytes, exact, uninitialized, infallible, v9
+    set_memory_object_len memorybytes, v10, v5
+    v11 = make_returndata_slice 0, v5
+    memory_object_copy_from_slice memorybytes, v10, v11
+    v12 = abi_decode [u256, u256], v10
+    v13 = frame_load multi_return, word, 0 !metadata(memory=scratch)
+    v14 = add v13, 32
+    v15 = mload v14
+    v16 = alloc memoryfixedarray<2, 1>, exact, uninitialized, infallible, 64
+    v17 = memory_object_data memoryfixedarray, v16
+    frame_store multi_return, word, 0, v17 !metadata(memory=scratch)
+    memory_object_store_element memoryfixedarray<2, 1>, v16, 1, v15
+    v18 = frame_load multi_return, word, 0 !metadata(memory=scratch)
+    v19 = add v18, 32
+    v20 = mload v19
+    ret v12, v20
+  bb3:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 65 !metadata(memory=scratch)
+    revert 0, 36
+}
+
+fn @aggregate(arg0: u256) -> memoryfixedarray [selector=0x407b7269, pure, abi_params=[u256], abi_returns=[array<2, word>]] {
+  bb0:
+    v0 = alloc memoryfixedarray<2, 1>, exact, uninitialized, infallible, 64
+    memory_zero v0, 64
+    v1 = abi_encode [word], selector 0x71e5ee5f00000000000000000000000000000000000000000000000000000000, args arg0
+    v2 = slice_ptr v1
+    v3 = slice_len v1
+    v4 = gas
+    v5 = delegatecall v4, 0x1111111111111111111111111111111111111111, v2, v3, 0, 0
+    jumpi v5, bb2, bb1
+  bb1:
+    revert_returndata
+  bb2:
+    v6 = returndatasize
+    v7 = add v6, 63
+    v8 = lt v7, v6
+    jumpi v8, bb3, bb4
+  bb4:
+    v9 = not 31
+    v10 = and v7, v9
+    v11 = alloc memorybytes, exact, uninitialized, infallible, v10
+    set_memory_object_len memorybytes, v11, v6
+    v12 = make_returndata_slice 0, v6
+    memory_object_copy_from_slice memorybytes, v11, v12
+    v13 = abi_decode [array<2, u256>], v11
+    ret v13
+  bb3:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 65 !metadata(memory=scratch)
+    revert 0, 36
+}
+
+fn @none(arg0: u256) [selector=0x2758da14, pure, abi_params=[u256], abi_returns=[]] {
+  bb0:
+    v0 = abi_encode [word], selector 0x89b964400000000000000000000000000000000000000000000000000000000, args arg0
+    v1 = slice_ptr v0
+    v2 = slice_len v0
+    v3 = gas
+    v4 = extcodesize 0x1111111111111111111111111111111111111111
+    v5 = iszero v4
+    jumpi v5, bb1, bb2
+  bb2:
+    v6 = delegatecall v3, 0x1111111111111111111111111111111111111111, v1, v2, 0, 0
+    jumpi v6, bb4, bb3
+  bb3:
+    revert_returndata
+  bb4:
+    stop
+  bb1:
+    revert 0, 0
+}

--- a/tests/ui/codegen/lowering/library_call_evm_version.byzantium.stdout
+++ b/tests/ui/codegen/lowering/library_call_evm_version.byzantium.stdout
@@ -73,6 +73,12 @@ fn @noret(arg0: u256) [selector=0x089b9644, pure, abi_params=[u256], abi_returns
     stop
 }
 
+fn @six(arg0: memorybytes) -> (u256, u256, u256, u256, u256, u256) [selector=0xb84d18fb, pure, abi_params=[bytes], abi_returns=[word, word, word, word, word, word]] {
+  bb0:
+    v0 = memory_object_len memorybytes, arg0
+    ret v0, 1, 2, 3, 4, 5
+}
+
 // === ROOT/tests/ui/codegen/lowering/library_call_evm_version.sol:C ===
 @module C
 fn @one(arg0: u256) -> u256 [selector=0xef56f928, pure, abi_params=[u256], abi_returns=[word]] {
@@ -264,6 +270,66 @@ fn @attached() -> u256 [selector=0xd9e6b370, view, abi_params=[], abi_returns=[w
     memory_object_copy_from_slice memorybytes, v10, v11
     v12 = abi_decode [u256], v10
     ret v12
+  bb3:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 65 !metadata(memory=scratch)
+    revert 0, 36
+}
+
+fn @dynamicArgument(arg0: memorybytes) -> (u256, u256) [selector=0x11b8efbf, pure, abi_params=[bytes], abi_returns=[word, word]] {
+  bb0:
+    v0 = abi_encode [memory_bytes], selector 0xb84d18fb00000000000000000000000000000000000000000000000000000000, args arg0
+    v1 = slice_ptr v0
+    v2 = slice_len v0
+    v3 = gas
+    v4 = delegatecall v3, 0x1111111111111111111111111111111111111111, v1, v2, 0, 0
+    jumpi v4, bb2, bb1
+  bb1:
+    revert_returndata
+  bb2:
+    v5 = returndatasize
+    v6 = add v5, 63
+    v7 = lt v6, v5
+    jumpi v7, bb3, bb4
+  bb4:
+    v8 = not 31
+    v9 = and v6, v8
+    v10 = alloc memorybytes, exact, uninitialized, infallible, v9
+    set_memory_object_len memorybytes, v10, v5
+    v11 = make_returndata_slice 0, v5
+    memory_object_copy_from_slice memorybytes, v10, v11
+    v12 = abi_decode [u256, u256, u256, u256, u256, u256], v10
+    v13 = frame_load multi_return, word, 0 !metadata(memory=scratch)
+    v14 = add v13, 32
+    v15 = mload v14
+    v16 = add v13, 64
+    v17 = mload v16
+    v18 = add v13, 96
+    v19 = mload v18
+    v20 = add v13, 128
+    v21 = mload v20
+    v22 = add v13, 160
+    v23 = mload v22
+    v24 = alloc memoryfixedarray<6, 1>, exact, uninitialized, infallible, 192
+    v25 = memory_object_data memoryfixedarray, v24
+    frame_store multi_return, word, 0, v25 !metadata(memory=scratch)
+    memory_object_store_element memoryfixedarray<6, 1>, v24, 1, v15
+    memory_object_store_element memoryfixedarray<6, 1>, v24, 2, v17
+    memory_object_store_element memoryfixedarray<6, 1>, v24, 3, v19
+    memory_object_store_element memoryfixedarray<6, 1>, v24, 4, v21
+    memory_object_store_element memoryfixedarray<6, 1>, v24, 5, v23
+    v26 = frame_load multi_return, word, 0 !metadata(memory=scratch)
+    v27 = add v26, 32
+    v28 = mload v27
+    v29 = add v26, 64
+    v30 = mload v29
+    v31 = add v26, 96
+    v32 = mload v31
+    v33 = add v26, 128
+    v34 = mload v33
+    v35 = add v26, 160
+    v36 = mload v35
+    ret v12, v36
   bb3:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 65 !metadata(memory=scratch)

--- a/tests/ui/codegen/lowering/library_call_evm_version.homestead.stdout
+++ b/tests/ui/codegen/lowering/library_call_evm_version.homestead.stdout
@@ -73,60 +73,72 @@ fn @noret(arg0: u256) [selector=0x089b9644, pure, abi_params=[u256], abi_returns
     stop
 }
 
+fn @six(arg0: memorybytes) -> (u256, u256, u256, u256, u256, u256) [selector=0xb84d18fb, pure, abi_params=[bytes], abi_returns=[word, word, word, word, word, word]] {
+  bb0:
+    v0 = memory_object_len memorybytes, arg0
+    ret v0, 1, 2, 3, 4, 5
+}
+
 // === ROOT/tests/ui/codegen/lowering/library_call_evm_version.sol:C ===
 @module C
 fn @one(arg0: u256) -> u256 [selector=0xef56f928, pure, abi_params=[u256], abi_returns=[word]] {
   bb0:
-    v0 = abi_encode [word], selector 0x5d2a686300000000000000000000000000000000000000000000000000000000, args arg0
-    v1 = slice_ptr v0
-    v2 = slice_len v0
-    v3 = extcodesize 0x1111111111111111111111111111111111111111
-    v4 = iszero v3
-    jumpi v4, bb1, bb2
+    v0 = fmp
+    v1 = add v0, 32
+    mstore v1, 0
+    v2 = abi_encode [word], selector 0x5d2a686300000000000000000000000000000000000000000000000000000000, args arg0
+    v3 = slice_ptr v2
+    v4 = slice_len v2
+    v5 = extcodesize 0x1111111111111111111111111111111111111111
+    v6 = iszero v5
+    jumpi v6, bb1, bb2
   bb2:
-    v5 = gas
-    v6 = sub v5, 50
-    v7 = delegatecall v6, 0x1111111111111111111111111111111111111111, v1, v2, v1, 32
-    jumpi v7, bb4, bb3
+    v7 = gas
+    v8 = sub v7, 50
+    v9 = delegatecall v8, 0x1111111111111111111111111111111111111111, v3, v4, v3, 32
+    jumpi v9, bb4, bb3
   bb3:
     revert_returndata
   bb4:
-    v8 = add v1, 0
-    v9 = mload v8
-    v10 = add v1, 0
+    v10 = add v3, 0
     v11 = mload v10
-    ret v11
+    v12 = add v3, 0
+    v13 = mload v12
+    ret v13
   bb1:
     revert 0, 0
 }
 
 fn @two(arg0: u256) -> (u256, u256) [selector=0xcf2a8612, pure, abi_params=[u256], abi_returns=[word, word]] {
   bb0:
-    v0 = abi_encode [word], selector 0x645751af00000000000000000000000000000000000000000000000000000000, args arg0
-    v1 = slice_ptr v0
-    v2 = slice_len v0
-    v3 = extcodesize 0x1111111111111111111111111111111111111111
-    v4 = iszero v3
-    jumpi v4, bb1, bb2
+    v0 = fmp
+    v1 = add v0, 64
+    mstore v1, 0
+    v2 = abi_encode [word], selector 0x645751af00000000000000000000000000000000000000000000000000000000, args arg0
+    v3 = slice_ptr v2
+    v4 = slice_len v2
+    v5 = extcodesize 0x1111111111111111111111111111111111111111
+    v6 = iszero v5
+    jumpi v6, bb1, bb2
   bb2:
-    v5 = gas
-    v6 = sub v5, 50
-    v7 = delegatecall v6, 0x1111111111111111111111111111111111111111, v1, v2, v1, 64
-    jumpi v7, bb4, bb3
+    v7 = gas
+    v8 = sub v7, 50
+    v9 = delegatecall v8, 0x1111111111111111111111111111111111111111, v3, v4, v3, 64
+    jumpi v9, bb4, bb3
   bb3:
     revert_returndata
   bb4:
-    v8 = add v1, 0
-    v9 = mload v8
-    v10 = add v1, 32
+    v10 = add v3, 0
     v11 = mload v10
-    frame_store multi_return, word, 0, v1 !metadata(memory=scratch)
-    v12 = add v1, 0
+    v12 = add v3, 32
     v13 = mload v12
-    v14 = frame_load multi_return, word, 0 !metadata(memory=scratch)
-    v15 = add v14, 32
-    v16 = mload v15
-    ret v13, v16
+    frame_store multi_return, word, 0, v3 !metadata(memory=scratch)
+    v14 = add v3, 0
+    v15 = mload v14
+    v16 = frame_load multi_return, word, 0 !metadata(memory=scratch)
+    v17 = add v16, 32
+    v18 = mload v17
+    ret v15, v18
   bb1:
     revert 0, 0
 }
@@ -138,54 +150,60 @@ fn @aggregate(arg0: u256) -> memoryfixedarray [selector=0x407b7269, pure, abi_pa
     v1 = alloc memorybytes, exact, uninitialized, infallible, 96
     set_memory_object_len memorybytes, v1, 64
     v2 = memory_object_data memorybytes, v1
-    v3 = abi_encode [word], selector 0x71e5ee5f00000000000000000000000000000000000000000000000000000000, args arg0
-    v4 = slice_ptr v3
-    v5 = slice_len v3
-    v6 = extcodesize 0x1111111111111111111111111111111111111111
-    v7 = iszero v6
-    jumpi v7, bb1, bb2
+    v3 = fmp
+    v4 = add v3, 64
+    mstore v4, 0
+    v5 = abi_encode [word], selector 0x71e5ee5f00000000000000000000000000000000000000000000000000000000, args arg0
+    v6 = slice_ptr v5
+    v7 = slice_len v5
+    v8 = extcodesize 0x1111111111111111111111111111111111111111
+    v9 = iszero v8
+    jumpi v9, bb1, bb2
   bb2:
-    v8 = gas
-    v9 = sub v8, 50
-    v10 = delegatecall v9, 0x1111111111111111111111111111111111111111, v4, v5, v4, 64
-    jumpi v10, bb4, bb3
+    v10 = gas
+    v11 = sub v10, 50
+    v12 = delegatecall v11, 0x1111111111111111111111111111111111111111, v6, v7, v6, 64
+    jumpi v12, bb4, bb3
   bb3:
     revert_returndata
   bb4:
-    mcopy v2, v4, 64
-    v11 = abi_decode [array<2, u256>], v1
-    ret v11
+    mcopy v2, v6, 64
+    v13 = abi_decode [array<2, u256>], v1
+    ret v13
   bb1:
     revert 0, 0
 }
 
 fn @boolean(arg0: u256) -> bool [selector=0xbc586ed6, pure, abi_params=[u256], abi_returns=[word<bool>]] {
   bb0:
-    v0 = abi_encode [word], selector 0xbb760a7500000000000000000000000000000000000000000000000000000000, args arg0
-    v1 = slice_ptr v0
-    v2 = slice_len v0
-    v3 = extcodesize 0x1111111111111111111111111111111111111111
-    v4 = iszero v3
-    jumpi v4, bb1, bb2
+    v0 = fmp
+    v1 = add v0, 32
+    mstore v1, 0
+    v2 = abi_encode [word], selector 0xbb760a7500000000000000000000000000000000000000000000000000000000, args arg0
+    v3 = slice_ptr v2
+    v4 = slice_len v2
+    v5 = extcodesize 0x1111111111111111111111111111111111111111
+    v6 = iszero v5
+    jumpi v6, bb1, bb2
   bb2:
-    v5 = gas
-    v6 = sub v5, 50
-    v7 = delegatecall v6, 0x1111111111111111111111111111111111111111, v1, v2, v1, 32
-    jumpi v7, bb4, bb3
+    v7 = gas
+    v8 = sub v7, 50
+    v9 = delegatecall v8, 0x1111111111111111111111111111111111111111, v3, v4, v3, 32
+    jumpi v9, bb4, bb3
   bb3:
     revert_returndata
   bb4:
-    v8 = add v1, 0
-    v9 = mload v8
-    v10 = iszero v9
-    v11 = iszero v10
-    v12 = eq v9, v11
+    v10 = add v3, 0
+    v11 = mload v10
+    v12 = iszero v11
     v13 = iszero v12
-    jumpi v13, bb1, bb5
+    v14 = eq v11, v13
+    v15 = iszero v14
+    jumpi v15, bb1, bb5
   bb5:
-    v14 = add v1, 0
-    v15 = mload v14
-    ret v15
+    v16 = add v3, 0
+    v17 = mload v16
+    ret v17
   bb1:
     revert 0, 0
 }
@@ -198,48 +216,104 @@ fn @structBool(arg0: u256) -> memorystruct [selector=0x199436a8, pure, abi_param
     v1 = alloc memorybytes, exact, uninitialized, infallible, 96
     set_memory_object_len memorybytes, v1, 64
     v2 = memory_object_data memorybytes, v1
-    v3 = abi_encode [word], selector 0xa370c66800000000000000000000000000000000000000000000000000000000, args arg0
-    v4 = slice_ptr v3
-    v5 = slice_len v3
-    v6 = extcodesize 0x1111111111111111111111111111111111111111
-    v7 = iszero v6
-    jumpi v7, bb1, bb2
+    v3 = fmp
+    v4 = add v3, 64
+    mstore v4, 0
+    v5 = abi_encode [word], selector 0xa370c66800000000000000000000000000000000000000000000000000000000, args arg0
+    v6 = slice_ptr v5
+    v7 = slice_len v5
+    v8 = extcodesize 0x1111111111111111111111111111111111111111
+    v9 = iszero v8
+    jumpi v9, bb1, bb2
   bb2:
-    v8 = gas
-    v9 = sub v8, 50
-    v10 = delegatecall v9, 0x1111111111111111111111111111111111111111, v4, v5, v4, 64
-    jumpi v10, bb4, bb3
+    v10 = gas
+    v11 = sub v10, 50
+    v12 = delegatecall v11, 0x1111111111111111111111111111111111111111, v6, v7, v6, 64
+    jumpi v12, bb4, bb3
   bb3:
     revert_returndata
   bb4:
-    mcopy v2, v4, 64
-    v11 = abi_decode [tuple<bool, u256>], v1
-    ret v11
+    mcopy v2, v6, 64
+    v13 = abi_decode [tuple<bool, u256>], v1
+    ret v13
   bb1:
     revert 0, 0
 }
 
 fn @attached() -> u256 [selector=0xd9e6b370, view, abi_params=[], abi_returns=[word]] {
   bb0:
-    v0 = abi_encode [word], selector 0xa2fc82bf00000000000000000000000000000000000000000000000000000000, args 0
-    v1 = slice_ptr v0
-    v2 = slice_len v0
-    v3 = extcodesize 0x1111111111111111111111111111111111111111
-    v4 = iszero v3
-    jumpi v4, bb1, bb2
+    v0 = fmp
+    v1 = add v0, 32
+    mstore v1, 0
+    v2 = abi_encode [word], selector 0xa2fc82bf00000000000000000000000000000000000000000000000000000000, args 0
+    v3 = slice_ptr v2
+    v4 = slice_len v2
+    v5 = extcodesize 0x1111111111111111111111111111111111111111
+    v6 = iszero v5
+    jumpi v6, bb1, bb2
   bb2:
-    v5 = gas
-    v6 = sub v5, 50
-    v7 = delegatecall v6, 0x1111111111111111111111111111111111111111, v1, v2, v1, 32
-    jumpi v7, bb4, bb3
+    v7 = gas
+    v8 = sub v7, 50
+    v9 = delegatecall v8, 0x1111111111111111111111111111111111111111, v3, v4, v3, 32
+    jumpi v9, bb4, bb3
   bb3:
     revert_returndata
   bb4:
-    v8 = add v1, 0
-    v9 = mload v8
-    v10 = add v1, 0
+    v10 = add v3, 0
     v11 = mload v10
-    ret v11
+    v12 = add v3, 0
+    v13 = mload v12
+    ret v13
+  bb1:
+    revert 0, 0
+}
+
+fn @dynamicArgument(arg0: memorybytes) -> (u256, u256) [selector=0x11b8efbf, pure, abi_params=[bytes], abi_returns=[word, word]] {
+  bb0:
+    v0 = fmp
+    v1 = add v0, 192
+    mstore v1, 0
+    v2 = abi_encode [memory_bytes], selector 0xb84d18fb00000000000000000000000000000000000000000000000000000000, args arg0
+    v3 = slice_ptr v2
+    v4 = slice_len v2
+    v5 = extcodesize 0x1111111111111111111111111111111111111111
+    v6 = iszero v5
+    jumpi v6, bb1, bb2
+  bb2:
+    v7 = gas
+    v8 = sub v7, 50
+    v9 = delegatecall v8, 0x1111111111111111111111111111111111111111, v3, v4, v3, 192
+    jumpi v9, bb4, bb3
+  bb3:
+    revert_returndata
+  bb4:
+    v10 = add v3, 0
+    v11 = mload v10
+    v12 = add v3, 32
+    v13 = mload v12
+    v14 = add v3, 64
+    v15 = mload v14
+    v16 = add v3, 96
+    v17 = mload v16
+    v18 = add v3, 128
+    v19 = mload v18
+    v20 = add v3, 160
+    v21 = mload v20
+    frame_store multi_return, word, 0, v3 !metadata(memory=scratch)
+    v22 = add v3, 0
+    v23 = mload v22
+    v24 = frame_load multi_return, word, 0 !metadata(memory=scratch)
+    v25 = add v24, 32
+    v26 = mload v25
+    v27 = add v24, 64
+    v28 = mload v27
+    v29 = add v24, 96
+    v30 = mload v29
+    v31 = add v24, 128
+    v32 = mload v31
+    v33 = add v24, 160
+    v34 = mload v33
+    ret v23, v34
   bb1:
     revert 0, 0
 }

--- a/tests/ui/codegen/lowering/library_call_evm_version.homestead.stdout
+++ b/tests/ui/codegen/lowering/library_call_evm_version.homestead.stdout
@@ -1,0 +1,155 @@
+// === ROOT/tests/ui/codegen/lowering/library_call_evm_version.sol:Lib ===
+@module Lib
+fn @dbl(arg0: u256) -> u256 [selector=0x5d2a6863, pure, abi_params=[u256], abi_returns=[word]] {
+  bb0:
+    v0 = mul 2, arg0
+    v1 = iszero arg0
+    v2 = div v0, arg0
+    v3 = eq v2, 2
+    v4 = or v1, v3
+    v5 = iszero v4
+    jumpi v5, bb1, bb2
+  bb2:
+    ret v0
+  bb1:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 17 !metadata(memory=scratch)
+    revert 0, 36
+}
+
+fn @pair(arg0: u256) -> (u256, u256) [selector=0x645751af, pure, abi_params=[u256], abi_returns=[word, word]] {
+  bb0:
+    v0 = add arg0, 1
+    v1 = lt v0, arg0
+    jumpi v1, bb1, bb2
+  bb2:
+    ret arg0, v0
+  bb1:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 17 !metadata(memory=scratch)
+    revert 0, 36
+}
+
+fn @arr(arg0: u256) -> memoryfixedarray [selector=0x71e5ee5f, pure, abi_params=[u256], abi_returns=[array<2, word>]] {
+  bb0:
+    v0 = alloc memoryfixedarray<2, 1>, exact, uninitialized, infallible, 64
+    memory_zero v0, 64
+    v1 = alloc memoryfixedarray<2, 1>, exact, uninitialized, infallible, 64
+    memory_object_store_element memoryfixedarray<2, 1>, v1, 0, arg0
+    memory_object_store_element memoryfixedarray<2, 1>, v1, 1, arg0
+    ret v1
+}
+
+fn @noret(arg0: u256) [selector=0x089b9644, pure, abi_params=[u256], abi_returns=[]] {
+  bb0:
+    stop
+}
+
+// === ROOT/tests/ui/codegen/lowering/library_call_evm_version.sol:C ===
+@module C
+fn @one(arg0: u256) -> u256 [selector=0xef56f928, pure, abi_params=[u256], abi_returns=[word]] {
+  bb0:
+    v0 = abi_encode [word], selector 0x5d2a686300000000000000000000000000000000000000000000000000000000, args arg0
+    v1 = slice_ptr v0
+    v2 = slice_len v0
+    v3 = extcodesize 0x1111111111111111111111111111111111111111
+    v4 = iszero v3
+    jumpi v4, bb1, bb2
+  bb2:
+    v5 = gas
+    v6 = sub v5, 50
+    v7 = delegatecall v6, 0x1111111111111111111111111111111111111111, v1, v2, 0, 32
+    jumpi v7, bb4, bb3
+  bb3:
+    revert_returndata
+  bb4:
+    v8 = add 0, 0
+    v9 = mload v8
+    v10 = add 0, 0
+    v11 = mload v10
+    ret v11
+  bb1:
+    revert 0, 0
+}
+
+fn @two(arg0: u256) -> (u256, u256) [selector=0xcf2a8612, pure, abi_params=[u256], abi_returns=[word, word]] {
+  bb0:
+    v0 = abi_encode [word], selector 0x645751af00000000000000000000000000000000000000000000000000000000, args arg0
+    v1 = slice_ptr v0
+    v2 = slice_len v0
+    v3 = alloc raw, exact, uninitialized, infallible, 64
+    v4 = add v3, 32
+    mstore v4, 0
+    v5 = extcodesize 0x1111111111111111111111111111111111111111
+    v6 = iszero v5
+    jumpi v6, bb1, bb2
+  bb2:
+    v7 = gas
+    v8 = sub v7, 50
+    v9 = delegatecall v8, 0x1111111111111111111111111111111111111111, v1, v2, v3, 64
+    jumpi v9, bb4, bb3
+  bb3:
+    revert_returndata
+  bb4:
+    v10 = add v3, 0
+    v11 = mload v10
+    v12 = add v3, 32
+    v13 = mload v12
+    frame_store multi_return, word, 0, v3 !metadata(memory=scratch)
+    v14 = add v3, 0
+    v15 = mload v14
+    v16 = frame_load multi_return, word, 0 !metadata(memory=scratch)
+    v17 = add v16, 32
+    v18 = mload v17
+    ret v15, v18
+  bb1:
+    revert 0, 0
+}
+
+fn @aggregate(arg0: u256) -> memoryfixedarray [selector=0x407b7269, pure, abi_params=[u256], abi_returns=[array<2, word>]] {
+  bb0:
+    v0 = alloc memoryfixedarray<2, 1>, exact, uninitialized, infallible, 64
+    memory_zero v0, 64
+    v1 = abi_encode [word], selector 0x71e5ee5f00000000000000000000000000000000000000000000000000000000, args arg0
+    v2 = slice_ptr v1
+    v3 = slice_len v1
+    v4 = alloc raw, exact, uninitialized, infallible, 64
+    v5 = add v4, 32
+    mstore v5, 0
+    v6 = extcodesize 0x1111111111111111111111111111111111111111
+    v7 = iszero v6
+    jumpi v7, bb1, bb2
+  bb2:
+    v8 = gas
+    v9 = sub v8, 50
+    v10 = delegatecall v9, 0x1111111111111111111111111111111111111111, v2, v3, v4, 64
+    jumpi v10, bb4, bb3
+  bb3:
+    revert_returndata
+  bb4:
+    v11 = abi_decode [array<2, u256>], v4
+    ret v11
+  bb1:
+    revert 0, 0
+}
+
+fn @none(arg0: u256) [selector=0x2758da14, pure, abi_params=[u256], abi_returns=[]] {
+  bb0:
+    v0 = abi_encode [word], selector 0x89b964400000000000000000000000000000000000000000000000000000000, args arg0
+    v1 = slice_ptr v0
+    v2 = slice_len v0
+    v3 = extcodesize 0x1111111111111111111111111111111111111111
+    v4 = iszero v3
+    jumpi v4, bb1, bb2
+  bb2:
+    v5 = gas
+    v6 = sub v5, 50
+    v7 = delegatecall v6, 0x1111111111111111111111111111111111111111, v1, v2, 0, 0
+    jumpi v7, bb4, bb3
+  bb3:
+    revert_returndata
+  bb4:
+    stop
+  bb1:
+    revert 0, 0
+}

--- a/tests/ui/codegen/lowering/library_call_evm_version.homestead.stdout
+++ b/tests/ui/codegen/lowering/library_call_evm_version.homestead.stdout
@@ -86,14 +86,14 @@ fn @one(arg0: u256) -> u256 [selector=0xef56f928, pure, abi_params=[u256], abi_r
   bb2:
     v5 = gas
     v6 = sub v5, 50
-    v7 = delegatecall v6, 0x1111111111111111111111111111111111111111, v1, v2, 0, 32
+    v7 = delegatecall v6, 0x1111111111111111111111111111111111111111, v1, v2, v1, 32
     jumpi v7, bb4, bb3
   bb3:
     revert_returndata
   bb4:
-    v8 = add 0, 0
+    v8 = add v1, 0
     v9 = mload v8
-    v10 = add 0, 0
+    v10 = add v1, 0
     v11 = mload v10
     ret v11
   bb1:
@@ -105,31 +105,28 @@ fn @two(arg0: u256) -> (u256, u256) [selector=0xcf2a8612, pure, abi_params=[u256
     v0 = abi_encode [word], selector 0x645751af00000000000000000000000000000000000000000000000000000000, args arg0
     v1 = slice_ptr v0
     v2 = slice_len v0
-    v3 = alloc raw, exact, uninitialized, infallible, 64
-    v4 = add v3, 32
-    mstore v4, 0
-    v5 = extcodesize 0x1111111111111111111111111111111111111111
-    v6 = iszero v5
-    jumpi v6, bb1, bb2
+    v3 = extcodesize 0x1111111111111111111111111111111111111111
+    v4 = iszero v3
+    jumpi v4, bb1, bb2
   bb2:
-    v7 = gas
-    v8 = sub v7, 50
-    v9 = delegatecall v8, 0x1111111111111111111111111111111111111111, v1, v2, v3, 64
-    jumpi v9, bb4, bb3
+    v5 = gas
+    v6 = sub v5, 50
+    v7 = delegatecall v6, 0x1111111111111111111111111111111111111111, v1, v2, v1, 64
+    jumpi v7, bb4, bb3
   bb3:
     revert_returndata
   bb4:
-    v10 = add v3, 0
+    v8 = add v1, 0
+    v9 = mload v8
+    v10 = add v1, 32
     v11 = mload v10
-    v12 = add v3, 32
+    frame_store multi_return, word, 0, v1 !metadata(memory=scratch)
+    v12 = add v1, 0
     v13 = mload v12
-    frame_store multi_return, word, 0, v3 !metadata(memory=scratch)
-    v14 = add v3, 0
-    v15 = mload v14
-    v16 = frame_load multi_return, word, 0 !metadata(memory=scratch)
-    v17 = add v16, 32
-    v18 = mload v17
-    ret v15, v18
+    v14 = frame_load multi_return, word, 0 !metadata(memory=scratch)
+    v15 = add v14, 32
+    v16 = mload v15
+    ret v13, v16
   bb1:
     revert 0, 0
 }
@@ -138,24 +135,25 @@ fn @aggregate(arg0: u256) -> memoryfixedarray [selector=0x407b7269, pure, abi_pa
   bb0:
     v0 = alloc memoryfixedarray<2, 1>, exact, uninitialized, infallible, 64
     memory_zero v0, 64
-    v1 = abi_encode [word], selector 0x71e5ee5f00000000000000000000000000000000000000000000000000000000, args arg0
-    v2 = slice_ptr v1
-    v3 = slice_len v1
-    v4 = alloc raw, exact, uninitialized, infallible, 64
-    v5 = add v4, 32
-    mstore v5, 0
+    v1 = alloc memorybytes, exact, uninitialized, infallible, 96
+    set_memory_object_len memorybytes, v1, 64
+    v2 = memory_object_data memorybytes, v1
+    v3 = abi_encode [word], selector 0x71e5ee5f00000000000000000000000000000000000000000000000000000000, args arg0
+    v4 = slice_ptr v3
+    v5 = slice_len v3
     v6 = extcodesize 0x1111111111111111111111111111111111111111
     v7 = iszero v6
     jumpi v7, bb1, bb2
   bb2:
     v8 = gas
     v9 = sub v8, 50
-    v10 = delegatecall v9, 0x1111111111111111111111111111111111111111, v2, v3, v4, 64
+    v10 = delegatecall v9, 0x1111111111111111111111111111111111111111, v4, v5, v4, 64
     jumpi v10, bb4, bb3
   bb3:
     revert_returndata
   bb4:
-    v11 = abi_decode [array<2, u256>], v4
+    mcopy v2, v4, 64
+    v11 = abi_decode [array<2, u256>], v1
     ret v11
   bb1:
     revert 0, 0
@@ -172,12 +170,12 @@ fn @boolean(arg0: u256) -> bool [selector=0xbc586ed6, pure, abi_params=[u256], a
   bb2:
     v5 = gas
     v6 = sub v5, 50
-    v7 = delegatecall v6, 0x1111111111111111111111111111111111111111, v1, v2, 0, 32
+    v7 = delegatecall v6, 0x1111111111111111111111111111111111111111, v1, v2, v1, 32
     jumpi v7, bb4, bb3
   bb3:
     revert_returndata
   bb4:
-    v8 = add 0, 0
+    v8 = add v1, 0
     v9 = mload v8
     v10 = iszero v9
     v11 = iszero v10
@@ -185,7 +183,7 @@ fn @boolean(arg0: u256) -> bool [selector=0xbc586ed6, pure, abi_params=[u256], a
     v13 = iszero v12
     jumpi v13, bb1, bb5
   bb5:
-    v14 = add 0, 0
+    v14 = add v1, 0
     v15 = mload v14
     ret v15
   bb1:
@@ -197,24 +195,25 @@ fn @structBool(arg0: u256) -> memorystruct [selector=0x199436a8, pure, abi_param
     v0 = alloc memorystruct<2>, exact, uninitialized, infallible, 64
     memory_object_store_field memorystruct<2>, v0, 0, 0
     memory_object_store_field memorystruct<2>, v0, 1, 0
-    v1 = abi_encode [word], selector 0xa370c66800000000000000000000000000000000000000000000000000000000, args arg0
-    v2 = slice_ptr v1
-    v3 = slice_len v1
-    v4 = alloc raw, exact, uninitialized, infallible, 64
-    v5 = add v4, 32
-    mstore v5, 0
+    v1 = alloc memorybytes, exact, uninitialized, infallible, 96
+    set_memory_object_len memorybytes, v1, 64
+    v2 = memory_object_data memorybytes, v1
+    v3 = abi_encode [word], selector 0xa370c66800000000000000000000000000000000000000000000000000000000, args arg0
+    v4 = slice_ptr v3
+    v5 = slice_len v3
     v6 = extcodesize 0x1111111111111111111111111111111111111111
     v7 = iszero v6
     jumpi v7, bb1, bb2
   bb2:
     v8 = gas
     v9 = sub v8, 50
-    v10 = delegatecall v9, 0x1111111111111111111111111111111111111111, v2, v3, v4, 64
+    v10 = delegatecall v9, 0x1111111111111111111111111111111111111111, v4, v5, v4, 64
     jumpi v10, bb4, bb3
   bb3:
     revert_returndata
   bb4:
-    v11 = abi_decode [tuple<bool, u256>], v4
+    mcopy v2, v4, 64
+    v11 = abi_decode [tuple<bool, u256>], v1
     ret v11
   bb1:
     revert 0, 0
@@ -231,14 +230,14 @@ fn @attached() -> u256 [selector=0xd9e6b370, view, abi_params=[], abi_returns=[w
   bb2:
     v5 = gas
     v6 = sub v5, 50
-    v7 = delegatecall v6, 0x1111111111111111111111111111111111111111, v1, v2, 0, 32
+    v7 = delegatecall v6, 0x1111111111111111111111111111111111111111, v1, v2, v1, 32
     jumpi v7, bb4, bb3
   bb3:
     revert_returndata
   bb4:
-    v8 = add 0, 0
+    v8 = add v1, 0
     v9 = mload v8
-    v10 = add 0, 0
+    v10 = add v1, 0
     v11 = mload v10
     ret v11
   bb1:
@@ -256,7 +255,7 @@ fn @none(arg0: u256) [selector=0x2758da14, pure, abi_params=[u256], abi_returns=
   bb2:
     v5 = gas
     v6 = sub v5, 50
-    v7 = delegatecall v6, 0x1111111111111111111111111111111111111111, v1, v2, 0, 0
+    v7 = delegatecall v6, 0x1111111111111111111111111111111111111111, v1, v2, v1, 0
     jumpi v7, bb4, bb3
   bb3:
     revert_returndata

--- a/tests/ui/codegen/lowering/library_call_evm_version.homestead.stdout
+++ b/tests/ui/codegen/lowering/library_call_evm_version.homestead.stdout
@@ -40,6 +40,34 @@ fn @arr(arg0: u256) -> memoryfixedarray [selector=0x71e5ee5f, pure, abi_params=[
     ret v1
 }
 
+fn @flag(arg0: u256) -> bool [selector=0xbb760a75, pure, abi_params=[u256], abi_returns=[word<bool>]] {
+  bb0:
+    v0 = eq arg0, 0
+    v1 = iszero v0
+    ret v1
+}
+
+fn @flagged(arg0: u256) -> memorystruct [selector=0xa370c668, pure, abi_params=[u256], abi_returns=[tuple<word<bool>, word>], abi_return_params=[tuple<bool, u256>]] {
+  bb0:
+    v0 = alloc memorystruct<2>, exact, uninitialized, infallible, 64
+    memory_object_store_field memorystruct<2>, v0, 0, 0
+    memory_object_store_field memorystruct<2>, v0, 1, 0
+    v1 = alloc memorystruct<2>, exact, uninitialized, infallible, 64
+    v2 = eq arg0, 0
+    v3 = iszero v2
+    v4 = eq v3, 0
+    v5 = iszero v4
+    memory_object_store_field memorystruct<2>, v1, 0, v5
+    memory_object_store_field memorystruct<2>, v1, 1, arg0
+    ret v1
+}
+
+fn @total(arg0: storageptr) -> u256 [selector=0xa2fc82bf, view, abi_params=[storageptr], abi_returns=[word]] {
+  bb0:
+    v0 = sload arg0 !metadata(storage=symbolic(arg0))
+    ret v0
+}
+
 fn @noret(arg0: u256) [selector=0x089b9644, pure, abi_params=[u256], abi_returns=[]] {
   bb0:
     stop
@@ -128,6 +156,90 @@ fn @aggregate(arg0: u256) -> memoryfixedarray [selector=0x407b7269, pure, abi_pa
     revert_returndata
   bb4:
     v11 = abi_decode [array<2, u256>], v4
+    ret v11
+  bb1:
+    revert 0, 0
+}
+
+fn @boolean(arg0: u256) -> bool [selector=0xbc586ed6, pure, abi_params=[u256], abi_returns=[word<bool>]] {
+  bb0:
+    v0 = abi_encode [word], selector 0xbb760a7500000000000000000000000000000000000000000000000000000000, args arg0
+    v1 = slice_ptr v0
+    v2 = slice_len v0
+    v3 = extcodesize 0x1111111111111111111111111111111111111111
+    v4 = iszero v3
+    jumpi v4, bb1, bb2
+  bb2:
+    v5 = gas
+    v6 = sub v5, 50
+    v7 = delegatecall v6, 0x1111111111111111111111111111111111111111, v1, v2, 0, 32
+    jumpi v7, bb4, bb3
+  bb3:
+    revert_returndata
+  bb4:
+    v8 = add 0, 0
+    v9 = mload v8
+    v10 = iszero v9
+    v11 = iszero v10
+    v12 = eq v9, v11
+    v13 = iszero v12
+    jumpi v13, bb1, bb5
+  bb5:
+    v14 = add 0, 0
+    v15 = mload v14
+    ret v15
+  bb1:
+    revert 0, 0
+}
+
+fn @structBool(arg0: u256) -> memorystruct [selector=0x199436a8, pure, abi_params=[u256], abi_returns=[tuple<word<bool>, word>], abi_return_params=[tuple<bool, u256>]] {
+  bb0:
+    v0 = alloc memorystruct<2>, exact, uninitialized, infallible, 64
+    memory_object_store_field memorystruct<2>, v0, 0, 0
+    memory_object_store_field memorystruct<2>, v0, 1, 0
+    v1 = abi_encode [word], selector 0xa370c66800000000000000000000000000000000000000000000000000000000, args arg0
+    v2 = slice_ptr v1
+    v3 = slice_len v1
+    v4 = alloc raw, exact, uninitialized, infallible, 64
+    v5 = add v4, 32
+    mstore v5, 0
+    v6 = extcodesize 0x1111111111111111111111111111111111111111
+    v7 = iszero v6
+    jumpi v7, bb1, bb2
+  bb2:
+    v8 = gas
+    v9 = sub v8, 50
+    v10 = delegatecall v9, 0x1111111111111111111111111111111111111111, v2, v3, v4, 64
+    jumpi v10, bb4, bb3
+  bb3:
+    revert_returndata
+  bb4:
+    v11 = abi_decode [tuple<bool, u256>], v4
+    ret v11
+  bb1:
+    revert 0, 0
+}
+
+fn @attached() -> u256 [selector=0xd9e6b370, view, abi_params=[], abi_returns=[word]] {
+  bb0:
+    v0 = abi_encode [word], selector 0xa2fc82bf00000000000000000000000000000000000000000000000000000000, args 0
+    v1 = slice_ptr v0
+    v2 = slice_len v0
+    v3 = extcodesize 0x1111111111111111111111111111111111111111
+    v4 = iszero v3
+    jumpi v4, bb1, bb2
+  bb2:
+    v5 = gas
+    v6 = sub v5, 50
+    v7 = delegatecall v6, 0x1111111111111111111111111111111111111111, v1, v2, 0, 32
+    jumpi v7, bb4, bb3
+  bb3:
+    revert_returndata
+  bb4:
+    v8 = add 0, 0
+    v9 = mload v8
+    v10 = add 0, 0
+    v11 = mload v10
     ret v11
   bb1:
     revert 0, 0

--- a/tests/ui/codegen/lowering/library_call_evm_version.sol
+++ b/tests/ui/codegen/lowering/library_call_evm_version.sol
@@ -1,0 +1,84 @@
+//@ revisions: homestead byzantium
+//@[homestead] compile-flags: -O none --evm-version homestead --libraries Lib=0x1111111111111111111111111111111111111111 -Zdump=mir
+//@[homestead] filecheck: --check-prefix=HOMESTEAD --implicit-check-not=returndatasize
+//@[byzantium] compile-flags: -O none --evm-version byzantium --libraries Lib=0x1111111111111111111111111111111111111111 -Zdump=mir
+//@[byzantium] filecheck: --check-prefix=BYZANTIUM
+
+library Lib {
+    function dbl(uint256 x) external pure returns (uint256) {
+        return 2 * x;
+    }
+
+    function pair(uint256 x) external pure returns (uint256, uint256) {
+        return (x, x + 1);
+    }
+
+    function arr(uint256 x) external pure returns (uint256[2] memory) {
+        return [x, x];
+    }
+
+    function noret(uint256) external pure {}
+}
+
+contract C {
+    // Before Byzantium a linked-library call takes its return values out of the delegatecall's
+    // static output area, as solc's `delegatecall(..., out, 32)` does; from Byzantium on they come
+    // out of the return data, and the length check there subsumes the code check.
+    // HOMESTEAD-LABEL: fn @one
+    // HOMESTEAD: extcodesize
+    // HOMESTEAD: [[GAS:v[0-9]+]] = gas
+    // HOMESTEAD: [[FWD:v[0-9]+]] = sub [[GAS]], 50
+    // HOMESTEAD: delegatecall [[FWD]], {{.*}}, 0, 32
+    // HOMESTEAD: mload
+    // BYZANTIUM-LABEL: fn @one
+    // BYZANTIUM-NOT: extcodesize
+    // BYZANTIUM: delegatecall {{.*}}, 0, 0
+    // BYZANTIUM: returndatasize
+    function one(uint256 x) external pure returns (uint256) {
+        return Lib.dbl(x);
+    }
+
+    // Two words get an output area of their own: the words the call writes above the arguments are
+    // untouched memory, whose expansion a pre-EIP-150 call charges before checking the gas it
+    // forwards.
+    // HOMESTEAD-LABEL: fn @two
+    // HOMESTEAD: [[BUF:v[0-9]+]] = alloc raw, exact, uninitialized, infallible, 64
+    // HOMESTEAD: [[LAST:v[0-9]+]] = add [[BUF]], 32
+    // HOMESTEAD: mstore [[LAST]], 0
+    // HOMESTEAD: delegatecall {{.*}}, [[BUF]], 64
+    // HOMESTEAD: mload
+    // HOMESTEAD: mload
+    // BYZANTIUM-LABEL: fn @two
+    // BYZANTIUM-NOT: extcodesize
+    // BYZANTIUM: delegatecall {{.*}}, 0, 0
+    // BYZANTIUM: returndatasize
+    function two(uint256 x) external pure returns (uint256 a, uint256 b) {
+        (a, b) = Lib.pair(x);
+    }
+
+    // A statically encoded aggregate is decoded out of the output area itself.
+    // HOMESTEAD-LABEL: fn @aggregate
+    // HOMESTEAD: [[BUF:v[0-9]+]] = alloc raw, exact, uninitialized, infallible, 64
+    // HOMESTEAD: [[LAST:v[0-9]+]] = add [[BUF]], 32
+    // HOMESTEAD: mstore [[LAST]], 0
+    // HOMESTEAD: delegatecall {{.*}}, [[BUF]], 64
+    // HOMESTEAD: abi_decode {{.*}}, [[BUF]]
+    // BYZANTIUM-LABEL: fn @aggregate
+    // BYZANTIUM-NOT: extcodesize
+    // BYZANTIUM: delegatecall {{.*}}, 0, 0
+    // BYZANTIUM: returndatasize
+    function aggregate(uint256 x) external pure returns (uint256[2] memory) {
+        return Lib.arr(x);
+    }
+
+    // A call with no return values declares no output area at either version.
+    // HOMESTEAD-LABEL: fn @none
+    // HOMESTEAD: extcodesize
+    // HOMESTEAD: delegatecall {{.*}}, 0, 0
+    // BYZANTIUM-LABEL: fn @none
+    // BYZANTIUM: extcodesize
+    // BYZANTIUM: delegatecall {{.*}}, 0, 0
+    function none(uint256 x) external pure {
+        Lib.noret(x);
+    }
+}

--- a/tests/ui/codegen/lowering/library_call_evm_version.sol
+++ b/tests/ui/codegen/lowering/library_call_evm_version.sol
@@ -37,6 +37,14 @@ library Lib {
     }
 
     function noret(uint256) external pure {}
+
+    function six(bytes memory b)
+        external
+        pure
+        returns (uint256, uint256, uint256, uint256, uint256, uint256)
+    {
+        return (b.length, 1, 2, 3, 4, 5);
+    }
 }
 
 contract C {
@@ -71,10 +79,13 @@ contract C {
         return Lib.dbl(x);
     }
 
-    // Two words overlay the input buffer as well. The area ends where encoding the selector and
-    // the one argument already expanded memory, so nothing has to be touched before the gas the
-    // call withholds is read.
+    // Two words overlay the input buffer as well, and the word above the area is touched before
+    // the arguments are encoded so that the delegatecall's own memory expansion is not charged
+    // against the gas it withholds.
     // HOMESTEAD-LABEL: fn @two
+    // HOMESTEAD: [[AREA:v[0-9]+]] = fmp
+    // HOMESTEAD: [[ABOVE:v[0-9]+]] = add [[AREA]], 64
+    // HOMESTEAD: mstore [[ABOVE]], 0
     // HOMESTEAD: [[IN:v[0-9]+]] = slice_ptr
     // HOMESTEAD-NOT: mstore
     // HOMESTEAD: delegatecall {{.*}}, [[IN]], 64
@@ -155,6 +166,29 @@ contract C {
     // BYZANTIUM: returndatasize
     function attached() external view returns (uint256) {
         return nums.total();
+    }
+
+    // A six-word output area behind a dynamically encoded argument reaches far past the
+    // argument's last word, and `sub(gas(), 50)` leaves only two words of expansion. The touch
+    // sits at the free-memory pointer plus the output size, so it covers the area whatever the
+    // argument encodes to, and it precedes the encoding it would otherwise write over.
+    // HOMESTEAD-LABEL: fn @dynamicArgument
+    // HOMESTEAD: [[AREA:v[0-9]+]] = fmp
+    // HOMESTEAD: [[ABOVE:v[0-9]+]] = add [[AREA]], 192
+    // HOMESTEAD: mstore [[ABOVE]], 0
+    // HOMESTEAD: [[IN:v[0-9]+]] = slice_ptr
+    // HOMESTEAD: [[GAS:v[0-9]+]] = gas
+    // HOMESTEAD: [[FWD:v[0-9]+]] = sub [[GAS]], 50
+    // HOMESTEAD: delegatecall [[FWD]], {{.*}}, [[IN]], {{.*}}, [[IN]], 192
+    // TANGERINE-LABEL: fn @dynamicArgument
+    // TANGERINE-NOT: = fmp
+    // TANGERINE: delegatecall {{.*}}, [[IN:v[0-9]+]], {{.*}}, [[IN]], 192
+    // BYZANTIUM-LABEL: fn @dynamicArgument
+    // BYZANTIUM: delegatecall {{.*}}, 0, 0
+    // BYZANTIUM: returndatasize
+    function dynamicArgument(bytes memory b) external pure returns (uint256, uint256) {
+        (uint256 a,,,,, uint256 f) = Lib.six(b);
+        return (a, f);
     }
 
     // A call with no return values declares an empty output area at either version.

--- a/tests/ui/codegen/lowering/library_call_evm_version.sol
+++ b/tests/ui/codegen/lowering/library_call_evm_version.sol
@@ -44,22 +44,24 @@ contract C {
 
     uint256[] private nums;
 
-    // Before Byzantium a linked-library call takes its return values out of the delegatecall's
-    // static output area, as solc's `delegatecall(..., out, 32)` does; from Byzantium on they come
-    // out of the return data, and the length check there subsumes the code check.
+    // Before Byzantium a linked-library call takes its return values out of a static output area
+    // overlaying its own input, as solc's `delegatecall(..., in, 32)` does; from Byzantium on they
+    // come out of the return data, and the length check there subsumes the code check.
     // HOMESTEAD-LABEL: fn @one
+    // HOMESTEAD: [[IN:v[0-9]+]] = slice_ptr
     // HOMESTEAD: extcodesize
     // HOMESTEAD: [[GAS:v[0-9]+]] = gas
     // HOMESTEAD: [[FWD:v[0-9]+]] = sub [[GAS]], 50
-    // HOMESTEAD: delegatecall [[FWD]], {{.*}}, 0, 32
+    // HOMESTEAD: delegatecall [[FWD]], {{.*}}, [[IN]], {{.*}}, [[IN]], 32
     // HOMESTEAD: mload
     // From EIP-150 on the forwarded gas is capped, so the reserve goes away while the output area
     // and the code check stay.
     // TANGERINE-LABEL: fn @one
+    // TANGERINE: [[IN:v[0-9]+]] = slice_ptr
     // TANGERINE: [[GAS:v[0-9]+]] = gas
     // TANGERINE-NOT: sub [[GAS]]
     // TANGERINE: extcodesize
-    // TANGERINE: delegatecall [[GAS]], {{.*}}, 0, 32
+    // TANGERINE: delegatecall [[GAS]], {{.*}}, [[IN]], {{.*}}, [[IN]], 32
     // TANGERINE: mload
     // BYZANTIUM-LABEL: fn @one
     // BYZANTIUM-NOT: extcodesize
@@ -69,18 +71,15 @@ contract C {
         return Lib.dbl(x);
     }
 
-    // Two words get an output area of their own: the words the call writes above the arguments are
-    // untouched memory, whose expansion a pre-EIP-150 call charges before checking the gas it
-    // forwards.
+    // Two words overlay the input buffer as well. The area ends where encoding the selector and
+    // the one argument already expanded memory, so nothing has to be touched before the gas the
+    // call withholds is read.
     // HOMESTEAD-LABEL: fn @two
-    // HOMESTEAD: [[BUF:v[0-9]+]] = alloc raw, exact, uninitialized, infallible, 64
-    // HOMESTEAD: [[LAST:v[0-9]+]] = add [[BUF]], 32
-    // HOMESTEAD: mstore [[LAST]], 0
-    // HOMESTEAD: delegatecall {{.*}}, [[BUF]], 64
+    // HOMESTEAD: [[IN:v[0-9]+]] = slice_ptr
+    // HOMESTEAD-NOT: mstore
+    // HOMESTEAD: delegatecall {{.*}}, [[IN]], 64
     // HOMESTEAD: mload
     // HOMESTEAD: mload
-    // Once the expansion is not charged out of the withheld gas the output area reuses the input
-    // buffer, as solc's does at every version.
     // TANGERINE-LABEL: fn @two
     // TANGERINE: [[IN:v[0-9]+]] = slice_ptr
     // TANGERINE-NOT: alloc raw
@@ -93,12 +92,14 @@ contract C {
         (a, b) = Lib.pair(x);
     }
 
-    // A statically encoded aggregate is decoded out of the output area itself.
+    // A statically encoded aggregate is copied out of the overlaid output area into a buffer taken
+    // before the arguments, which the decoding then reads.
     // HOMESTEAD-LABEL: fn @aggregate
-    // HOMESTEAD: [[BUF:v[0-9]+]] = alloc raw, exact, uninitialized, infallible, 64
-    // HOMESTEAD: [[LAST:v[0-9]+]] = add [[BUF]], 32
-    // HOMESTEAD: mstore [[LAST]], 0
-    // HOMESTEAD: delegatecall {{.*}}, [[BUF]], 64
+    // HOMESTEAD: [[BUF:v[0-9]+]] = alloc memorybytes
+    // HOMESTEAD: [[DATA:v[0-9]+]] = memory_object_data memorybytes, [[BUF]]
+    // HOMESTEAD: [[IN:v[0-9]+]] = slice_ptr
+    // HOMESTEAD: delegatecall {{.*}}, [[IN]], 64
+    // HOMESTEAD: mcopy [[DATA]], [[IN]], 64
     // HOMESTEAD: abi_decode {{.*}}, [[BUF]]
     // BYZANTIUM-LABEL: fn @aggregate
     // BYZANTIUM-NOT: extcodesize
@@ -111,7 +112,8 @@ contract C {
     // A returned word is validated where it is read from, so a dirty `bool` reverts before
     // Byzantium as well.
     // HOMESTEAD-LABEL: fn @boolean
-    // HOMESTEAD: delegatecall {{.*}}, 0, 32
+    // HOMESTEAD: [[IN:v[0-9]+]] = slice_ptr
+    // HOMESTEAD: delegatecall {{.*}}, [[IN]], 32
     // HOMESTEAD: [[WORD:v[0-9]+]] = mload
     // HOMESTEAD: [[CLEAN:v[0-9]+]] = eq [[WORD]],
     // HOMESTEAD: iszero [[CLEAN]]
@@ -126,8 +128,11 @@ contract C {
     // A static struct is decoded out of the output area with its member types, so its `bool` member
     // is validated too.
     // HOMESTEAD-LABEL: fn @structBool
-    // HOMESTEAD: [[BUF:v[0-9]+]] = alloc raw, exact, uninitialized, infallible, 64
-    // HOMESTEAD: delegatecall {{.*}}, [[BUF]], 64
+    // HOMESTEAD: [[BUF:v[0-9]+]] = alloc memorybytes
+    // HOMESTEAD: [[DATA:v[0-9]+]] = memory_object_data memorybytes, [[BUF]]
+    // HOMESTEAD: [[IN:v[0-9]+]] = slice_ptr
+    // HOMESTEAD: delegatecall {{.*}}, [[IN]], 64
+    // HOMESTEAD: mcopy [[DATA]], [[IN]], 64
     // HOMESTEAD: abi_decode [tuple<bool, u256>], [[BUF]]
     // BYZANTIUM-LABEL: fn @structBool
     // BYZANTIUM: delegatecall {{.*}}, 0, 0
@@ -137,11 +142,12 @@ contract C {
     }
 
     // An attached call passes its storage receiver as a slot and reads its return value out of the
-    // same output area.
+    // same overlaid output area.
     // HOMESTEAD-LABEL: fn @attached
     // HOMESTEAD: abi_encode {{.*}}, args 0
+    // HOMESTEAD: [[IN:v[0-9]+]] = slice_ptr
     // HOMESTEAD: extcodesize
-    // HOMESTEAD: delegatecall {{.*}}, 0, 32
+    // HOMESTEAD: delegatecall {{.*}}, [[IN]], 32
     // HOMESTEAD: mload
     // BYZANTIUM-LABEL: fn @attached
     // BYZANTIUM: abi_encode {{.*}}, args 0
@@ -151,10 +157,11 @@ contract C {
         return nums.total();
     }
 
-    // A call with no return values declares no output area at either version.
+    // A call with no return values declares an empty output area at either version.
     // HOMESTEAD-LABEL: fn @none
+    // HOMESTEAD: [[IN:v[0-9]+]] = slice_ptr
     // HOMESTEAD: extcodesize
-    // HOMESTEAD: delegatecall {{.*}}, 0, 0
+    // HOMESTEAD: delegatecall {{.*}}, [[IN]], 0
     // BYZANTIUM-LABEL: fn @none
     // BYZANTIUM: extcodesize
     // BYZANTIUM: delegatecall {{.*}}, 0, 0

--- a/tests/ui/codegen/lowering/library_call_evm_version.sol
+++ b/tests/ui/codegen/lowering/library_call_evm_version.sol
@@ -1,10 +1,17 @@
-//@ revisions: homestead byzantium
+//@ revisions: homestead tangerineWhistle byzantium
 //@[homestead] compile-flags: -O none --evm-version homestead --libraries Lib=0x1111111111111111111111111111111111111111 -Zdump=mir
 //@[homestead] filecheck: --check-prefix=HOMESTEAD --implicit-check-not=returndatasize
+//@[tangerineWhistle] compile-flags: -O none --evm-version tangerineWhistle --libraries Lib=0x1111111111111111111111111111111111111111 -Zdump=mir
+//@[tangerineWhistle] filecheck: --check-prefix=TANGERINE --implicit-check-not=returndatasize
 //@[byzantium] compile-flags: -O none --evm-version byzantium --libraries Lib=0x1111111111111111111111111111111111111111 -Zdump=mir
 //@[byzantium] filecheck: --check-prefix=BYZANTIUM
 
 library Lib {
+    struct Flagged {
+        bool set;
+        uint256 value;
+    }
+
     function dbl(uint256 x) external pure returns (uint256) {
         return 2 * x;
     }
@@ -17,10 +24,26 @@ library Lib {
         return [x, x];
     }
 
+    function flag(uint256 x) external pure returns (bool) {
+        return x != 0;
+    }
+
+    function flagged(uint256 x) external pure returns (Flagged memory) {
+        return Flagged(x != 0, x);
+    }
+
+    function total(uint256[] storage a) external view returns (uint256) {
+        return a.length;
+    }
+
     function noret(uint256) external pure {}
 }
 
 contract C {
+    using Lib for uint256[];
+
+    uint256[] private nums;
+
     // Before Byzantium a linked-library call takes its return values out of the delegatecall's
     // static output area, as solc's `delegatecall(..., out, 32)` does; from Byzantium on they come
     // out of the return data, and the length check there subsumes the code check.
@@ -30,6 +53,14 @@ contract C {
     // HOMESTEAD: [[FWD:v[0-9]+]] = sub [[GAS]], 50
     // HOMESTEAD: delegatecall [[FWD]], {{.*}}, 0, 32
     // HOMESTEAD: mload
+    // From EIP-150 on the forwarded gas is capped, so the reserve goes away while the output area
+    // and the code check stay.
+    // TANGERINE-LABEL: fn @one
+    // TANGERINE: [[GAS:v[0-9]+]] = gas
+    // TANGERINE-NOT: sub [[GAS]]
+    // TANGERINE: extcodesize
+    // TANGERINE: delegatecall [[GAS]], {{.*}}, 0, 32
+    // TANGERINE: mload
     // BYZANTIUM-LABEL: fn @one
     // BYZANTIUM-NOT: extcodesize
     // BYZANTIUM: delegatecall {{.*}}, 0, 0
@@ -48,6 +79,12 @@ contract C {
     // HOMESTEAD: delegatecall {{.*}}, [[BUF]], 64
     // HOMESTEAD: mload
     // HOMESTEAD: mload
+    // Once the expansion is not charged out of the withheld gas the output area reuses the input
+    // buffer, as solc's does at every version.
+    // TANGERINE-LABEL: fn @two
+    // TANGERINE: [[IN:v[0-9]+]] = slice_ptr
+    // TANGERINE-NOT: alloc raw
+    // TANGERINE: delegatecall {{.*}}, [[IN]], 64
     // BYZANTIUM-LABEL: fn @two
     // BYZANTIUM-NOT: extcodesize
     // BYZANTIUM: delegatecall {{.*}}, 0, 0
@@ -69,6 +106,49 @@ contract C {
     // BYZANTIUM: returndatasize
     function aggregate(uint256 x) external pure returns (uint256[2] memory) {
         return Lib.arr(x);
+    }
+
+    // A returned word is validated where it is read from, so a dirty `bool` reverts before
+    // Byzantium as well.
+    // HOMESTEAD-LABEL: fn @boolean
+    // HOMESTEAD: delegatecall {{.*}}, 0, 32
+    // HOMESTEAD: [[WORD:v[0-9]+]] = mload
+    // HOMESTEAD: [[CLEAN:v[0-9]+]] = eq [[WORD]],
+    // HOMESTEAD: iszero [[CLEAN]]
+    // HOMESTEAD: revert 0, 0
+    // BYZANTIUM-LABEL: fn @boolean
+    // BYZANTIUM: delegatecall {{.*}}, 0, 0
+    // BYZANTIUM: returndatasize
+    function boolean(uint256 x) external pure returns (bool) {
+        return Lib.flag(x);
+    }
+
+    // A static struct is decoded out of the output area with its member types, so its `bool` member
+    // is validated too.
+    // HOMESTEAD-LABEL: fn @structBool
+    // HOMESTEAD: [[BUF:v[0-9]+]] = alloc raw, exact, uninitialized, infallible, 64
+    // HOMESTEAD: delegatecall {{.*}}, [[BUF]], 64
+    // HOMESTEAD: abi_decode [tuple<bool, u256>], [[BUF]]
+    // BYZANTIUM-LABEL: fn @structBool
+    // BYZANTIUM: delegatecall {{.*}}, 0, 0
+    // BYZANTIUM: returndatasize
+    function structBool(uint256 x) external pure returns (Lib.Flagged memory) {
+        return Lib.flagged(x);
+    }
+
+    // An attached call passes its storage receiver as a slot and reads its return value out of the
+    // same output area.
+    // HOMESTEAD-LABEL: fn @attached
+    // HOMESTEAD: abi_encode {{.*}}, args 0
+    // HOMESTEAD: extcodesize
+    // HOMESTEAD: delegatecall {{.*}}, 0, 32
+    // HOMESTEAD: mload
+    // BYZANTIUM-LABEL: fn @attached
+    // BYZANTIUM: abi_encode {{.*}}, args 0
+    // BYZANTIUM: delegatecall {{.*}}, 0, 0
+    // BYZANTIUM: returndatasize
+    function attached() external view returns (uint256) {
+        return nums.total();
     }
 
     // A call with no return values declares no output area at either version.

--- a/tests/ui/codegen/lowering/library_call_evm_version.tangerineWhistle.stdout
+++ b/tests/ui/codegen/lowering/library_call_evm_version.tangerineWhistle.stdout
@@ -73,6 +73,12 @@ fn @noret(arg0: u256) [selector=0x089b9644, pure, abi_params=[u256], abi_returns
     stop
 }
 
+fn @six(arg0: memorybytes) -> (u256, u256, u256, u256, u256, u256) [selector=0xb84d18fb, pure, abi_params=[bytes], abi_returns=[word, word, word, word, word, word]] {
+  bb0:
+    v0 = memory_object_len memorybytes, arg0
+    ret v0, 1, 2, 3, 4, 5
+}
+
 // === ROOT/tests/ui/codegen/lowering/library_call_evm_version.sol:C ===
 @module C
 fn @one(arg0: u256) -> u256 [selector=0xef56f928, pure, abi_params=[u256], abi_returns=[word]] {
@@ -234,6 +240,52 @@ fn @attached() -> u256 [selector=0xd9e6b370, view, abi_params=[], abi_returns=[w
     v9 = add v1, 0
     v10 = mload v9
     ret v10
+  bb1:
+    revert 0, 0
+}
+
+fn @dynamicArgument(arg0: memorybytes) -> (u256, u256) [selector=0x11b8efbf, pure, abi_params=[bytes], abi_returns=[word, word]] {
+  bb0:
+    v0 = abi_encode [memory_bytes], selector 0xb84d18fb00000000000000000000000000000000000000000000000000000000, args arg0
+    v1 = slice_ptr v0
+    v2 = slice_len v0
+    v3 = gas
+    v4 = extcodesize 0x1111111111111111111111111111111111111111
+    v5 = iszero v4
+    jumpi v5, bb1, bb2
+  bb2:
+    v6 = delegatecall v3, 0x1111111111111111111111111111111111111111, v1, v2, v1, 192
+    jumpi v6, bb4, bb3
+  bb3:
+    revert_returndata
+  bb4:
+    v7 = add v1, 0
+    v8 = mload v7
+    v9 = add v1, 32
+    v10 = mload v9
+    v11 = add v1, 64
+    v12 = mload v11
+    v13 = add v1, 96
+    v14 = mload v13
+    v15 = add v1, 128
+    v16 = mload v15
+    v17 = add v1, 160
+    v18 = mload v17
+    frame_store multi_return, word, 0, v1 !metadata(memory=scratch)
+    v19 = add v1, 0
+    v20 = mload v19
+    v21 = frame_load multi_return, word, 0 !metadata(memory=scratch)
+    v22 = add v21, 32
+    v23 = mload v22
+    v24 = add v21, 64
+    v25 = mload v24
+    v26 = add v21, 96
+    v27 = mload v26
+    v28 = add v21, 128
+    v29 = mload v28
+    v30 = add v21, 160
+    v31 = mload v30
+    ret v20, v31
   bb1:
     revert 0, 0
 }

--- a/tests/ui/codegen/lowering/library_call_evm_version.tangerineWhistle.stdout
+++ b/tests/ui/codegen/lowering/library_call_evm_version.tangerineWhistle.stdout
@@ -85,14 +85,14 @@ fn @one(arg0: u256) -> u256 [selector=0xef56f928, pure, abi_params=[u256], abi_r
     v5 = iszero v4
     jumpi v5, bb1, bb2
   bb2:
-    v6 = delegatecall v3, 0x1111111111111111111111111111111111111111, v1, v2, 0, 32
+    v6 = delegatecall v3, 0x1111111111111111111111111111111111111111, v1, v2, v1, 32
     jumpi v6, bb4, bb3
   bb3:
     revert_returndata
   bb4:
-    v7 = add 0, 0
+    v7 = add v1, 0
     v8 = mload v7
-    v9 = add 0, 0
+    v9 = add v1, 0
     v10 = mload v9
     ret v10
   bb1:
@@ -133,22 +133,25 @@ fn @aggregate(arg0: u256) -> memoryfixedarray [selector=0x407b7269, pure, abi_pa
   bb0:
     v0 = alloc memoryfixedarray<2, 1>, exact, uninitialized, infallible, 64
     memory_zero v0, 64
-    v1 = abi_encode [word], selector 0x71e5ee5f00000000000000000000000000000000000000000000000000000000, args arg0
-    v2 = slice_ptr v1
-    v3 = slice_len v1
-    v4 = gas
-    v5 = alloc raw, exact, uninitialized, infallible, 64
-    v6 = extcodesize 0x1111111111111111111111111111111111111111
-    v7 = iszero v6
-    jumpi v7, bb1, bb2
+    v1 = alloc memorybytes, exact, uninitialized, infallible, 96
+    set_memory_object_len memorybytes, v1, 64
+    v2 = memory_object_data memorybytes, v1
+    v3 = abi_encode [word], selector 0x71e5ee5f00000000000000000000000000000000000000000000000000000000, args arg0
+    v4 = slice_ptr v3
+    v5 = slice_len v3
+    v6 = gas
+    v7 = extcodesize 0x1111111111111111111111111111111111111111
+    v8 = iszero v7
+    jumpi v8, bb1, bb2
   bb2:
-    v8 = delegatecall v4, 0x1111111111111111111111111111111111111111, v2, v3, v5, 64
-    jumpi v8, bb4, bb3
+    v9 = delegatecall v6, 0x1111111111111111111111111111111111111111, v4, v5, v4, 64
+    jumpi v9, bb4, bb3
   bb3:
     revert_returndata
   bb4:
-    v9 = abi_decode [array<2, u256>], v5
-    ret v9
+    mcopy v2, v4, 64
+    v10 = abi_decode [array<2, u256>], v1
+    ret v10
   bb1:
     revert 0, 0
 }
@@ -163,12 +166,12 @@ fn @boolean(arg0: u256) -> bool [selector=0xbc586ed6, pure, abi_params=[u256], a
     v5 = iszero v4
     jumpi v5, bb1, bb2
   bb2:
-    v6 = delegatecall v3, 0x1111111111111111111111111111111111111111, v1, v2, 0, 32
+    v6 = delegatecall v3, 0x1111111111111111111111111111111111111111, v1, v2, v1, 32
     jumpi v6, bb4, bb3
   bb3:
     revert_returndata
   bb4:
-    v7 = add 0, 0
+    v7 = add v1, 0
     v8 = mload v7
     v9 = iszero v8
     v10 = iszero v9
@@ -176,7 +179,7 @@ fn @boolean(arg0: u256) -> bool [selector=0xbc586ed6, pure, abi_params=[u256], a
     v12 = iszero v11
     jumpi v12, bb1, bb5
   bb5:
-    v13 = add 0, 0
+    v13 = add v1, 0
     v14 = mload v13
     ret v14
   bb1:
@@ -188,22 +191,25 @@ fn @structBool(arg0: u256) -> memorystruct [selector=0x199436a8, pure, abi_param
     v0 = alloc memorystruct<2>, exact, uninitialized, infallible, 64
     memory_object_store_field memorystruct<2>, v0, 0, 0
     memory_object_store_field memorystruct<2>, v0, 1, 0
-    v1 = abi_encode [word], selector 0xa370c66800000000000000000000000000000000000000000000000000000000, args arg0
-    v2 = slice_ptr v1
-    v3 = slice_len v1
-    v4 = gas
-    v5 = alloc raw, exact, uninitialized, infallible, 64
-    v6 = extcodesize 0x1111111111111111111111111111111111111111
-    v7 = iszero v6
-    jumpi v7, bb1, bb2
+    v1 = alloc memorybytes, exact, uninitialized, infallible, 96
+    set_memory_object_len memorybytes, v1, 64
+    v2 = memory_object_data memorybytes, v1
+    v3 = abi_encode [word], selector 0xa370c66800000000000000000000000000000000000000000000000000000000, args arg0
+    v4 = slice_ptr v3
+    v5 = slice_len v3
+    v6 = gas
+    v7 = extcodesize 0x1111111111111111111111111111111111111111
+    v8 = iszero v7
+    jumpi v8, bb1, bb2
   bb2:
-    v8 = delegatecall v4, 0x1111111111111111111111111111111111111111, v2, v3, v5, 64
-    jumpi v8, bb4, bb3
+    v9 = delegatecall v6, 0x1111111111111111111111111111111111111111, v4, v5, v4, 64
+    jumpi v9, bb4, bb3
   bb3:
     revert_returndata
   bb4:
-    v9 = abi_decode [tuple<bool, u256>], v5
-    ret v9
+    mcopy v2, v4, 64
+    v10 = abi_decode [tuple<bool, u256>], v1
+    ret v10
   bb1:
     revert 0, 0
 }
@@ -218,14 +224,14 @@ fn @attached() -> u256 [selector=0xd9e6b370, view, abi_params=[], abi_returns=[w
     v5 = iszero v4
     jumpi v5, bb1, bb2
   bb2:
-    v6 = delegatecall v3, 0x1111111111111111111111111111111111111111, v1, v2, 0, 32
+    v6 = delegatecall v3, 0x1111111111111111111111111111111111111111, v1, v2, v1, 32
     jumpi v6, bb4, bb3
   bb3:
     revert_returndata
   bb4:
-    v7 = add 0, 0
+    v7 = add v1, 0
     v8 = mload v7
-    v9 = add 0, 0
+    v9 = add v1, 0
     v10 = mload v9
     ret v10
   bb1:
@@ -242,7 +248,7 @@ fn @none(arg0: u256) [selector=0x2758da14, pure, abi_params=[u256], abi_returns=
     v5 = iszero v4
     jumpi v5, bb1, bb2
   bb2:
-    v6 = delegatecall v3, 0x1111111111111111111111111111111111111111, v1, v2, 0, 0
+    v6 = delegatecall v3, 0x1111111111111111111111111111111111111111, v1, v2, v1, 0
     jumpi v6, bb4, bb3
   bb3:
     revert_returndata

--- a/tests/ui/codegen/lowering/library_call_evm_version.tangerineWhistle.stdout
+++ b/tests/ui/codegen/lowering/library_call_evm_version.tangerineWhistle.stdout
@@ -81,28 +81,22 @@ fn @one(arg0: u256) -> u256 [selector=0xef56f928, pure, abi_params=[u256], abi_r
     v1 = slice_ptr v0
     v2 = slice_len v0
     v3 = gas
-    v4 = delegatecall v3, 0x1111111111111111111111111111111111111111, v1, v2, 0, 0
-    jumpi v4, bb2, bb1
-  bb1:
-    revert_returndata
+    v4 = extcodesize 0x1111111111111111111111111111111111111111
+    v5 = iszero v4
+    jumpi v5, bb1, bb2
   bb2:
-    v5 = returndatasize
-    v6 = add v5, 63
-    v7 = lt v6, v5
-    jumpi v7, bb3, bb4
-  bb4:
-    v8 = not 31
-    v9 = and v6, v8
-    v10 = alloc memorybytes, exact, uninitialized, infallible, v9
-    set_memory_object_len memorybytes, v10, v5
-    v11 = make_returndata_slice 0, v5
-    memory_object_copy_from_slice memorybytes, v10, v11
-    v12 = abi_decode [u256], v10
-    ret v12
+    v6 = delegatecall v3, 0x1111111111111111111111111111111111111111, v1, v2, 0, 32
+    jumpi v6, bb4, bb3
   bb3:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 65 !metadata(memory=scratch)
-    revert 0, 36
+    revert_returndata
+  bb4:
+    v7 = add 0, 0
+    v8 = mload v7
+    v9 = add 0, 0
+    v10 = mload v9
+    ret v10
+  bb1:
+    revert 0, 0
 }
 
 fn @two(arg0: u256) -> (u256, u256) [selector=0xcf2a8612, pure, abi_params=[u256], abi_returns=[word, word]] {
@@ -111,38 +105,28 @@ fn @two(arg0: u256) -> (u256, u256) [selector=0xcf2a8612, pure, abi_params=[u256
     v1 = slice_ptr v0
     v2 = slice_len v0
     v3 = gas
-    v4 = delegatecall v3, 0x1111111111111111111111111111111111111111, v1, v2, 0, 0
-    jumpi v4, bb2, bb1
-  bb1:
-    revert_returndata
+    v4 = extcodesize 0x1111111111111111111111111111111111111111
+    v5 = iszero v4
+    jumpi v5, bb1, bb2
   bb2:
-    v5 = returndatasize
-    v6 = add v5, 63
-    v7 = lt v6, v5
-    jumpi v7, bb3, bb4
+    v6 = delegatecall v3, 0x1111111111111111111111111111111111111111, v1, v2, v1, 64
+    jumpi v6, bb4, bb3
+  bb3:
+    revert_returndata
   bb4:
-    v8 = not 31
-    v9 = and v6, v8
-    v10 = alloc memorybytes, exact, uninitialized, infallible, v9
-    set_memory_object_len memorybytes, v10, v5
-    v11 = make_returndata_slice 0, v5
-    memory_object_copy_from_slice memorybytes, v10, v11
-    v12 = abi_decode [u256, u256], v10
+    v7 = add v1, 0
+    v8 = mload v7
+    v9 = add v1, 32
+    v10 = mload v9
+    frame_store multi_return, word, 0, v1 !metadata(memory=scratch)
+    v11 = add v1, 0
+    v12 = mload v11
     v13 = frame_load multi_return, word, 0 !metadata(memory=scratch)
     v14 = add v13, 32
     v15 = mload v14
-    v16 = alloc memoryfixedarray<2, 1>, exact, uninitialized, infallible, 64
-    v17 = memory_object_data memoryfixedarray, v16
-    frame_store multi_return, word, 0, v17 !metadata(memory=scratch)
-    memory_object_store_element memoryfixedarray<2, 1>, v16, 1, v15
-    v18 = frame_load multi_return, word, 0 !metadata(memory=scratch)
-    v19 = add v18, 32
-    v20 = mload v19
-    ret v12, v20
-  bb3:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 65 !metadata(memory=scratch)
-    revert 0, 36
+    ret v12, v15
+  bb1:
+    revert 0, 0
 }
 
 fn @aggregate(arg0: u256) -> memoryfixedarray [selector=0x407b7269, pure, abi_params=[u256], abi_returns=[array<2, word>]] {
@@ -153,28 +137,20 @@ fn @aggregate(arg0: u256) -> memoryfixedarray [selector=0x407b7269, pure, abi_pa
     v2 = slice_ptr v1
     v3 = slice_len v1
     v4 = gas
-    v5 = delegatecall v4, 0x1111111111111111111111111111111111111111, v2, v3, 0, 0
-    jumpi v5, bb2, bb1
-  bb1:
-    revert_returndata
+    v5 = alloc raw, exact, uninitialized, infallible, 64
+    v6 = extcodesize 0x1111111111111111111111111111111111111111
+    v7 = iszero v6
+    jumpi v7, bb1, bb2
   bb2:
-    v6 = returndatasize
-    v7 = add v6, 63
-    v8 = lt v7, v6
-    jumpi v8, bb3, bb4
-  bb4:
-    v9 = not 31
-    v10 = and v7, v9
-    v11 = alloc memorybytes, exact, uninitialized, infallible, v10
-    set_memory_object_len memorybytes, v11, v6
-    v12 = make_returndata_slice 0, v6
-    memory_object_copy_from_slice memorybytes, v11, v12
-    v13 = abi_decode [array<2, u256>], v11
-    ret v13
+    v8 = delegatecall v4, 0x1111111111111111111111111111111111111111, v2, v3, v5, 64
+    jumpi v8, bb4, bb3
   bb3:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 65 !metadata(memory=scratch)
-    revert 0, 36
+    revert_returndata
+  bb4:
+    v9 = abi_decode [array<2, u256>], v5
+    ret v9
+  bb1:
+    revert 0, 0
 }
 
 fn @boolean(arg0: u256) -> bool [selector=0xbc586ed6, pure, abi_params=[u256], abi_returns=[word<bool>]] {
@@ -183,28 +159,28 @@ fn @boolean(arg0: u256) -> bool [selector=0xbc586ed6, pure, abi_params=[u256], a
     v1 = slice_ptr v0
     v2 = slice_len v0
     v3 = gas
-    v4 = delegatecall v3, 0x1111111111111111111111111111111111111111, v1, v2, 0, 0
-    jumpi v4, bb2, bb1
-  bb1:
-    revert_returndata
+    v4 = extcodesize 0x1111111111111111111111111111111111111111
+    v5 = iszero v4
+    jumpi v5, bb1, bb2
   bb2:
-    v5 = returndatasize
-    v6 = add v5, 63
-    v7 = lt v6, v5
-    jumpi v7, bb3, bb4
-  bb4:
-    v8 = not 31
-    v9 = and v6, v8
-    v10 = alloc memorybytes, exact, uninitialized, infallible, v9
-    set_memory_object_len memorybytes, v10, v5
-    v11 = make_returndata_slice 0, v5
-    memory_object_copy_from_slice memorybytes, v10, v11
-    v12 = abi_decode [bool], v10
-    ret v12
+    v6 = delegatecall v3, 0x1111111111111111111111111111111111111111, v1, v2, 0, 32
+    jumpi v6, bb4, bb3
   bb3:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 65 !metadata(memory=scratch)
-    revert 0, 36
+    revert_returndata
+  bb4:
+    v7 = add 0, 0
+    v8 = mload v7
+    v9 = iszero v8
+    v10 = iszero v9
+    v11 = eq v8, v10
+    v12 = iszero v11
+    jumpi v12, bb1, bb5
+  bb5:
+    v13 = add 0, 0
+    v14 = mload v13
+    ret v14
+  bb1:
+    revert 0, 0
 }
 
 fn @structBool(arg0: u256) -> memorystruct [selector=0x199436a8, pure, abi_params=[u256], abi_returns=[tuple<word<bool>, word>], abi_return_params=[tuple<bool, u256>]] {
@@ -216,28 +192,20 @@ fn @structBool(arg0: u256) -> memorystruct [selector=0x199436a8, pure, abi_param
     v2 = slice_ptr v1
     v3 = slice_len v1
     v4 = gas
-    v5 = delegatecall v4, 0x1111111111111111111111111111111111111111, v2, v3, 0, 0
-    jumpi v5, bb2, bb1
-  bb1:
-    revert_returndata
+    v5 = alloc raw, exact, uninitialized, infallible, 64
+    v6 = extcodesize 0x1111111111111111111111111111111111111111
+    v7 = iszero v6
+    jumpi v7, bb1, bb2
   bb2:
-    v6 = returndatasize
-    v7 = add v6, 63
-    v8 = lt v7, v6
-    jumpi v8, bb3, bb4
-  bb4:
-    v9 = not 31
-    v10 = and v7, v9
-    v11 = alloc memorybytes, exact, uninitialized, infallible, v10
-    set_memory_object_len memorybytes, v11, v6
-    v12 = make_returndata_slice 0, v6
-    memory_object_copy_from_slice memorybytes, v11, v12
-    v13 = abi_decode [tuple<bool, u256>], v11
-    ret v13
+    v8 = delegatecall v4, 0x1111111111111111111111111111111111111111, v2, v3, v5, 64
+    jumpi v8, bb4, bb3
   bb3:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 65 !metadata(memory=scratch)
-    revert 0, 36
+    revert_returndata
+  bb4:
+    v9 = abi_decode [tuple<bool, u256>], v5
+    ret v9
+  bb1:
+    revert 0, 0
 }
 
 fn @attached() -> u256 [selector=0xd9e6b370, view, abi_params=[], abi_returns=[word]] {
@@ -246,28 +214,22 @@ fn @attached() -> u256 [selector=0xd9e6b370, view, abi_params=[], abi_returns=[w
     v1 = slice_ptr v0
     v2 = slice_len v0
     v3 = gas
-    v4 = delegatecall v3, 0x1111111111111111111111111111111111111111, v1, v2, 0, 0
-    jumpi v4, bb2, bb1
-  bb1:
-    revert_returndata
+    v4 = extcodesize 0x1111111111111111111111111111111111111111
+    v5 = iszero v4
+    jumpi v5, bb1, bb2
   bb2:
-    v5 = returndatasize
-    v6 = add v5, 63
-    v7 = lt v6, v5
-    jumpi v7, bb3, bb4
-  bb4:
-    v8 = not 31
-    v9 = and v6, v8
-    v10 = alloc memorybytes, exact, uninitialized, infallible, v9
-    set_memory_object_len memorybytes, v10, v5
-    v11 = make_returndata_slice 0, v5
-    memory_object_copy_from_slice memorybytes, v10, v11
-    v12 = abi_decode [u256], v10
-    ret v12
+    v6 = delegatecall v3, 0x1111111111111111111111111111111111111111, v1, v2, 0, 32
+    jumpi v6, bb4, bb3
   bb3:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 65 !metadata(memory=scratch)
-    revert 0, 36
+    revert_returndata
+  bb4:
+    v7 = add 0, 0
+    v8 = mload v7
+    v9 = add 0, 0
+    v10 = mload v9
+    ret v10
+  bb1:
+    revert 0, 0
 }
 
 fn @none(arg0: u256) [selector=0x2758da14, pure, abi_params=[u256], abi_returns=[]] {

--- a/tests/ui/codegen/lowering/run-call/call_reserve_shared_tail.sol
+++ b/tests/ui/codegen/lowering/run-call/call_reserve_shared_tail.sol
@@ -1,0 +1,96 @@
+//@ revisions: homestead homesteadGas homesteadSize tangerineWhistleGas
+//@[homestead] compile-flags: -O none --evm-version homestead
+//@[homesteadGas] compile-flags: -O gas --evm-version homestead -Zdump=evm-ir-runtime
+//@[homesteadGas] filecheck: --check-prefix=RESERVE --implicit-check-not={{^[ ]+gas}}
+//@[homesteadSize] compile-flags: -O size --evm-version homestead -Zdump=evm-ir-runtime
+//@[homesteadSize] filecheck: --check-prefix=RESERVE --implicit-check-not={{^[ ]+gas}}
+//@[tangerineWhistleGas] compile-flags: -O gas --evm-version tangerineWhistle
+//@ run-call: ReserveCalls::fixedGas => 42
+//@ run-call: ReserveCalls::two => 3
+//@ run-call: ReserveCalls::aggregate => 7
+//@ run-call: ReserveCalls::noReturn => 1
+//@ run-call: ReserveCalls::pointer => 42
+//@ run-call: ReserveCalls::twoFixed => 3
+
+// Before EIP-150 a `CALL` asking for more gas than is left throws, so a call that forwards the
+// gas left withholds its own cost plus solc's 10-gas margin (`sub(gas(), 50)`). That margin only
+// covers the `SUB`, so the reserve stays correct only while the `GAS` read and the call are in
+// one block: a shared call tail puts a `JUMP` (8) and a `JUMPDEST` (1) in between and the call
+// throws. Mixing forwarded-gas calls with `{gas: ...}` calls of the same shape gives the backend
+// the equal tails it wants to merge, and every call below runs on a homestead EVM.
+
+interface ReserveTarget {
+    function value() external returns (uint256);
+    function pair() external returns (uint256, uint256);
+    function agg() external returns (uint256[2] memory);
+    function noop() external;
+}
+
+contract ReserveCallee {
+    function value() external pure returns (uint256) {
+        return 42;
+    }
+
+    function pair() external pure returns (uint256, uint256) {
+        return (1, 2);
+    }
+
+    function agg() external pure returns (uint256[2] memory r) {
+        r[0] = 3;
+        r[1] = 4;
+    }
+
+    function noop() external {}
+}
+
+contract ReserveCalls {
+    ReserveTarget internal callee;
+
+    constructor() {
+        callee = ReserveTarget(address(new ReserveCallee()));
+    }
+
+    // Every `gas` in the runtime object is a reserve read, and `keep_with_next` pins each one to
+    // the `sub` and the `call` that follow it in the same block. The implicit check-not covers
+    // every other `gas` line, so a pass that splits one of these sequences fails the test.
+    // RESERVE: gas !meta(keep_with_next)
+    // RESERVE-NEXT: sub !meta(keep_with_next)
+    // RESERVE-NEXT: call
+    // RESERVE: gas !meta(keep_with_next)
+    // RESERVE-NEXT: sub !meta(keep_with_next)
+    // RESERVE-NEXT: call
+    // RESERVE: gas !meta(keep_with_next)
+    // RESERVE-NEXT: sub !meta(keep_with_next)
+    // RESERVE-NEXT: call
+    // RESERVE: gas !meta(keep_with_next)
+    // RESERVE-NEXT: sub !meta(keep_with_next)
+    // RESERVE-NEXT: call
+    function fixedGas() external returns (uint256) {
+        return callee.value{gas: 50000}();
+    }
+
+    function two() external returns (uint256) {
+        (uint256 x, uint256 y) = callee.pair();
+        return x + y;
+    }
+
+    function aggregate() external returns (uint256) {
+        uint256[2] memory v = callee.agg();
+        return v[0] + v[1];
+    }
+
+    function noReturn() external returns (uint256) {
+        callee.noop();
+        return 1;
+    }
+
+    function pointer() external returns (uint256) {
+        function() external returns (uint256) f = callee.value;
+        return f();
+    }
+
+    function twoFixed() external returns (uint256) {
+        (uint256 x, uint256 y) = callee.pair{gas: 50000}();
+        return x + y;
+    }
+}

--- a/tests/ui/codegen/lowering/run-call/call_reserve_shared_tail.sol
+++ b/tests/ui/codegen/lowering/run-call/call_reserve_shared_tail.sol
@@ -53,17 +53,17 @@ contract ReserveCalls {
     // Every `gas` in the runtime object is a reserve read, and `keep_with_next` pins each one to
     // the `sub` and the `call` that follow it in the same block. The implicit check-not covers
     // every other `gas` line, so a pass that splits one of these sequences fails the test.
-    // RESERVE: gas !meta(keep_with_next)
-    // RESERVE-NEXT: sub !meta(keep_with_next)
+    // RESERVE: gas !metadata(keep_with_next)
+    // RESERVE-NEXT: sub !metadata(keep_with_next)
     // RESERVE-NEXT: call
-    // RESERVE: gas !meta(keep_with_next)
-    // RESERVE-NEXT: sub !meta(keep_with_next)
+    // RESERVE: gas !metadata(keep_with_next)
+    // RESERVE-NEXT: sub !metadata(keep_with_next)
     // RESERVE-NEXT: call
-    // RESERVE: gas !meta(keep_with_next)
-    // RESERVE-NEXT: sub !meta(keep_with_next)
+    // RESERVE: gas !metadata(keep_with_next)
+    // RESERVE-NEXT: sub !metadata(keep_with_next)
     // RESERVE-NEXT: call
-    // RESERVE: gas !meta(keep_with_next)
-    // RESERVE-NEXT: sub !meta(keep_with_next)
+    // RESERVE: gas !metadata(keep_with_next)
+    // RESERVE-NEXT: sub !metadata(keep_with_next)
     // RESERVE-NEXT: call
     function fixedGas() external returns (uint256) {
         return callee.value{gas: 50000}();

--- a/tests/ui/codegen/lowering/run-call/dynamic_return_unused_evm_version.homestead.stdout
+++ b/tests/ui/codegen/lowering/run-call/dynamic_return_unused_evm_version.homestead.stdout
@@ -50,24 +50,27 @@ fn @live() -> u256 [selector=0x957aa58c, abi_params=[], abi_returns=[word]] {
   bb1:
     revert_returndata
   bb2:
-    v7 = abi_encode [], selector 0x7271bb2c00000000000000000000000000000000000000000000000000000000
-    v8 = slice_ptr v7
-    v9 = slice_len v7
-    v10 = extcodesize v6
-    v11 = iszero v10
-    jumpi v11, bb3, bb4
+    v7 = fmp
+    v8 = add v7, 32
+    mstore v8, 0
+    v9 = abi_encode [], selector 0x7271bb2c00000000000000000000000000000000000000000000000000000000
+    v10 = slice_ptr v9
+    v11 = slice_len v9
+    v12 = extcodesize v6
+    v13 = iszero v12
+    jumpi v13, bb3, bb4
   bb4:
-    v12 = gas
-    v13 = sub v12, 50
-    v14 = call v13, v6, 0, v8, v9, v8, 32
-    jumpi v14, bb6, bb5
+    v14 = gas
+    v15 = sub v14, 50
+    v16 = call v15, v6, 0, v10, v11, v10, 32
+    jumpi v16, bb6, bb5
   bb5:
     revert_returndata
   bb6:
-    v15 = add v8, 0
-    v16 = mload v15
-    v17 = add v8, 0
+    v17 = add v10, 0
     v18 = mload v17
+    v19 = add v10, 0
+    v20 = mload v19
     ret 1
   bb3:
     revert 0, 0
@@ -88,24 +91,27 @@ fn @liveString() -> u256 [selector=0x86c92c52, abi_params=[], abi_returns=[word]
   bb1:
     revert_returndata
   bb2:
-    v7 = abi_encode [], selector 0x2f4e740900000000000000000000000000000000000000000000000000000000
-    v8 = slice_ptr v7
-    v9 = slice_len v7
-    v10 = extcodesize v6
-    v11 = iszero v10
-    jumpi v11, bb3, bb4
+    v7 = fmp
+    v8 = add v7, 32
+    mstore v8, 0
+    v9 = abi_encode [], selector 0x2f4e740900000000000000000000000000000000000000000000000000000000
+    v10 = slice_ptr v9
+    v11 = slice_len v9
+    v12 = extcodesize v6
+    v13 = iszero v12
+    jumpi v13, bb3, bb4
   bb4:
-    v12 = gas
-    v13 = sub v12, 50
-    v14 = call v13, v6, 0, v8, v9, v8, 32
-    jumpi v14, bb6, bb5
+    v14 = gas
+    v15 = sub v14, 50
+    v16 = call v15, v6, 0, v10, v11, v10, 32
+    jumpi v16, bb6, bb5
   bb5:
     revert_returndata
   bb6:
-    v15 = add v8, 0
-    v16 = mload v15
-    v17 = add v8, 0
+    v17 = add v10, 0
     v18 = mload v17
+    v19 = add v10, 0
+    v20 = mload v19
     ret 1
   bb3:
     revert 0, 0
@@ -126,17 +132,20 @@ fn @liveTry() -> u256 [selector=0xc2e69a83, abi_params=[], abi_returns=[word]] {
   bb1:
     revert_returndata
   bb2:
-    v7 = abi_encode [], selector 0x7271bb2c00000000000000000000000000000000000000000000000000000000
-    v8 = slice_ptr v7
-    v9 = slice_len v7
-    v10 = extcodesize v6
-    v11 = iszero v10
-    jumpi v11, bb3, bb4
+    v7 = fmp
+    v8 = add v7, 32
+    mstore v8, 0
+    v9 = abi_encode [], selector 0x7271bb2c00000000000000000000000000000000000000000000000000000000
+    v10 = slice_ptr v9
+    v11 = slice_len v9
+    v12 = extcodesize v6
+    v13 = iszero v12
+    jumpi v13, bb3, bb4
   bb4:
-    v12 = gas
-    v13 = sub v12, 50
-    v14 = call v13, v6, 0, v8, v9, v8, 32
-    jumpi v14, bb5, bb6
+    v14 = gas
+    v15 = sub v14, 50
+    v16 = call v15, v6, 0, v10, v11, v10, 32
+    jumpi v16, bb5, bb6
   bb6:
     jumpi 1, bb8, bb9
   bb9:
@@ -144,14 +153,14 @@ fn @liveTry() -> u256 [selector=0xc2e69a83, abi_params=[], abi_returns=[word]] {
   bb8:
     jump bb7
   bb5:
-    v15 = add v8, 0
-    v16 = mload v15
-    v17 = add v8, 0
+    v17 = add v10, 0
     v18 = mload v17
+    v19 = add v10, 0
+    v20 = mload v19
     jump bb7
   bb7:
-    v19 = phi [bb5: 1], [bb8: 2]
-    ret v19
+    v21 = phi [bb5: 1], [bb8: 2]
+    ret v21
   bb3:
     revert 0, 0
 }
@@ -171,32 +180,33 @@ fn @liveMixed() -> u256 [selector=0xaf1b6bff, abi_params=[], abi_returns=[word]]
   bb1:
     revert_returndata
   bb2:
-    v7 = abi_encode [], selector 0x354df1f900000000000000000000000000000000000000000000000000000000
-    v8 = slice_ptr v7
-    v9 = slice_len v7
-    v10 = add v8, 32
-    mstore v10, 0
-    v11 = extcodesize v6
-    v12 = iszero v11
-    jumpi v12, bb3, bb4
+    v7 = fmp
+    v8 = add v7, 64
+    mstore v8, 0
+    v9 = abi_encode [], selector 0x354df1f900000000000000000000000000000000000000000000000000000000
+    v10 = slice_ptr v9
+    v11 = slice_len v9
+    v12 = extcodesize v6
+    v13 = iszero v12
+    jumpi v13, bb3, bb4
   bb4:
-    v13 = gas
-    v14 = sub v13, 50
-    v15 = call v14, v6, 0, v8, v9, v8, 64
-    jumpi v15, bb6, bb5
+    v14 = gas
+    v15 = sub v14, 50
+    v16 = call v15, v6, 0, v10, v11, v10, 64
+    jumpi v16, bb6, bb5
   bb5:
     revert_returndata
   bb6:
-    v16 = add v8, 0
-    v17 = mload v16
-    v18 = add v8, 32
-    v19 = mload v18
-    frame_store multi_return, word, 0, v8 !metadata(memory=scratch)
-    v20 = add v8, 0
-    v21 = mload v20
-    v22 = frame_load multi_return, word, 0 !metadata(memory=scratch)
-    v23 = memory_object_load_element memoryfixedarray<2, 1>, v22, 1
-    ret v21
+    v17 = add v10, 0
+    v18 = mload v17
+    v19 = add v10, 32
+    v20 = mload v19
+    frame_store multi_return, word, 0, v10 !metadata(memory=scratch)
+    v21 = add v10, 0
+    v22 = mload v21
+    v23 = frame_load multi_return, word, 0 !metadata(memory=scratch)
+    v24 = memory_object_load_element memoryfixedarray<2, 1>, v23, 1
+    ret v22
   bb3:
     revert 0, 0
 }
@@ -216,42 +226,48 @@ fn @liveTuple() -> u256 [selector=0x04e1eee0, abi_params=[], abi_returns=[word]]
   bb1:
     revert_returndata
   bb2:
-    v7 = abi_encode [], selector 0x7271bb2c00000000000000000000000000000000000000000000000000000000
-    v8 = slice_ptr v7
-    v9 = slice_len v7
-    v10 = extcodesize v6
-    v11 = iszero v10
-    jumpi v11, bb3, bb4
+    v7 = fmp
+    v8 = add v7, 32
+    mstore v8, 0
+    v9 = abi_encode [], selector 0x7271bb2c00000000000000000000000000000000000000000000000000000000
+    v10 = slice_ptr v9
+    v11 = slice_len v9
+    v12 = extcodesize v6
+    v13 = iszero v12
+    jumpi v13, bb3, bb4
   bb4:
-    v12 = gas
-    v13 = sub v12, 50
-    v14 = call v13, v6, 0, v8, v9, v8, 32
-    jumpi v14, bb6, bb5
+    v14 = gas
+    v15 = sub v14, 50
+    v16 = call v15, v6, 0, v10, v11, v10, 32
+    jumpi v16, bb6, bb5
   bb5:
     revert_returndata
   bb6:
-    v15 = add v8, 0
-    v16 = mload v15
-    v17 = add v8, 0
+    v17 = add v10, 0
     v18 = mload v17
-    v19 = abi_encode [], selector 0x2f4e740900000000000000000000000000000000000000000000000000000000
-    v20 = slice_ptr v19
-    v21 = slice_len v19
-    v22 = extcodesize v6
-    v23 = iszero v22
-    jumpi v23, bb3, bb7
+    v19 = add v10, 0
+    v20 = mload v19
+    v21 = fmp
+    v22 = add v21, 32
+    mstore v22, 0
+    v23 = abi_encode [], selector 0x2f4e740900000000000000000000000000000000000000000000000000000000
+    v24 = slice_ptr v23
+    v25 = slice_len v23
+    v26 = extcodesize v6
+    v27 = iszero v26
+    jumpi v27, bb3, bb7
   bb7:
-    v24 = gas
-    v25 = sub v24, 50
-    v26 = call v25, v6, 0, v20, v21, v20, 32
-    jumpi v26, bb9, bb8
+    v28 = gas
+    v29 = sub v28, 50
+    v30 = call v29, v6, 0, v24, v25, v24, 32
+    jumpi v30, bb9, bb8
   bb8:
     revert_returndata
   bb9:
-    v27 = add v20, 0
-    v28 = mload v27
-    v29 = add v20, 0
-    v30 = mload v29
+    v31 = add v24, 0
+    v32 = mload v31
+    v33 = add v24, 0
+    v34 = mload v33
     ret 1
   bb3:
     revert 0, 0
@@ -277,24 +293,27 @@ fn @livePointer() -> u256 [selector=0x6347cf88, abi_params=[], abi_returns=[word
     v9 = and v8, 0xffffffff
     v10 = shl 224, v9
     v11 = shr 32, v8
-    v12 = abi_encode [], selector v10
-    v13 = slice_ptr v12
-    v14 = slice_len v12
-    v15 = extcodesize v11
-    v16 = iszero v15
-    jumpi v16, bb3, bb4
+    v12 = fmp
+    v13 = add v12, 32
+    mstore v13, 0
+    v14 = abi_encode [], selector v10
+    v15 = slice_ptr v14
+    v16 = slice_len v14
+    v17 = extcodesize v11
+    v18 = iszero v17
+    jumpi v18, bb3, bb4
   bb4:
-    v17 = gas
-    v18 = sub v17, 50
-    v19 = call v18, v11, 0, v13, v14, v13, 32
-    jumpi v19, bb6, bb5
+    v19 = gas
+    v20 = sub v19, 50
+    v21 = call v20, v11, 0, v15, v16, v15, 32
+    jumpi v21, bb6, bb5
   bb5:
     revert_returndata
   bb6:
-    v20 = add v13, 0
-    v21 = mload v20
-    v22 = add v13, 0
+    v22 = add v15, 0
     v23 = mload v22
+    v24 = add v15, 0
+    v25 = mload v24
     ret 1
   bb3:
     revert 0, 0
@@ -317,9 +336,9 @@ fn @liveLoop() -> u256 [selector=0xcb9e3e0f, abi_params=[], abi_returns=[word]] 
   bb2:
     jump bb3
   bb3:
-    v7 = phi [bb2: 0], [bb15: v23]
+    v7 = phi [bb2: 0], [bb15: v25]
     v8 = phi [bb2: v6], [bb15: v8]
-    v9 = phi [bb2: 0], [bb15: v25]
+    v9 = phi [bb2: 0], [bb15: v27]
     v10 = lt v9, 3
     jumpi v10, bb6, bb7
   bb7:
@@ -327,35 +346,38 @@ fn @liveLoop() -> u256 [selector=0xcb9e3e0f, abi_params=[], abi_returns=[word]] 
   bb4:
     ret v7
   bb6:
-    v11 = abi_encode [], selector 0x7271bb2c00000000000000000000000000000000000000000000000000000000
-    v12 = slice_ptr v11
-    v13 = slice_len v11
-    v14 = extcodesize v8
-    v15 = iszero v14
-    jumpi v15, bb9, bb10
+    v11 = fmp
+    v12 = add v11, 32
+    mstore v12, 0
+    v13 = abi_encode [], selector 0x7271bb2c00000000000000000000000000000000000000000000000000000000
+    v14 = slice_ptr v13
+    v15 = slice_len v13
+    v16 = extcodesize v8
+    v17 = iszero v16
+    jumpi v17, bb9, bb10
   bb10:
-    v16 = gas
-    v17 = sub v16, 50
-    v18 = call v17, v8, 0, v12, v13, v12, 32
-    jumpi v18, bb12, bb11
+    v18 = gas
+    v19 = sub v18, 50
+    v20 = call v19, v8, 0, v14, v15, v14, 32
+    jumpi v20, bb12, bb11
   bb11:
     revert_returndata
   bb12:
-    v19 = add v12, 0
-    v20 = mload v19
-    v21 = add v12, 0
+    v21 = add v14, 0
     v22 = mload v21
-    v23 = add v7, 1
-    v24 = lt v23, v7
-    jumpi v24, bb13, bb14
+    v23 = add v14, 0
+    v24 = mload v23
+    v25 = add v7, 1
+    v26 = lt v25, v7
+    jumpi v26, bb13, bb14
   bb14:
     jump bb8
   bb8:
     jump bb5
   bb5:
-    v25 = add v9, 1
-    v26 = lt v25, v9
-    jumpi v26, bb13, bb15
+    v27 = add v9, 1
+    v28 = lt v27, v9
+    jumpi v28, bb13, bb15
   bb15:
     jump bb3
   bb13:
@@ -368,24 +390,27 @@ fn @liveLoop() -> u256 [selector=0xcb9e3e0f, abi_params=[], abi_returns=[word]] 
 
 fn @noCode() -> u256 [selector=0x96c56dce, abi_params=[], abi_returns=[word]] {
   bb0:
-    v0 = abi_encode [], selector 0x7271bb2c00000000000000000000000000000000000000000000000000000000
-    v1 = slice_ptr v0
-    v2 = slice_len v0
-    v3 = extcodesize 0
-    v4 = iszero v3
-    jumpi v4, bb1, bb2
+    v0 = fmp
+    v1 = add v0, 32
+    mstore v1, 0
+    v2 = abi_encode [], selector 0x7271bb2c00000000000000000000000000000000000000000000000000000000
+    v3 = slice_ptr v2
+    v4 = slice_len v2
+    v5 = extcodesize 0
+    v6 = iszero v5
+    jumpi v6, bb1, bb2
   bb2:
-    v5 = gas
-    v6 = sub v5, 50
-    v7 = call v6, 0, 0, v1, v2, v1, 32
-    jumpi v7, bb4, bb3
+    v7 = gas
+    v8 = sub v7, 50
+    v9 = call v8, 0, 0, v3, v4, v3, 32
+    jumpi v9, bb4, bb3
   bb3:
     revert_returndata
   bb4:
-    v8 = add v1, 0
-    v9 = mload v8
-    v10 = add v1, 0
+    v10 = add v3, 0
     v11 = mload v10
+    v12 = add v3, 0
+    v13 = mload v12
     ret 1
   bb1:
     revert 0, 0
@@ -393,17 +418,20 @@ fn @noCode() -> u256 [selector=0x96c56dce, abi_params=[], abi_returns=[word]] {
 
 fn @noCodeTry() -> u256 [selector=0x1908ad35, abi_params=[], abi_returns=[word]] {
   bb0:
-    v0 = abi_encode [], selector 0x7271bb2c00000000000000000000000000000000000000000000000000000000
-    v1 = slice_ptr v0
-    v2 = slice_len v0
-    v3 = extcodesize 0
-    v4 = iszero v3
-    jumpi v4, bb1, bb2
+    v0 = fmp
+    v1 = add v0, 32
+    mstore v1, 0
+    v2 = abi_encode [], selector 0x7271bb2c00000000000000000000000000000000000000000000000000000000
+    v3 = slice_ptr v2
+    v4 = slice_len v2
+    v5 = extcodesize 0
+    v6 = iszero v5
+    jumpi v6, bb1, bb2
   bb2:
-    v5 = gas
-    v6 = sub v5, 50
-    v7 = call v6, 0, 0, v1, v2, v1, 32
-    jumpi v7, bb3, bb4
+    v7 = gas
+    v8 = sub v7, 50
+    v9 = call v8, 0, 0, v3, v4, v3, 32
+    jumpi v9, bb3, bb4
   bb4:
     jumpi 1, bb6, bb7
   bb7:
@@ -411,14 +439,14 @@ fn @noCodeTry() -> u256 [selector=0x1908ad35, abi_params=[], abi_returns=[word]]
   bb6:
     jump bb5
   bb3:
-    v8 = add v1, 0
-    v9 = mload v8
-    v10 = add v1, 0
+    v10 = add v3, 0
     v11 = mload v10
+    v12 = add v3, 0
+    v13 = mload v12
     jump bb5
   bb5:
-    v12 = phi [bb3: 1], [bb6: 2]
-    ret v12
+    v14 = phi [bb3: 1], [bb6: 2]
+    ret v14
   bb1:
     revert 0, 0
 }

--- a/tests/ui/codegen/lowering/run-call/dynamic_return_unused_evm_version.homestead.stdout
+++ b/tests/ui/codegen/lowering/run-call/dynamic_return_unused_evm_version.homestead.stdout
@@ -1,0 +1,369 @@
+// === ROOT/tests/ui/codegen/lowering/run-call/dynamic_return_unused_evm_version.sol:DynamicCallee ===
+@module DynamicCallee
+data:
+  literal_0: hex"30313233343536373839616263646566303132333435363738396162636465663031000000000000000000000000000000000000000000000000000000000000"
+
+fn @dynBytes() -> memorybytes [selector=0x7271bb2c, pure, abi_params=[], abi_returns=[memory_bytes]] {
+  bb0:
+    v0 = alloc memorybytes, exact, uninitialized, infallible, 96
+    set_memory_object_len memorybytes, v0, 34
+    v1 = memory_object_data memorybytes, v0
+    data_copy literal_0, v1, 64
+    ret v0
+}
+
+fn @dynString() -> memorybytes [selector=0x2f4e7409, pure, abi_params=[], abi_returns=[memory_bytes]] {
+  bb0:
+    v0 = alloc memorybytes, exact, uninitialized, infallible, 64
+    set_memory_object_len memorybytes, v0, 5
+    v1 = memory_object_data memorybytes, v0
+    mstore v1, 0x68656c6c6f000000000000000000000000000000000000000000000000000000
+    ret v0
+}
+
+fn @mixed() -> (u256, memorybytes) [selector=0x354df1f9, pure, abi_params=[], abi_returns=[word, memory_bytes]] {
+  bb0:
+    v0 = alloc memorybytes, exact, uninitialized, infallible, 64
+    set_memory_object_len memorybytes, v0, 3
+    v1 = memory_object_data memorybytes, v0
+    mstore v1, 0x6162630000000000000000000000000000000000000000000000000000000000
+    ret 11, v0
+}
+
+// === ROOT/tests/ui/codegen/lowering/run-call/dynamic_return_unused_evm_version.sol:DynamicReturnUnused ===
+@module DynamicReturnUnused
+data:
+  DynamicCallee_initcode_0: hex"3460105761062b8060166000396000f35b60006000fe346056576000357c0100000000000000000000000000000000000000000000000000000000900480632f4e7409146048578063354df1f914604d5780637271bb2c146052576056565b610221565b610402565b605b565b600080fe5b6101e06040526040518060e0528060e0526060810160405260228152602081016040816105eb903950604051806101005280610100526020810181806101005281038252828060e05251838060e0521515810280608052905080608052806080528152601f19601f60805101168060c0528060c052602082018061014052915081610140528060c0521560c051608051919092909192916101025760208203810160008152505b60208501806101605294508461016052818060c0528101806101805291508161018052601f1983168060a0528060a0526000919291929592939593949594610176565b818061010052810391505060009001601f8101601f1981169050604051806101a05281810191508160405290508181f35b8061012052818060a0528110156101a757806101205283015161012051806101205285015260206101205101610176565b8580608052821090506101c05750905090509050610145565b601f8516945084602003945084600360020a0294508060a0528201915081519150818460020a90049150818460020a02915060a0518060a05283019250825160018560020a0294506001850394508490169350838217915092509052610145565b6101e06040526040518060e0528060e0526040810160405260058152602081017f68656c6c6f000000000000000000000000000000000000000000000000000000815250604051806101005280610100526020810181806101005281038252828060e05251838060e0521515810280608052905080608052806080528152601f19601f60805101168060c0528060c052602082018061014052915081610140528060c0521560c051608051919092909192916102e35760208203810160008152505b60208501806101605294508461016052818060c0528101806101805291508161018052601f1983168060a0528060a0526000919291929592939593949594610357565b818061010052810391505060009001601f8101601f1981169050604051806101a05281810191508160405290508181f35b8061012052818060a05281101561038857806101205283015161012051806101205285015260206101205101610357565b8580608052821090506103a15750905090509050610326565b601f8516945084602003945084600360020a0294508060a0528201915081519150818460020a90049150818460020a02915060a0518060a05283019250825160018560020a0294506001850394508490169350838217915092509052610326565b6101e06040526040518060e0528060e0526040810160405260038152602081017f61626300000000000000000000000000000000000000000000000000000000008152506040518061010052806101005260408101600b82526020820182806101005282039052828060e05251838060e0521515810280608052905080608052806080528152601f19601f60805101168060c0528060c052602082018061014052915081610140528060c0521560c051608051919092909192916104cc5760208203810160008152505b60208501806101605294508461016052818060c0528101806101805291508161018052601f1983168060a0528060a0526000919291929592939593949594610540565b818061010052810391505060009001601f8101601f1981169050604051806101a05281810191508160405290508181f35b8061012052818060a05281101561057157806101205283015161012051806101205285015260206101205101610540565b85806080528210905061058a575090509050905061050f565b601f8516945084602003945084600360020a0294508060a0528201915081519150818460020a90049150818460020a02915060a0518060a05283019250825160018560020a029450600185039450849016935083821791509250905261050f5630313233343536373839616263646566303132333435363738396162636465663031000000000000000000000000000000000000000000000000000000000000"
+
+fn @live() -> u256 [selector=0x957aa58c, abi_params=[], abi_returns=[word]] {
+  bb0:
+    v0 = abi_encode []
+    v1 = not 31
+    v2 = and 0x660, v1
+    v3 = alloc raw, exact, uninitialized, infallible, v2
+    data_copy DynamicCallee_initcode_0, v3, 0x641
+    v4 = slice_ptr v0
+    v5 = add v3, 0x641
+    mcopy v5, v4, 0 !metadata(memory=heap)
+    v6 = create 0, v3, 0x641
+    jumpi v6, bb2, bb1
+  bb1:
+    revert_returndata
+  bb2:
+    v7 = abi_encode [], selector 0x7271bb2c00000000000000000000000000000000000000000000000000000000
+    v8 = slice_ptr v7
+    v9 = slice_len v7
+    v10 = extcodesize v6
+    v11 = iszero v10
+    jumpi v11, bb3, bb4
+  bb4:
+    v12 = gas
+    v13 = sub v12, 50
+    v14 = call v13, v6, 0, v8, v9, 0, 32
+    jumpi v14, bb6, bb5
+  bb5:
+    revert_returndata
+  bb6:
+    v15 = add 0, 0
+    v16 = mload v15
+    v17 = add 0, 0
+    v18 = mload v17
+    ret 1
+  bb3:
+    revert 0, 0
+}
+
+fn @liveString() -> u256 [selector=0x86c92c52, abi_params=[], abi_returns=[word]] {
+  bb0:
+    v0 = abi_encode []
+    v1 = not 31
+    v2 = and 0x660, v1
+    v3 = alloc raw, exact, uninitialized, infallible, v2
+    data_copy DynamicCallee_initcode_0, v3, 0x641
+    v4 = slice_ptr v0
+    v5 = add v3, 0x641
+    mcopy v5, v4, 0 !metadata(memory=heap)
+    v6 = create 0, v3, 0x641
+    jumpi v6, bb2, bb1
+  bb1:
+    revert_returndata
+  bb2:
+    v7 = abi_encode [], selector 0x2f4e740900000000000000000000000000000000000000000000000000000000
+    v8 = slice_ptr v7
+    v9 = slice_len v7
+    v10 = extcodesize v6
+    v11 = iszero v10
+    jumpi v11, bb3, bb4
+  bb4:
+    v12 = gas
+    v13 = sub v12, 50
+    v14 = call v13, v6, 0, v8, v9, 0, 32
+    jumpi v14, bb6, bb5
+  bb5:
+    revert_returndata
+  bb6:
+    v15 = add 0, 0
+    v16 = mload v15
+    v17 = add 0, 0
+    v18 = mload v17
+    ret 1
+  bb3:
+    revert 0, 0
+}
+
+fn @liveTry() -> u256 [selector=0xc2e69a83, abi_params=[], abi_returns=[word]] {
+  bb0:
+    v0 = abi_encode []
+    v1 = not 31
+    v2 = and 0x660, v1
+    v3 = alloc raw, exact, uninitialized, infallible, v2
+    data_copy DynamicCallee_initcode_0, v3, 0x641
+    v4 = slice_ptr v0
+    v5 = add v3, 0x641
+    mcopy v5, v4, 0 !metadata(memory=heap)
+    v6 = create 0, v3, 0x641
+    jumpi v6, bb2, bb1
+  bb1:
+    revert_returndata
+  bb2:
+    v7 = abi_encode [], selector 0x7271bb2c00000000000000000000000000000000000000000000000000000000
+    v8 = slice_ptr v7
+    v9 = slice_len v7
+    v10 = extcodesize v6
+    v11 = iszero v10
+    jumpi v11, bb3, bb4
+  bb4:
+    v12 = gas
+    v13 = sub v12, 50
+    v14 = call v13, v6, 0, v8, v9, 0, 32
+    jumpi v14, bb5, bb6
+  bb6:
+    jumpi 1, bb8, bb9
+  bb9:
+    revert 0, 0
+  bb8:
+    jump bb7
+  bb5:
+    v15 = add 0, 0
+    v16 = mload v15
+    v17 = add 0, 0
+    v18 = mload v17
+    jump bb7
+  bb7:
+    v19 = phi [bb5: 1], [bb8: 2]
+    ret v19
+  bb3:
+    revert 0, 0
+}
+
+fn @liveMixed() -> u256 [selector=0xaf1b6bff, abi_params=[], abi_returns=[word]] {
+  bb0:
+    v0 = abi_encode []
+    v1 = not 31
+    v2 = and 0x660, v1
+    v3 = alloc raw, exact, uninitialized, infallible, v2
+    data_copy DynamicCallee_initcode_0, v3, 0x641
+    v4 = slice_ptr v0
+    v5 = add v3, 0x641
+    mcopy v5, v4, 0 !metadata(memory=heap)
+    v6 = create 0, v3, 0x641
+    jumpi v6, bb2, bb1
+  bb1:
+    revert_returndata
+  bb2:
+    v7 = abi_encode [], selector 0x354df1f900000000000000000000000000000000000000000000000000000000
+    v8 = slice_ptr v7
+    v9 = slice_len v7
+    v10 = alloc raw, exact, uninitialized, infallible, 64
+    v11 = add v10, 32
+    mstore v11, 0
+    v12 = extcodesize v6
+    v13 = iszero v12
+    jumpi v13, bb3, bb4
+  bb4:
+    v14 = gas
+    v15 = sub v14, 50
+    v16 = call v15, v6, 0, v8, v9, v10, 64
+    jumpi v16, bb6, bb5
+  bb5:
+    revert_returndata
+  bb6:
+    v17 = add v10, 0
+    v18 = mload v17
+    v19 = add v10, 32
+    v20 = mload v19
+    frame_store multi_return, word, 0, v10 !metadata(memory=scratch)
+    v21 = add v10, 0
+    v22 = mload v21
+    v23 = frame_load multi_return, word, 0 !metadata(memory=scratch)
+    v24 = memory_object_load_element memoryfixedarray<2, 1>, v23, 1
+    ret v22
+  bb3:
+    revert 0, 0
+}
+
+fn @livePointer() -> u256 [selector=0x6347cf88, abi_params=[], abi_returns=[word]] {
+  bb0:
+    v0 = abi_encode []
+    v1 = not 31
+    v2 = and 0x660, v1
+    v3 = alloc raw, exact, uninitialized, infallible, v2
+    data_copy DynamicCallee_initcode_0, v3, 0x641
+    v4 = slice_ptr v0
+    v5 = add v3, 0x641
+    mcopy v5, v4, 0 !metadata(memory=heap)
+    v6 = create 0, v3, 0x641
+    jumpi v6, bb2, bb1
+  bb1:
+    revert_returndata
+  bb2:
+    v7 = shl 32, v6
+    v8 = or v7, 0x7271bb2c
+    v9 = and v8, 0xffffffff
+    v10 = shl 224, v9
+    v11 = shr 32, v8
+    v12 = abi_encode [], selector v10
+    v13 = slice_ptr v12
+    v14 = slice_len v12
+    v15 = extcodesize v11
+    v16 = iszero v15
+    jumpi v16, bb3, bb4
+  bb4:
+    v17 = gas
+    v18 = sub v17, 50
+    v19 = call v18, v11, 0, v13, v14, 0, 32
+    jumpi v19, bb6, bb5
+  bb5:
+    revert_returndata
+  bb6:
+    v20 = add 0, 0
+    v21 = mload v20
+    v22 = add 0, 0
+    v23 = mload v22
+    ret 1
+  bb3:
+    revert 0, 0
+}
+
+fn @liveLoop() -> u256 [selector=0xcb9e3e0f, abi_params=[], abi_returns=[word]] {
+  bb0:
+    v0 = abi_encode []
+    v1 = not 31
+    v2 = and 0x660, v1
+    v3 = alloc raw, exact, uninitialized, infallible, v2
+    data_copy DynamicCallee_initcode_0, v3, 0x641
+    v4 = slice_ptr v0
+    v5 = add v3, 0x641
+    mcopy v5, v4, 0 !metadata(memory=heap)
+    v6 = create 0, v3, 0x641
+    jumpi v6, bb2, bb1
+  bb1:
+    revert_returndata
+  bb2:
+    jump bb3
+  bb3:
+    v7 = phi [bb2: v6], [bb15: v7]
+    v8 = phi [bb2: 0], [bb15: v25]
+    v9 = phi [bb2: 0], [bb15: v23]
+    v10 = lt v8, 3
+    jumpi v10, bb6, bb7
+  bb7:
+    jump bb4
+  bb4:
+    ret v9
+  bb6:
+    v11 = abi_encode [], selector 0x7271bb2c00000000000000000000000000000000000000000000000000000000
+    v12 = slice_ptr v11
+    v13 = slice_len v11
+    v14 = extcodesize v7
+    v15 = iszero v14
+    jumpi v15, bb9, bb10
+  bb10:
+    v16 = gas
+    v17 = sub v16, 50
+    v18 = call v17, v7, 0, v12, v13, 0, 32
+    jumpi v18, bb12, bb11
+  bb11:
+    revert_returndata
+  bb12:
+    v19 = add 0, 0
+    v20 = mload v19
+    v21 = add 0, 0
+    v22 = mload v21
+    v23 = add v9, 1
+    v24 = lt v23, v9
+    jumpi v24, bb13, bb14
+  bb14:
+    jump bb8
+  bb8:
+    jump bb5
+  bb5:
+    v25 = add v8, 1
+    v26 = lt v25, v8
+    jumpi v26, bb13, bb15
+  bb15:
+    jump bb3
+  bb13:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 17 !metadata(memory=scratch)
+    revert 0, 36
+  bb9:
+    revert 0, 0
+}
+
+fn @noCode() -> u256 [selector=0x96c56dce, abi_params=[], abi_returns=[word]] {
+  bb0:
+    v0 = abi_encode [], selector 0x7271bb2c00000000000000000000000000000000000000000000000000000000
+    v1 = slice_ptr v0
+    v2 = slice_len v0
+    v3 = extcodesize 0
+    v4 = iszero v3
+    jumpi v4, bb1, bb2
+  bb2:
+    v5 = gas
+    v6 = sub v5, 50
+    v7 = call v6, 0, 0, v1, v2, 0, 32
+    jumpi v7, bb4, bb3
+  bb3:
+    revert_returndata
+  bb4:
+    v8 = add 0, 0
+    v9 = mload v8
+    v10 = add 0, 0
+    v11 = mload v10
+    ret 1
+  bb1:
+    revert 0, 0
+}
+
+fn @noCodeTry() -> u256 [selector=0x1908ad35, abi_params=[], abi_returns=[word]] {
+  bb0:
+    v0 = abi_encode [], selector 0x7271bb2c00000000000000000000000000000000000000000000000000000000
+    v1 = slice_ptr v0
+    v2 = slice_len v0
+    v3 = extcodesize 0
+    v4 = iszero v3
+    jumpi v4, bb1, bb2
+  bb2:
+    v5 = gas
+    v6 = sub v5, 50
+    v7 = call v6, 0, 0, v1, v2, 0, 32
+    jumpi v7, bb3, bb4
+  bb4:
+    jumpi 1, bb6, bb7
+  bb7:
+    revert 0, 0
+  bb6:
+    jump bb5
+  bb3:
+    v8 = add 0, 0
+    v9 = mload v8
+    v10 = add 0, 0
+    v11 = mload v10
+    jump bb5
+  bb5:
+    v12 = phi [bb3: 1], [bb6: 2]
+    ret v12
+  bb1:
+    revert 0, 0
+}

--- a/tests/ui/codegen/lowering/run-call/dynamic_return_unused_evm_version.homestead.stdout
+++ b/tests/ui/codegen/lowering/run-call/dynamic_return_unused_evm_version.homestead.stdout
@@ -202,6 +202,62 @@ fn @liveMixed() -> u256 [selector=0xaf1b6bff, abi_params=[], abi_returns=[word]]
     revert 0, 0
 }
 
+fn @liveTuple() -> u256 [selector=0x04e1eee0, abi_params=[], abi_returns=[word]] {
+  bb0:
+    v0 = abi_encode []
+    v1 = not 31
+    v2 = and 0x660, v1
+    v3 = alloc raw, exact, uninitialized, infallible, v2
+    data_copy DynamicCallee_initcode_0, v3, 0x641
+    v4 = slice_ptr v0
+    v5 = add v3, 0x641
+    mcopy v5, v4, 0 !metadata(memory=heap)
+    v6 = create 0, v3, 0x641
+    jumpi v6, bb2, bb1
+  bb1:
+    revert_returndata
+  bb2:
+    v7 = abi_encode [], selector 0x7271bb2c00000000000000000000000000000000000000000000000000000000
+    v8 = slice_ptr v7
+    v9 = slice_len v7
+    v10 = extcodesize v6
+    v11 = iszero v10
+    jumpi v11, bb3, bb4
+  bb4:
+    v12 = gas
+    v13 = sub v12, 50
+    v14 = call v13, v6, 0, v8, v9, 0, 32
+    jumpi v14, bb6, bb5
+  bb5:
+    revert_returndata
+  bb6:
+    v15 = add 0, 0
+    v16 = mload v15
+    v17 = add 0, 0
+    v18 = mload v17
+    v19 = abi_encode [], selector 0x2f4e740900000000000000000000000000000000000000000000000000000000
+    v20 = slice_ptr v19
+    v21 = slice_len v19
+    v22 = extcodesize v6
+    v23 = iszero v22
+    jumpi v23, bb3, bb7
+  bb7:
+    v24 = gas
+    v25 = sub v24, 50
+    v26 = call v25, v6, 0, v20, v21, 0, 32
+    jumpi v26, bb9, bb8
+  bb8:
+    revert_returndata
+  bb9:
+    v27 = add 0, 0
+    v28 = mload v27
+    v29 = add 0, 0
+    v30 = mload v29
+    ret 1
+  bb3:
+    revert 0, 0
+}
+
 fn @livePointer() -> u256 [selector=0x6347cf88, abi_params=[], abi_returns=[word]] {
   bb0:
     v0 = abi_encode []
@@ -262,26 +318,26 @@ fn @liveLoop() -> u256 [selector=0xcb9e3e0f, abi_params=[], abi_returns=[word]] 
   bb2:
     jump bb3
   bb3:
-    v7 = phi [bb2: v6], [bb15: v7]
-    v8 = phi [bb2: 0], [bb15: v25]
-    v9 = phi [bb2: 0], [bb15: v23]
-    v10 = lt v8, 3
+    v7 = phi [bb2: 0], [bb15: v23]
+    v8 = phi [bb2: v6], [bb15: v8]
+    v9 = phi [bb2: 0], [bb15: v25]
+    v10 = lt v9, 3
     jumpi v10, bb6, bb7
   bb7:
     jump bb4
   bb4:
-    ret v9
+    ret v7
   bb6:
     v11 = abi_encode [], selector 0x7271bb2c00000000000000000000000000000000000000000000000000000000
     v12 = slice_ptr v11
     v13 = slice_len v11
-    v14 = extcodesize v7
+    v14 = extcodesize v8
     v15 = iszero v14
     jumpi v15, bb9, bb10
   bb10:
     v16 = gas
     v17 = sub v16, 50
-    v18 = call v17, v7, 0, v12, v13, 0, 32
+    v18 = call v17, v8, 0, v12, v13, 0, 32
     jumpi v18, bb12, bb11
   bb11:
     revert_returndata
@@ -290,16 +346,16 @@ fn @liveLoop() -> u256 [selector=0xcb9e3e0f, abi_params=[], abi_returns=[word]] 
     v20 = mload v19
     v21 = add 0, 0
     v22 = mload v21
-    v23 = add v9, 1
-    v24 = lt v23, v9
+    v23 = add v7, 1
+    v24 = lt v23, v7
     jumpi v24, bb13, bb14
   bb14:
     jump bb8
   bb8:
     jump bb5
   bb5:
-    v25 = add v8, 1
-    v26 = lt v25, v8
+    v25 = add v9, 1
+    v26 = lt v25, v9
     jumpi v26, bb13, bb15
   bb15:
     jump bb3

--- a/tests/ui/codegen/lowering/run-call/dynamic_return_unused_evm_version.homestead.stdout
+++ b/tests/ui/codegen/lowering/run-call/dynamic_return_unused_evm_version.homestead.stdout
@@ -59,14 +59,14 @@ fn @live() -> u256 [selector=0x957aa58c, abi_params=[], abi_returns=[word]] {
   bb4:
     v12 = gas
     v13 = sub v12, 50
-    v14 = call v13, v6, 0, v8, v9, 0, 32
+    v14 = call v13, v6, 0, v8, v9, v8, 32
     jumpi v14, bb6, bb5
   bb5:
     revert_returndata
   bb6:
-    v15 = add 0, 0
+    v15 = add v8, 0
     v16 = mload v15
-    v17 = add 0, 0
+    v17 = add v8, 0
     v18 = mload v17
     ret 1
   bb3:
@@ -97,14 +97,14 @@ fn @liveString() -> u256 [selector=0x86c92c52, abi_params=[], abi_returns=[word]
   bb4:
     v12 = gas
     v13 = sub v12, 50
-    v14 = call v13, v6, 0, v8, v9, 0, 32
+    v14 = call v13, v6, 0, v8, v9, v8, 32
     jumpi v14, bb6, bb5
   bb5:
     revert_returndata
   bb6:
-    v15 = add 0, 0
+    v15 = add v8, 0
     v16 = mload v15
-    v17 = add 0, 0
+    v17 = add v8, 0
     v18 = mload v17
     ret 1
   bb3:
@@ -135,7 +135,7 @@ fn @liveTry() -> u256 [selector=0xc2e69a83, abi_params=[], abi_returns=[word]] {
   bb4:
     v12 = gas
     v13 = sub v12, 50
-    v14 = call v13, v6, 0, v8, v9, 0, 32
+    v14 = call v13, v6, 0, v8, v9, v8, 32
     jumpi v14, bb5, bb6
   bb6:
     jumpi 1, bb8, bb9
@@ -144,9 +144,9 @@ fn @liveTry() -> u256 [selector=0xc2e69a83, abi_params=[], abi_returns=[word]] {
   bb8:
     jump bb7
   bb5:
-    v15 = add 0, 0
+    v15 = add v8, 0
     v16 = mload v15
-    v17 = add 0, 0
+    v17 = add v8, 0
     v18 = mload v17
     jump bb7
   bb7:
@@ -174,30 +174,29 @@ fn @liveMixed() -> u256 [selector=0xaf1b6bff, abi_params=[], abi_returns=[word]]
     v7 = abi_encode [], selector 0x354df1f900000000000000000000000000000000000000000000000000000000
     v8 = slice_ptr v7
     v9 = slice_len v7
-    v10 = alloc raw, exact, uninitialized, infallible, 64
-    v11 = add v10, 32
-    mstore v11, 0
-    v12 = extcodesize v6
-    v13 = iszero v12
-    jumpi v13, bb3, bb4
+    v10 = add v8, 32
+    mstore v10, 0
+    v11 = extcodesize v6
+    v12 = iszero v11
+    jumpi v12, bb3, bb4
   bb4:
-    v14 = gas
-    v15 = sub v14, 50
-    v16 = call v15, v6, 0, v8, v9, v10, 64
-    jumpi v16, bb6, bb5
+    v13 = gas
+    v14 = sub v13, 50
+    v15 = call v14, v6, 0, v8, v9, v8, 64
+    jumpi v15, bb6, bb5
   bb5:
     revert_returndata
   bb6:
-    v17 = add v10, 0
-    v18 = mload v17
-    v19 = add v10, 32
-    v20 = mload v19
-    frame_store multi_return, word, 0, v10 !metadata(memory=scratch)
-    v21 = add v10, 0
-    v22 = mload v21
-    v23 = frame_load multi_return, word, 0 !metadata(memory=scratch)
-    v24 = memory_object_load_element memoryfixedarray<2, 1>, v23, 1
-    ret v22
+    v16 = add v8, 0
+    v17 = mload v16
+    v18 = add v8, 32
+    v19 = mload v18
+    frame_store multi_return, word, 0, v8 !metadata(memory=scratch)
+    v20 = add v8, 0
+    v21 = mload v20
+    v22 = frame_load multi_return, word, 0 !metadata(memory=scratch)
+    v23 = memory_object_load_element memoryfixedarray<2, 1>, v22, 1
+    ret v21
   bb3:
     revert 0, 0
 }
@@ -226,14 +225,14 @@ fn @liveTuple() -> u256 [selector=0x04e1eee0, abi_params=[], abi_returns=[word]]
   bb4:
     v12 = gas
     v13 = sub v12, 50
-    v14 = call v13, v6, 0, v8, v9, 0, 32
+    v14 = call v13, v6, 0, v8, v9, v8, 32
     jumpi v14, bb6, bb5
   bb5:
     revert_returndata
   bb6:
-    v15 = add 0, 0
+    v15 = add v8, 0
     v16 = mload v15
-    v17 = add 0, 0
+    v17 = add v8, 0
     v18 = mload v17
     v19 = abi_encode [], selector 0x2f4e740900000000000000000000000000000000000000000000000000000000
     v20 = slice_ptr v19
@@ -244,14 +243,14 @@ fn @liveTuple() -> u256 [selector=0x04e1eee0, abi_params=[], abi_returns=[word]]
   bb7:
     v24 = gas
     v25 = sub v24, 50
-    v26 = call v25, v6, 0, v20, v21, 0, 32
+    v26 = call v25, v6, 0, v20, v21, v20, 32
     jumpi v26, bb9, bb8
   bb8:
     revert_returndata
   bb9:
-    v27 = add 0, 0
+    v27 = add v20, 0
     v28 = mload v27
-    v29 = add 0, 0
+    v29 = add v20, 0
     v30 = mload v29
     ret 1
   bb3:
@@ -287,14 +286,14 @@ fn @livePointer() -> u256 [selector=0x6347cf88, abi_params=[], abi_returns=[word
   bb4:
     v17 = gas
     v18 = sub v17, 50
-    v19 = call v18, v11, 0, v13, v14, 0, 32
+    v19 = call v18, v11, 0, v13, v14, v13, 32
     jumpi v19, bb6, bb5
   bb5:
     revert_returndata
   bb6:
-    v20 = add 0, 0
+    v20 = add v13, 0
     v21 = mload v20
-    v22 = add 0, 0
+    v22 = add v13, 0
     v23 = mload v22
     ret 1
   bb3:
@@ -337,14 +336,14 @@ fn @liveLoop() -> u256 [selector=0xcb9e3e0f, abi_params=[], abi_returns=[word]] 
   bb10:
     v16 = gas
     v17 = sub v16, 50
-    v18 = call v17, v8, 0, v12, v13, 0, 32
+    v18 = call v17, v8, 0, v12, v13, v12, 32
     jumpi v18, bb12, bb11
   bb11:
     revert_returndata
   bb12:
-    v19 = add 0, 0
+    v19 = add v12, 0
     v20 = mload v19
-    v21 = add 0, 0
+    v21 = add v12, 0
     v22 = mload v21
     v23 = add v7, 1
     v24 = lt v23, v7
@@ -378,14 +377,14 @@ fn @noCode() -> u256 [selector=0x96c56dce, abi_params=[], abi_returns=[word]] {
   bb2:
     v5 = gas
     v6 = sub v5, 50
-    v7 = call v6, 0, 0, v1, v2, 0, 32
+    v7 = call v6, 0, 0, v1, v2, v1, 32
     jumpi v7, bb4, bb3
   bb3:
     revert_returndata
   bb4:
-    v8 = add 0, 0
+    v8 = add v1, 0
     v9 = mload v8
-    v10 = add 0, 0
+    v10 = add v1, 0
     v11 = mload v10
     ret 1
   bb1:
@@ -403,7 +402,7 @@ fn @noCodeTry() -> u256 [selector=0x1908ad35, abi_params=[], abi_returns=[word]]
   bb2:
     v5 = gas
     v6 = sub v5, 50
-    v7 = call v6, 0, 0, v1, v2, 0, 32
+    v7 = call v6, 0, 0, v1, v2, v1, 32
     jumpi v7, bb3, bb4
   bb4:
     jumpi 1, bb6, bb7
@@ -412,9 +411,9 @@ fn @noCodeTry() -> u256 [selector=0x1908ad35, abi_params=[], abi_returns=[word]]
   bb6:
     jump bb5
   bb3:
-    v8 = add 0, 0
+    v8 = add v1, 0
     v9 = mload v8
-    v10 = add 0, 0
+    v10 = add v1, 0
     v11 = mload v10
     jump bb5
   bb5:

--- a/tests/ui/codegen/lowering/run-call/dynamic_return_unused_evm_version.osaka.stdout
+++ b/tests/ui/codegen/lowering/run-call/dynamic_return_unused_evm_version.osaka.stdout
@@ -245,6 +245,70 @@ fn @liveMixed() -> u256 [selector=0xaf1b6bff, abi_params=[], abi_returns=[word]]
     revert 0, 36
 }
 
+fn @liveTuple() -> u256 [selector=0x04e1eee0, abi_params=[], abi_returns=[word]] {
+  bb0:
+    v0 = abi_encode []
+    v1 = not 31
+    v2 = and 969, v1
+    v3 = alloc raw, exact, uninitialized, infallible, v2
+    data_copy DynamicCallee_initcode_0, v3, 938
+    v4 = slice_ptr v0
+    v5 = add v3, 938
+    mcopy v5, v4, 0 !metadata(memory=heap)
+    v6 = create 0, v3, 938
+    jumpi v6, bb2, bb1
+  bb1:
+    revert_returndata
+  bb2:
+    v7 = gas
+    v8 = abi_encode [], selector 0x7271bb2c00000000000000000000000000000000000000000000000000000000
+    v9 = slice_ptr v8
+    v10 = slice_len v8
+    v11 = call v7, v6, 0, v9, v10, 0, 0
+    jumpi v11, bb4, bb3
+  bb3:
+    revert_returndata
+  bb4:
+    v12 = returndatasize
+    v13 = add v12, 63
+    v14 = lt v13, v12
+    jumpi v14, bb5, bb6
+  bb6:
+    v15 = not 31
+    v16 = and v13, v15
+    v17 = alloc memorybytes, exact, uninitialized, infallible, v16
+    set_memory_object_len memorybytes, v17, v12
+    v18 = make_returndata_slice 0, v12
+    memory_object_copy_from_slice memorybytes, v17, v18
+    v19 = abi_decode [bytes], v17
+    v20 = gas
+    v21 = abi_encode [], selector 0x2f4e740900000000000000000000000000000000000000000000000000000000
+    v22 = slice_ptr v21
+    v23 = slice_len v21
+    v24 = call v20, v6, 0, v22, v23, 0, 0
+    jumpi v24, bb8, bb7
+  bb7:
+    revert_returndata
+  bb8:
+    v25 = returndatasize
+    v26 = add v25, 63
+    v27 = lt v26, v25
+    jumpi v27, bb5, bb9
+  bb9:
+    v28 = not 31
+    v29 = and v26, v28
+    v30 = alloc memorybytes, exact, uninitialized, infallible, v29
+    set_memory_object_len memorybytes, v30, v25
+    v31 = make_returndata_slice 0, v25
+    memory_object_copy_from_slice memorybytes, v30, v31
+    v32 = abi_decode [bytes], v30
+    ret 1
+  bb5:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 65 !metadata(memory=scratch)
+    revert 0, 36
+}
+
 fn @livePointer() -> u256 [selector=0x6347cf88, abi_params=[], abi_returns=[word]] {
   bb0:
     v0 = abi_encode []
@@ -310,21 +374,21 @@ fn @liveLoop() -> u256 [selector=0xcb9e3e0f, abi_params=[], abi_returns=[word]] 
   bb2:
     jump bb3
   bb3:
-    v7 = phi [bb2: v6], [bb15: v7]
-    v8 = phi [bb2: 0], [bb15: v26]
-    v9 = phi [bb2: 0], [bb15: v24]
-    v10 = lt v8, 3
+    v7 = phi [bb2: 0], [bb15: v24]
+    v8 = phi [bb2: v6], [bb15: v8]
+    v9 = phi [bb2: 0], [bb15: v26]
+    v10 = lt v9, 3
     jumpi v10, bb6, bb7
   bb7:
     jump bb4
   bb4:
-    ret v9
+    ret v7
   bb6:
     v11 = gas
     v12 = abi_encode [], selector 0x7271bb2c00000000000000000000000000000000000000000000000000000000
     v13 = slice_ptr v12
     v14 = slice_len v12
-    v15 = call v11, v7, 0, v13, v14, 0, 0
+    v15 = call v11, v8, 0, v13, v14, 0, 0
     jumpi v15, bb10, bb9
   bb9:
     revert_returndata
@@ -341,16 +405,16 @@ fn @liveLoop() -> u256 [selector=0xcb9e3e0f, abi_params=[], abi_returns=[word]] 
     v22 = make_returndata_slice 0, v16
     memory_object_copy_from_slice memorybytes, v21, v22
     v23 = abi_decode [bytes], v21
-    v24 = add v9, 1
-    v25 = lt v24, v9
+    v24 = add v7, 1
+    v25 = lt v24, v7
     jumpi v25, bb13, bb14
   bb14:
     jump bb8
   bb8:
     jump bb5
   bb5:
-    v26 = add v8, 1
-    v27 = lt v26, v8
+    v26 = add v9, 1
+    v27 = lt v26, v9
     jumpi v27, bb13, bb15
   bb15:
     jump bb3

--- a/tests/ui/codegen/lowering/run-call/dynamic_return_unused_evm_version.osaka.stdout
+++ b/tests/ui/codegen/lowering/run-call/dynamic_return_unused_evm_version.osaka.stdout
@@ -1,0 +1,456 @@
+// === ROOT/tests/ui/codegen/lowering/run-call/dynamic_return_unused_evm_version.sol:DynamicCallee ===
+@module DynamicCallee
+fn @dynBytes() -> memorybytes [selector=0x7271bb2c, pure, abi_params=[], abi_returns=[memory_bytes]] {
+  bb0:
+    v0 = alloc memorybytes, exact, uninitialized, infallible, 96
+    set_memory_object_len memorybytes, v0, 34
+    v1 = memory_object_data memorybytes, v0
+    mstore v1, 0x3031323334353637383961626364656630313233343536373839616263646566
+    v2 = add v1, 32
+    mstore v2, 0x3031000000000000000000000000000000000000000000000000000000000000
+    ret v0
+}
+
+fn @dynString() -> memorybytes [selector=0x2f4e7409, pure, abi_params=[], abi_returns=[memory_bytes]] {
+  bb0:
+    v0 = alloc memorybytes, exact, uninitialized, infallible, 64
+    set_memory_object_len memorybytes, v0, 5
+    v1 = memory_object_data memorybytes, v0
+    mstore v1, 0x68656c6c6f000000000000000000000000000000000000000000000000000000
+    ret v0
+}
+
+fn @mixed() -> (u256, memorybytes) [selector=0x354df1f9, pure, abi_params=[], abi_returns=[word, memory_bytes]] {
+  bb0:
+    v0 = alloc memorybytes, exact, uninitialized, infallible, 64
+    set_memory_object_len memorybytes, v0, 3
+    v1 = memory_object_data memorybytes, v0
+    mstore v1, 0x6162630000000000000000000000000000000000000000000000000000000000
+    ret 11, v0
+}
+
+// === ROOT/tests/ui/codegen/lowering/run-call/dynamic_return_unused_evm_version.sol:DynamicReturnUnused ===
+@module DynamicReturnUnused
+data:
+  DynamicCallee_initcode_0: hex"34600e576103988060125f395ff35b5f5ffd346038575f3560e01c80632f4e740914602a578063354df1f914602f5780637271bb2c146034576038565b610172565b610281565b603c565b5f5ffd5b6101406040526040518060e0528060e0526060810160405260228152602081017f30313233343536373839616263646566303132333435363738396162636465668152602090017f3031000000000000000000000000000000000000000000000000000000000000815250604051806101005280610100526020810181806101005281038252828060e05251838060e0521515810280608052905080608052806080528152601f19601f60805101168060a0528060a052602082018060c05291508160c0528060a0521590509050905061011f57602060a0510360c051015f8152505b602060e0510160a0518060a05260c05101608051806080528260c0518060c0525e905061010051806101005290035f9001601f8101601f1981169050604051806101205281810191508160405290508181f35b6101406040526040518060e0528060e0526040810160405260058152602081017f68656c6c6f000000000000000000000000000000000000000000000000000000815250604051806101005280610100526020810181806101005281038252828060e05251838060e0521515810280608052905080608052806080528152601f19601f60805101168060a0528060a052602082018060c05291508160c0528060a0521590509050905061022e57602060a0510360c051015f8152505b602060e0510160a0518060a05260c05101608051806080528260c0518060c0525e905061010051806101005290035f9001601f8101601f1981169050604051806101205281810191508160405290508181f35b6101406040526040518060e0528060e0526040810160405260038152602081017f61626300000000000000000000000000000000000000000000000000000000008152506040518061010052806101005260408101600b82526020820182806101005282039052828060e05251838060e0521515810280608052905080608052806080528152601f19601f60805101168060a0528060a052602082018060c05291508160c0528060a0521590509050905061034557602060a0510360c051015f8152505b602060e0510160a0518060a05260c05101608051806080528260c0518060c0525e905061010051806101005290035f9001601f8101601f1981169050604051806101205281810191508160405290508181f3"
+
+fn @live() -> u256 [selector=0x957aa58c, abi_params=[], abi_returns=[word]] {
+  bb0:
+    v0 = abi_encode []
+    v1 = not 31
+    v2 = and 969, v1
+    v3 = alloc raw, exact, uninitialized, infallible, v2
+    data_copy DynamicCallee_initcode_0, v3, 938
+    v4 = slice_ptr v0
+    v5 = add v3, 938
+    mcopy v5, v4, 0 !metadata(memory=heap)
+    v6 = create 0, v3, 938
+    jumpi v6, bb2, bb1
+  bb1:
+    revert_returndata
+  bb2:
+    v7 = gas
+    v8 = abi_encode [], selector 0x7271bb2c00000000000000000000000000000000000000000000000000000000
+    v9 = slice_ptr v8
+    v10 = slice_len v8
+    v11 = call v7, v6, 0, v9, v10, 0, 0
+    jumpi v11, bb4, bb3
+  bb3:
+    revert_returndata
+  bb4:
+    v12 = returndatasize
+    v13 = add v12, 63
+    v14 = lt v13, v12
+    jumpi v14, bb5, bb6
+  bb6:
+    v15 = not 31
+    v16 = and v13, v15
+    v17 = alloc memorybytes, exact, uninitialized, infallible, v16
+    set_memory_object_len memorybytes, v17, v12
+    v18 = make_returndata_slice 0, v12
+    memory_object_copy_from_slice memorybytes, v17, v18
+    v19 = abi_decode [bytes], v17
+    ret 1
+  bb5:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 65 !metadata(memory=scratch)
+    revert 0, 36
+}
+
+fn @liveString() -> u256 [selector=0x86c92c52, abi_params=[], abi_returns=[word]] {
+  bb0:
+    v0 = abi_encode []
+    v1 = not 31
+    v2 = and 969, v1
+    v3 = alloc raw, exact, uninitialized, infallible, v2
+    data_copy DynamicCallee_initcode_0, v3, 938
+    v4 = slice_ptr v0
+    v5 = add v3, 938
+    mcopy v5, v4, 0 !metadata(memory=heap)
+    v6 = create 0, v3, 938
+    jumpi v6, bb2, bb1
+  bb1:
+    revert_returndata
+  bb2:
+    v7 = gas
+    v8 = abi_encode [], selector 0x2f4e740900000000000000000000000000000000000000000000000000000000
+    v9 = slice_ptr v8
+    v10 = slice_len v8
+    v11 = call v7, v6, 0, v9, v10, 0, 0
+    jumpi v11, bb4, bb3
+  bb3:
+    revert_returndata
+  bb4:
+    v12 = returndatasize
+    v13 = add v12, 63
+    v14 = lt v13, v12
+    jumpi v14, bb5, bb6
+  bb6:
+    v15 = not 31
+    v16 = and v13, v15
+    v17 = alloc memorybytes, exact, uninitialized, infallible, v16
+    set_memory_object_len memorybytes, v17, v12
+    v18 = make_returndata_slice 0, v12
+    memory_object_copy_from_slice memorybytes, v17, v18
+    v19 = abi_decode [bytes], v17
+    ret 1
+  bb5:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 65 !metadata(memory=scratch)
+    revert 0, 36
+}
+
+fn @liveTry() -> u256 [selector=0xc2e69a83, abi_params=[], abi_returns=[word]] {
+  bb0:
+    v0 = abi_encode []
+    v1 = not 31
+    v2 = and 969, v1
+    v3 = alloc raw, exact, uninitialized, infallible, v2
+    data_copy DynamicCallee_initcode_0, v3, 938
+    v4 = slice_ptr v0
+    v5 = add v3, 938
+    mcopy v5, v4, 0 !metadata(memory=heap)
+    v6 = create 0, v3, 938
+    jumpi v6, bb2, bb1
+  bb1:
+    revert_returndata
+  bb2:
+    v7 = gas
+    v8 = abi_encode [], selector 0x7271bb2c00000000000000000000000000000000000000000000000000000000
+    v9 = slice_ptr v8
+    v10 = slice_len v8
+    v11 = call v7, v6, 0, v9, v10, 0, 0
+    jumpi v11, bb3, bb4
+  bb4:
+    v20 = returndatasize
+    v21 = add v20, 63
+    v22 = lt v21, v20
+    jumpi v22, bb6, bb8
+  bb8:
+    v23 = not 31
+    v24 = and v21, v23
+    v25 = alloc memorybytes, exact, uninitialized, infallible, v24
+    set_memory_object_len memorybytes, v25, v20
+    v26 = make_returndata_slice 0, v20
+    memory_object_copy_from_slice memorybytes, v25, v26
+    v27 = memory_object_data memorybytes, v25
+    v28 = memory_object_len memorybytes, v25
+    v29 = make_memory_slice v27, v28
+    v30 = memory_slice_load_word memory, v29, 0
+    v31 = lt v28, 4
+    v32 = iszero v31
+    v33 = shr 224, v30
+    v34 = eq v33, 0x8c379a0
+    v35 = and v32, v34
+    v36 = lt v28, 36
+    v37 = iszero v36
+    v38 = eq v33, 0x4e487b71
+    v39 = and v37, v38
+    jumpi 1, bb9, bb10
+  bb10:
+    revert v27, v28
+  bb9:
+    jump bb5
+  bb3:
+    v12 = returndatasize
+    v13 = add v12, 63
+    v14 = lt v13, v12
+    jumpi v14, bb6, bb7
+  bb7:
+    v15 = not 31
+    v16 = and v13, v15
+    v17 = alloc memorybytes, exact, uninitialized, infallible, v16
+    set_memory_object_len memorybytes, v17, v12
+    v18 = make_returndata_slice 0, v12
+    memory_object_copy_from_slice memorybytes, v17, v18
+    v19 = abi_decode [bytes], v17
+    jump bb5
+  bb5:
+    v40 = phi [bb7: 1], [bb9: 2]
+    ret v40
+  bb6:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 65 !metadata(memory=scratch)
+    revert 0, 36
+}
+
+fn @liveMixed() -> u256 [selector=0xaf1b6bff, abi_params=[], abi_returns=[word]] {
+  bb0:
+    v0 = abi_encode []
+    v1 = not 31
+    v2 = and 969, v1
+    v3 = alloc raw, exact, uninitialized, infallible, v2
+    data_copy DynamicCallee_initcode_0, v3, 938
+    v4 = slice_ptr v0
+    v5 = add v3, 938
+    mcopy v5, v4, 0 !metadata(memory=heap)
+    v6 = create 0, v3, 938
+    jumpi v6, bb2, bb1
+  bb1:
+    revert_returndata
+  bb2:
+    v7 = gas
+    v8 = abi_encode [], selector 0x354df1f900000000000000000000000000000000000000000000000000000000
+    v9 = slice_ptr v8
+    v10 = slice_len v8
+    v11 = call v7, v6, 0, v9, v10, 0, 0
+    jumpi v11, bb4, bb3
+  bb3:
+    revert_returndata
+  bb4:
+    v12 = returndatasize
+    v13 = add v12, 63
+    v14 = lt v13, v12
+    jumpi v14, bb5, bb6
+  bb6:
+    v15 = not 31
+    v16 = and v13, v15
+    v17 = alloc memorybytes, exact, uninitialized, infallible, v16
+    set_memory_object_len memorybytes, v17, v12
+    v18 = make_returndata_slice 0, v12
+    memory_object_copy_from_slice memorybytes, v17, v18
+    v19 = abi_decode [u256, bytes], v17
+    v20 = frame_load multi_return, word, 0 !metadata(memory=scratch)
+    v21 = memory_object_load_element memoryfixedarray<2, 1>, v20, 1
+    v22 = alloc memoryfixedarray<2, 1>, exact, uninitialized, infallible, 64
+    v23 = memory_object_data memoryfixedarray, v22
+    frame_store multi_return, word, 0, v23 !metadata(memory=scratch)
+    memory_object_store_element memoryfixedarray<2, 1>, v22, 1, v21
+    v24 = frame_load multi_return, word, 0 !metadata(memory=scratch)
+    v25 = memory_object_load_element memoryfixedarray<2, 1>, v24, 1
+    ret v19
+  bb5:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 65 !metadata(memory=scratch)
+    revert 0, 36
+}
+
+fn @livePointer() -> u256 [selector=0x6347cf88, abi_params=[], abi_returns=[word]] {
+  bb0:
+    v0 = abi_encode []
+    v1 = not 31
+    v2 = and 969, v1
+    v3 = alloc raw, exact, uninitialized, infallible, v2
+    data_copy DynamicCallee_initcode_0, v3, 938
+    v4 = slice_ptr v0
+    v5 = add v3, 938
+    mcopy v5, v4, 0 !metadata(memory=heap)
+    v6 = create 0, v3, 938
+    jumpi v6, bb2, bb1
+  bb1:
+    revert_returndata
+  bb2:
+    v7 = shl 32, v6
+    v8 = or v7, 0x7271bb2c
+    v9 = and v8, 0xffffffff
+    v10 = shl 224, v9
+    v11 = shr 32, v8
+    v12 = gas
+    v13 = abi_encode [], selector v10
+    v14 = slice_ptr v13
+    v15 = slice_len v13
+    v16 = call v12, v11, 0, v14, v15, 0, 0
+    jumpi v16, bb4, bb3
+  bb3:
+    revert_returndata
+  bb4:
+    v17 = returndatasize
+    v18 = add v17, 63
+    v19 = lt v18, v17
+    jumpi v19, bb5, bb6
+  bb6:
+    v20 = not 31
+    v21 = and v18, v20
+    v22 = alloc memorybytes, exact, uninitialized, infallible, v21
+    set_memory_object_len memorybytes, v22, v17
+    v23 = make_returndata_slice 0, v17
+    memory_object_copy_from_slice memorybytes, v22, v23
+    v24 = abi_decode [bytes], v22
+    ret 1
+  bb5:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 65 !metadata(memory=scratch)
+    revert 0, 36
+}
+
+fn @liveLoop() -> u256 [selector=0xcb9e3e0f, abi_params=[], abi_returns=[word]] {
+  bb0:
+    v0 = abi_encode []
+    v1 = not 31
+    v2 = and 969, v1
+    v3 = alloc raw, exact, uninitialized, infallible, v2
+    data_copy DynamicCallee_initcode_0, v3, 938
+    v4 = slice_ptr v0
+    v5 = add v3, 938
+    mcopy v5, v4, 0 !metadata(memory=heap)
+    v6 = create 0, v3, 938
+    jumpi v6, bb2, bb1
+  bb1:
+    revert_returndata
+  bb2:
+    jump bb3
+  bb3:
+    v7 = phi [bb2: v6], [bb15: v7]
+    v8 = phi [bb2: 0], [bb15: v26]
+    v9 = phi [bb2: 0], [bb15: v24]
+    v10 = lt v8, 3
+    jumpi v10, bb6, bb7
+  bb7:
+    jump bb4
+  bb4:
+    ret v9
+  bb6:
+    v11 = gas
+    v12 = abi_encode [], selector 0x7271bb2c00000000000000000000000000000000000000000000000000000000
+    v13 = slice_ptr v12
+    v14 = slice_len v12
+    v15 = call v11, v7, 0, v13, v14, 0, 0
+    jumpi v15, bb10, bb9
+  bb9:
+    revert_returndata
+  bb10:
+    v16 = returndatasize
+    v17 = add v16, 63
+    v18 = lt v17, v16
+    jumpi v18, bb11, bb12
+  bb12:
+    v19 = not 31
+    v20 = and v17, v19
+    v21 = alloc memorybytes, exact, uninitialized, infallible, v20
+    set_memory_object_len memorybytes, v21, v16
+    v22 = make_returndata_slice 0, v16
+    memory_object_copy_from_slice memorybytes, v21, v22
+    v23 = abi_decode [bytes], v21
+    v24 = add v9, 1
+    v25 = lt v24, v9
+    jumpi v25, bb13, bb14
+  bb14:
+    jump bb8
+  bb8:
+    jump bb5
+  bb5:
+    v26 = add v8, 1
+    v27 = lt v26, v8
+    jumpi v27, bb13, bb15
+  bb15:
+    jump bb3
+  bb13:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 17 !metadata(memory=scratch)
+    revert 0, 36
+  bb11:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 65 !metadata(memory=scratch)
+    revert 0, 36
+}
+
+fn @noCode() -> u256 [selector=0x96c56dce, abi_params=[], abi_returns=[word]] {
+  bb0:
+    v0 = gas
+    v1 = abi_encode [], selector 0x7271bb2c00000000000000000000000000000000000000000000000000000000
+    v2 = slice_ptr v1
+    v3 = slice_len v1
+    v4 = call v0, 0, 0, v2, v3, 0, 0
+    jumpi v4, bb2, bb1
+  bb1:
+    revert_returndata
+  bb2:
+    v5 = returndatasize
+    v6 = add v5, 63
+    v7 = lt v6, v5
+    jumpi v7, bb3, bb4
+  bb4:
+    v8 = not 31
+    v9 = and v6, v8
+    v10 = alloc memorybytes, exact, uninitialized, infallible, v9
+    set_memory_object_len memorybytes, v10, v5
+    v11 = make_returndata_slice 0, v5
+    memory_object_copy_from_slice memorybytes, v10, v11
+    v12 = abi_decode [bytes], v10
+    ret 1
+  bb3:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 65 !metadata(memory=scratch)
+    revert 0, 36
+}
+
+fn @noCodeTry() -> u256 [selector=0x1908ad35, abi_params=[], abi_returns=[word]] {
+  bb0:
+    v0 = gas
+    v1 = abi_encode [], selector 0x7271bb2c00000000000000000000000000000000000000000000000000000000
+    v2 = slice_ptr v1
+    v3 = slice_len v1
+    v4 = call v0, 0, 0, v2, v3, 0, 0
+    jumpi v4, bb1, bb2
+  bb2:
+    v13 = returndatasize
+    v14 = add v13, 63
+    v15 = lt v14, v13
+    jumpi v15, bb4, bb6
+  bb6:
+    v16 = not 31
+    v17 = and v14, v16
+    v18 = alloc memorybytes, exact, uninitialized, infallible, v17
+    set_memory_object_len memorybytes, v18, v13
+    v19 = make_returndata_slice 0, v13
+    memory_object_copy_from_slice memorybytes, v18, v19
+    v20 = memory_object_data memorybytes, v18
+    v21 = memory_object_len memorybytes, v18
+    v22 = make_memory_slice v20, v21
+    v23 = memory_slice_load_word memory, v22, 0
+    v24 = lt v21, 4
+    v25 = iszero v24
+    v26 = shr 224, v23
+    v27 = eq v26, 0x8c379a0
+    v28 = and v25, v27
+    v29 = lt v21, 36
+    v30 = iszero v29
+    v31 = eq v26, 0x4e487b71
+    v32 = and v30, v31
+    jumpi 1, bb7, bb8
+  bb8:
+    revert v20, v21
+  bb7:
+    jump bb3
+  bb1:
+    v5 = returndatasize
+    v6 = add v5, 63
+    v7 = lt v6, v5
+    jumpi v7, bb4, bb5
+  bb5:
+    v8 = not 31
+    v9 = and v6, v8
+    v10 = alloc memorybytes, exact, uninitialized, infallible, v9
+    set_memory_object_len memorybytes, v10, v5
+    v11 = make_returndata_slice 0, v5
+    memory_object_copy_from_slice memorybytes, v10, v11
+    v12 = abi_decode [bytes], v10
+    jump bb3
+  bb3:
+    v33 = phi [bb5: 1], [bb7: 2]
+    ret v33
+  bb4:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 65 !metadata(memory=scratch)
+    revert 0, 36
+}

--- a/tests/ui/codegen/lowering/run-call/dynamic_return_unused_evm_version.sol
+++ b/tests/ui/codegen/lowering/run-call/dynamic_return_unused_evm_version.sol
@@ -10,6 +10,7 @@
 //@ run-call: DynamicReturnUnused::liveString => 1
 //@ run-call: DynamicReturnUnused::liveTry => 1
 //@ run-call: DynamicReturnUnused::liveMixed => 11
+//@ run-call: DynamicReturnUnused::liveTuple => 1
 //@ run-call: DynamicReturnUnused::livePointer => 1
 //@ run-call: DynamicReturnUnused::liveLoop => 3
 //@ run-call-fail: DynamicReturnUnused::noCode => 0x
@@ -87,6 +88,14 @@ contract DynamicReturnUnused {
     function liveMixed() external returns (uint256 r) {
         (uint256 v, ) = DynamicTarget(address(new DynamicCallee())).mixed();
         r = v;
+    }
+
+    // A tuple expression statement discards every component, so both calls are lowered like a
+    // discarded one.
+    function liveTuple() external returns (uint256) {
+        DynamicTarget target = DynamicTarget(address(new DynamicCallee()));
+        (target.dynBytes(), target.dynString());
+        return 1;
     }
 
     function livePointer() external returns (uint256) {

--- a/tests/ui/codegen/lowering/run-call/dynamic_return_unused_evm_version.sol
+++ b/tests/ui/codegen/lowering/run-call/dynamic_return_unused_evm_version.sol
@@ -1,0 +1,125 @@
+//@ revisions: homestead homesteadGas homesteadSize byzantium osaka
+//@[homestead] compile-flags: -O none --evm-version homestead -Zdump=mir
+//@[homestead] filecheck: --check-prefix=HOMESTEAD --implicit-check-not=returndatasize --implicit-check-not=returndatacopy
+//@[homesteadGas] compile-flags: -O gas --evm-version homestead
+//@[homesteadSize] compile-flags: -O size --evm-version homestead
+//@[byzantium] compile-flags: -O none --evm-version byzantium
+//@[osaka] compile-flags: -O none --evm-version osaka -Zdump=mir
+//@[osaka] filecheck: --check-prefix=OSAKA
+//@ run-call: DynamicReturnUnused::live => 1
+//@ run-call: DynamicReturnUnused::liveString => 1
+//@ run-call: DynamicReturnUnused::liveTry => 1
+//@ run-call: DynamicReturnUnused::liveMixed => 11
+//@ run-call: DynamicReturnUnused::livePointer => 1
+//@ run-call: DynamicReturnUnused::liveLoop => 3
+//@ run-call-fail: DynamicReturnUnused::noCode => 0x
+//@ run-call-fail: DynamicReturnUnused::noCodeTry => 0x
+
+interface DynamicTarget {
+    function dynBytes() external returns (bytes memory);
+    function dynString() external returns (string memory);
+    function mixed() external returns (uint256, bytes memory);
+}
+
+contract DynamicCallee {
+    function dynBytes() external pure returns (bytes memory) {
+        return "0123456789abcdef0123456789abcdef01";
+    }
+
+    function dynString() external pure returns (string memory) {
+        return "hello";
+    }
+
+    function mixed() external pure returns (uint256, bytes memory) {
+        return (11, "abc");
+    }
+}
+
+contract DynamicReturnUnused {
+    // Before Byzantium a dynamically encoded return value is inaccessible: the call reserves a
+    // word of output area for it, nothing decodes it, and the `extcodesize` guard and the
+    // pre-EIP-150 gas reserve still apply.
+    // HOMESTEAD-LABEL: fn @live()
+    // HOMESTEAD: extcodesize
+    // HOMESTEAD: [[GAS:v[0-9]+]] = gas
+    // HOMESTEAD: [[FWD:v[0-9]+]] = sub [[GAS]], 50
+    // HOMESTEAD: [[OK:v[0-9]+]] = call [[FWD]], {{v[0-9]+}}, 0, {{v[0-9]+}}, {{v[0-9]+}}, 0, 32
+    // HOMESTEAD: jumpi [[OK]]
+    // OSAKA-LABEL: fn @live()
+    // OSAKA: [[OK:v[0-9]+]] = call {{v[0-9]+}}, {{v[0-9]+}}, 0, {{v[0-9]+}}, {{v[0-9]+}}, 0, 0
+    // OSAKA: jumpi [[OK]]
+    function live() external returns (uint256) {
+        DynamicTarget(address(new DynamicCallee())).dynBytes();
+        return 1;
+    }
+
+    function liveString() external returns (uint256) {
+        DynamicTarget(address(new DynamicCallee())).dynString();
+        return 1;
+    }
+
+    // A bare `catch` around an inaccessible value needs no return data either.
+    // HOMESTEAD-LABEL: fn @liveTry()
+    // HOMESTEAD: extcodesize
+    // HOMESTEAD: [[GAS:v[0-9]+]] = gas
+    // HOMESTEAD: [[FWD:v[0-9]+]] = sub [[GAS]], 50
+    // HOMESTEAD: [[OK:v[0-9]+]] = call [[FWD]], {{v[0-9]+}}, 0, {{v[0-9]+}}, {{v[0-9]+}}, 0, 32
+    // HOMESTEAD: jumpi [[OK]]
+    function liveTry() external returns (uint256 r) {
+        try DynamicTarget(address(new DynamicCallee())).dynBytes() {
+            r = 1;
+        } catch {
+            r = 2;
+        }
+    }
+
+    // The static components of a mixed return stay accessible, so the output area covers both
+    // words and the first one is read back from it.
+    // HOMESTEAD-LABEL: fn @liveMixed()
+    // HOMESTEAD: [[BUFFER:v[0-9]+]] = alloc raw, exact, uninitialized, infallible, 64
+    // HOMESTEAD: [[LAST:v[0-9]+]] = add [[BUFFER]], 32
+    // HOMESTEAD: mstore [[LAST]], 0
+    // HOMESTEAD: [[GAS:v[0-9]+]] = gas
+    // HOMESTEAD: [[FWD:v[0-9]+]] = sub [[GAS]], 50
+    // HOMESTEAD: call [[FWD]], {{v[0-9]+}}, 0, {{v[0-9]+}}, {{v[0-9]+}}, [[BUFFER]], 64
+    // HOMESTEAD: [[FIRST:v[0-9]+]] = add [[BUFFER]], 0
+    // HOMESTEAD: mload [[FIRST]]
+    function liveMixed() external returns (uint256 r) {
+        (uint256 v, ) = DynamicTarget(address(new DynamicCallee())).mixed();
+        r = v;
+    }
+
+    function livePointer() external returns (uint256) {
+        DynamicTarget target = DynamicTarget(address(new DynamicCallee()));
+        function() external returns (bytes memory) f = target.dynBytes;
+        f();
+        return 1;
+    }
+
+    function liveLoop() external returns (uint256 r) {
+        DynamicTarget target = DynamicTarget(address(new DynamicCallee()));
+        for (uint256 i = 0; i < 3; i++) {
+            target.dynBytes();
+            r++;
+        }
+    }
+
+    // A code-less callee reverts: the guard is what a pre-Byzantium call has in place of a
+    // return-data check, and from Byzantium on the empty return data fails to decode.
+    // HOMESTEAD-LABEL: fn @noCode()
+    // HOMESTEAD: extcodesize
+    function noCode() external returns (uint256) {
+        DynamicTarget(address(0)).dynBytes();
+        return 1;
+    }
+
+    // HOMESTEAD-LABEL: fn @noCodeTry()
+    // HOMESTEAD: extcodesize
+    function noCodeTry() external returns (uint256 r) {
+        try DynamicTarget(address(0)).dynBytes() {
+            r = 1;
+        } catch {
+            r = 2;
+        }
+    }
+}

--- a/tests/ui/codegen/lowering/run-call/dynamic_return_unused_evm_version.sol
+++ b/tests/ui/codegen/lowering/run-call/dynamic_return_unused_evm_version.sol
@@ -82,9 +82,10 @@ contract DynamicReturnUnused {
     // words and the first one is read back from the input area it overlays.
     // HOMESTEAD-LABEL: fn @liveMixed()
     // HOMESTEAD: create
+    // HOMESTEAD: [[AREA:v[0-9]+]] = fmp
+    // HOMESTEAD: [[ABOVE:v[0-9]+]] = add [[AREA]], 64
+    // HOMESTEAD: mstore [[ABOVE]], 0
     // HOMESTEAD: [[INPUT:v[0-9]+]] = slice_ptr
-    // HOMESTEAD: [[LAST:v[0-9]+]] = add [[INPUT]], 32
-    // HOMESTEAD: mstore [[LAST]], 0
     // HOMESTEAD: [[GAS:v[0-9]+]] = gas
     // HOMESTEAD: [[FWD:v[0-9]+]] = sub [[GAS]], 50
     // HOMESTEAD: call [[FWD]], {{v[0-9]+}}, 0, [[INPUT]], {{v[0-9]+}}, [[INPUT]], 64

--- a/tests/ui/codegen/lowering/run-call/dynamic_return_unused_evm_version.sol
+++ b/tests/ui/codegen/lowering/run-call/dynamic_return_unused_evm_version.sol
@@ -41,10 +41,12 @@ contract DynamicReturnUnused {
     // word of output area for it, nothing decodes it, and the `extcodesize` guard and the
     // pre-EIP-150 gas reserve still apply.
     // HOMESTEAD-LABEL: fn @live()
+    // HOMESTEAD: create
+    // HOMESTEAD: [[INPUT:v[0-9]+]] = slice_ptr
     // HOMESTEAD: extcodesize
     // HOMESTEAD: [[GAS:v[0-9]+]] = gas
     // HOMESTEAD: [[FWD:v[0-9]+]] = sub [[GAS]], 50
-    // HOMESTEAD: [[OK:v[0-9]+]] = call [[FWD]], {{v[0-9]+}}, 0, {{v[0-9]+}}, {{v[0-9]+}}, 0, 32
+    // HOMESTEAD: [[OK:v[0-9]+]] = call [[FWD]], {{v[0-9]+}}, 0, [[INPUT]], {{v[0-9]+}}, [[INPUT]], 32
     // HOMESTEAD: jumpi [[OK]]
     // OSAKA-LABEL: fn @live()
     // OSAKA: [[OK:v[0-9]+]] = call {{v[0-9]+}}, {{v[0-9]+}}, 0, {{v[0-9]+}}, {{v[0-9]+}}, 0, 0
@@ -61,10 +63,12 @@ contract DynamicReturnUnused {
 
     // A bare `catch` around an inaccessible value needs no return data either.
     // HOMESTEAD-LABEL: fn @liveTry()
+    // HOMESTEAD: create
+    // HOMESTEAD: [[INPUT:v[0-9]+]] = slice_ptr
     // HOMESTEAD: extcodesize
     // HOMESTEAD: [[GAS:v[0-9]+]] = gas
     // HOMESTEAD: [[FWD:v[0-9]+]] = sub [[GAS]], 50
-    // HOMESTEAD: [[OK:v[0-9]+]] = call [[FWD]], {{v[0-9]+}}, 0, {{v[0-9]+}}, {{v[0-9]+}}, 0, 32
+    // HOMESTEAD: [[OK:v[0-9]+]] = call [[FWD]], {{v[0-9]+}}, 0, [[INPUT]], {{v[0-9]+}}, [[INPUT]], 32
     // HOMESTEAD: jumpi [[OK]]
     function liveTry() external returns (uint256 r) {
         try DynamicTarget(address(new DynamicCallee())).dynBytes() {
@@ -75,15 +79,16 @@ contract DynamicReturnUnused {
     }
 
     // The static components of a mixed return stay accessible, so the output area covers both
-    // words and the first one is read back from it.
+    // words and the first one is read back from the input area it overlays.
     // HOMESTEAD-LABEL: fn @liveMixed()
-    // HOMESTEAD: [[BUFFER:v[0-9]+]] = alloc raw, exact, uninitialized, infallible, 64
-    // HOMESTEAD: [[LAST:v[0-9]+]] = add [[BUFFER]], 32
+    // HOMESTEAD: create
+    // HOMESTEAD: [[INPUT:v[0-9]+]] = slice_ptr
+    // HOMESTEAD: [[LAST:v[0-9]+]] = add [[INPUT]], 32
     // HOMESTEAD: mstore [[LAST]], 0
     // HOMESTEAD: [[GAS:v[0-9]+]] = gas
     // HOMESTEAD: [[FWD:v[0-9]+]] = sub [[GAS]], 50
-    // HOMESTEAD: call [[FWD]], {{v[0-9]+}}, 0, {{v[0-9]+}}, {{v[0-9]+}}, [[BUFFER]], 64
-    // HOMESTEAD: [[FIRST:v[0-9]+]] = add [[BUFFER]], 0
+    // HOMESTEAD: call [[FWD]], {{v[0-9]+}}, 0, [[INPUT]], {{v[0-9]+}}, [[INPUT]], 64
+    // HOMESTEAD: [[FIRST:v[0-9]+]] = add [[INPUT]], 0
     // HOMESTEAD: mload [[FIRST]]
     function liveMixed() external returns (uint256 r) {
         (uint256 v, ) = DynamicTarget(address(new DynamicCallee())).mixed();

--- a/tests/ui/codegen/lowering/run-call/external_call_evaluation_order.mir.stdout
+++ b/tests/ui/codegen/lowering/run-call/external_call_evaluation_order.mir.stdout
@@ -155,13 +155,19 @@ fn @callOptions() -> u256 [selector=0xec5f47fe, abi_params=[], abi_returns=[word
     v5 = abi_encode [word], selector 0xa4ba067e00000000000000000000000000000000000000000000000000000000, args v4
     v6 = slice_ptr v5
     v7 = slice_len v5
-    v8 = call v2, v0, v3, v6, v7, 0, 0
-    jumpi v8, bb2, bb1
-  bb1:
-    revert_returndata
+    v8 = extcodesize v0
+    v9 = iszero v8
+    jumpi v9, bb1, bb2
   bb2:
-    v9 = sload 1 !metadata(storage=slot(1))
-    ret v9
+    v10 = call v2, v0, v3, v6, v7, 0, 0
+    jumpi v10, bb4, bb3
+  bb3:
+    revert_returndata
+  bb4:
+    v11 = sload 1 !metadata(storage=slot(1))
+    ret v11
+  bb1:
+    revert 0, 0
 }
 
 fn @dirtyUint8(arg0: u256) -> u8 [pure] {

--- a/tests/ui/codegen/lowering/run-call/external_call_gas_evm_version.homestead.stdout
+++ b/tests/ui/codegen/lowering/run-call/external_call_gas_evm_version.homestead.stdout
@@ -105,25 +105,28 @@ fn @withReturn() -> u256 [selector=0x2149184b, abi_params=[], abi_returns=[word]
   bb1:
     revert_returndata
   bb2:
-    v7 = abi_encode [], selector 0x3fa4f24500000000000000000000000000000000000000000000000000000000
-    v8 = slice_ptr v7
-    v9 = slice_len v7
-    v10 = extcodesize v6
-    v11 = iszero v10
-    jumpi v11, bb3, bb4
+    v7 = fmp
+    v8 = add v7, 32
+    mstore v8, 0
+    v9 = abi_encode [], selector 0x3fa4f24500000000000000000000000000000000000000000000000000000000
+    v10 = slice_ptr v9
+    v11 = slice_len v9
+    v12 = extcodesize v6
+    v13 = iszero v12
+    jumpi v13, bb3, bb4
   bb4:
-    v12 = gas
-    v13 = sub v12, 50
-    v14 = call v13, v6, 0, v8, v9, v8, 32
-    jumpi v14, bb6, bb5
+    v14 = gas
+    v15 = sub v14, 50
+    v16 = call v15, v6, 0, v10, v11, v10, 32
+    jumpi v16, bb6, bb5
   bb5:
     revert_returndata
   bb6:
-    v15 = add v8, 0
-    v16 = mload v15
-    v17 = add v8, 0
+    v17 = add v10, 0
     v18 = mload v17
-    ret v18
+    v19 = add v10, 0
+    v20 = mload v19
+    ret v20
   bb3:
     revert 0, 0
 }
@@ -143,25 +146,28 @@ fn @withValue() -> u256 [selector=0xd6b69802, abi_params=[], abi_returns=[word]]
   bb1:
     revert_returndata
   bb2:
-    v7 = abi_encode [], selector 0x295b4e1700000000000000000000000000000000000000000000000000000000
-    v8 = slice_ptr v7
-    v9 = slice_len v7
-    v10 = extcodesize v6
-    v11 = iszero v10
-    jumpi v11, bb3, bb4
+    v7 = fmp
+    v8 = add v7, 32
+    mstore v8, 0
+    v9 = abi_encode [], selector 0x295b4e1700000000000000000000000000000000000000000000000000000000
+    v10 = slice_ptr v9
+    v11 = slice_len v9
+    v12 = extcodesize v6
+    v13 = iszero v12
+    jumpi v13, bb3, bb4
   bb4:
-    v12 = gas
-    v13 = sub v12, 0x235a
-    v14 = call v13, v6, 0, v8, v9, v8, 32
-    jumpi v14, bb6, bb5
+    v14 = gas
+    v15 = sub v14, 0x235a
+    v16 = call v15, v6, 0, v10, v11, v10, 32
+    jumpi v16, bb6, bb5
   bb5:
     revert_returndata
   bb6:
-    v15 = add v8, 0
-    v16 = mload v15
-    v17 = add v8, 0
+    v17 = add v10, 0
     v18 = mload v17
-    ret v18
+    v19 = add v10, 0
+    v20 = mload v19
+    ret v20
   bb3:
     revert 0, 0
 }
@@ -181,37 +187,38 @@ fn @twoReturns() -> u256 [selector=0xf7f4979a, abi_params=[], abi_returns=[word]
   bb1:
     revert_returndata
   bb2:
-    v7 = abi_encode [], selector 0xa8aa1b3100000000000000000000000000000000000000000000000000000000
-    v8 = slice_ptr v7
-    v9 = slice_len v7
-    v10 = add v8, 32
-    mstore v10, 0
-    v11 = extcodesize v6
-    v12 = iszero v11
-    jumpi v12, bb3, bb4
+    v7 = fmp
+    v8 = add v7, 64
+    mstore v8, 0
+    v9 = abi_encode [], selector 0xa8aa1b3100000000000000000000000000000000000000000000000000000000
+    v10 = slice_ptr v9
+    v11 = slice_len v9
+    v12 = extcodesize v6
+    v13 = iszero v12
+    jumpi v13, bb3, bb4
   bb4:
-    v13 = gas
-    v14 = sub v13, 50
-    v15 = call v14, v6, 0, v8, v9, v8, 64
-    jumpi v15, bb6, bb5
+    v14 = gas
+    v15 = sub v14, 50
+    v16 = call v15, v6, 0, v10, v11, v10, 64
+    jumpi v16, bb6, bb5
   bb5:
     revert_returndata
   bb6:
-    v16 = add v8, 0
-    v17 = mload v16
-    v18 = add v8, 32
-    v19 = mload v18
-    frame_store multi_return, word, 0, v8 !metadata(memory=scratch)
-    v20 = add v8, 0
-    v21 = mload v20
-    v22 = frame_load multi_return, word, 0 !metadata(memory=scratch)
-    v23 = add v22, 32
-    v24 = mload v23
-    v25 = add v21, v24
-    v26 = lt v25, v21
-    jumpi v26, bb7, bb8
+    v17 = add v10, 0
+    v18 = mload v17
+    v19 = add v10, 32
+    v20 = mload v19
+    frame_store multi_return, word, 0, v10 !metadata(memory=scratch)
+    v21 = add v10, 0
+    v22 = mload v21
+    v23 = frame_load multi_return, word, 0 !metadata(memory=scratch)
+    v24 = add v23, 32
+    v25 = mload v24
+    v26 = add v22, v25
+    v27 = lt v26, v22
+    jumpi v27, bb7, bb8
   bb8:
-    ret v25
+    ret v26
   bb7:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
@@ -235,85 +242,86 @@ fn @eightReturns() -> u256 [selector=0x67b0b213, abi_params=[], abi_returns=[wor
   bb1:
     revert_returndata
   bb2:
-    v7 = abi_encode [], selector 0xcb94343e00000000000000000000000000000000000000000000000000000000
-    v8 = slice_ptr v7
-    v9 = slice_len v7
-    v10 = add v8, 224
-    mstore v10, 0
-    v11 = extcodesize v6
-    v12 = iszero v11
-    jumpi v12, bb3, bb4
+    v7 = fmp
+    v8 = add v7, 256
+    mstore v8, 0
+    v9 = abi_encode [], selector 0xcb94343e00000000000000000000000000000000000000000000000000000000
+    v10 = slice_ptr v9
+    v11 = slice_len v9
+    v12 = extcodesize v6
+    v13 = iszero v12
+    jumpi v13, bb3, bb4
   bb4:
-    v13 = gas
-    v14 = sub v13, 50
-    v15 = call v14, v6, 0, v8, v9, v8, 256
-    jumpi v15, bb6, bb5
+    v14 = gas
+    v15 = sub v14, 50
+    v16 = call v15, v6, 0, v10, v11, v10, 256
+    jumpi v16, bb6, bb5
   bb5:
     revert_returndata
   bb6:
-    v16 = add v8, 0
-    v17 = mload v16
-    v18 = add v8, 32
-    v19 = mload v18
-    v20 = add v8, 64
-    v21 = mload v20
-    v22 = add v8, 96
-    v23 = mload v22
-    v24 = add v8, 128
-    v25 = mload v24
-    v26 = add v8, 160
-    v27 = mload v26
-    v28 = add v8, 192
-    v29 = mload v28
-    v30 = add v8, 224
-    v31 = mload v30
-    frame_store multi_return, word, 0, v8 !metadata(memory=scratch)
-    v32 = add v8, 0
-    v33 = mload v32
-    v34 = frame_load multi_return, word, 0 !metadata(memory=scratch)
-    v35 = add v34, 32
-    v36 = mload v35
-    v37 = add v34, 64
-    v38 = mload v37
-    v39 = add v34, 96
-    v40 = mload v39
-    v41 = add v34, 128
-    v42 = mload v41
-    v43 = add v34, 160
-    v44 = mload v43
-    v45 = add v34, 192
-    v46 = mload v45
-    v47 = add v34, 224
-    v48 = mload v47
-    v49 = add v33, v36
-    v50 = lt v49, v33
-    jumpi v50, bb7, bb8
+    v17 = add v10, 0
+    v18 = mload v17
+    v19 = add v10, 32
+    v20 = mload v19
+    v21 = add v10, 64
+    v22 = mload v21
+    v23 = add v10, 96
+    v24 = mload v23
+    v25 = add v10, 128
+    v26 = mload v25
+    v27 = add v10, 160
+    v28 = mload v27
+    v29 = add v10, 192
+    v30 = mload v29
+    v31 = add v10, 224
+    v32 = mload v31
+    frame_store multi_return, word, 0, v10 !metadata(memory=scratch)
+    v33 = add v10, 0
+    v34 = mload v33
+    v35 = frame_load multi_return, word, 0 !metadata(memory=scratch)
+    v36 = add v35, 32
+    v37 = mload v36
+    v38 = add v35, 64
+    v39 = mload v38
+    v40 = add v35, 96
+    v41 = mload v40
+    v42 = add v35, 128
+    v43 = mload v42
+    v44 = add v35, 160
+    v45 = mload v44
+    v46 = add v35, 192
+    v47 = mload v46
+    v48 = add v35, 224
+    v49 = mload v48
+    v50 = add v34, v37
+    v51 = lt v50, v34
+    jumpi v51, bb7, bb8
   bb8:
-    v51 = add v49, v38
-    v52 = lt v51, v49
-    jumpi v52, bb7, bb9
+    v52 = add v50, v39
+    v53 = lt v52, v50
+    jumpi v53, bb7, bb9
   bb9:
-    v53 = add v51, v40
-    v54 = lt v53, v51
-    jumpi v54, bb7, bb10
+    v54 = add v52, v41
+    v55 = lt v54, v52
+    jumpi v55, bb7, bb10
   bb10:
-    v55 = add v53, v42
-    v56 = lt v55, v53
-    jumpi v56, bb7, bb11
+    v56 = add v54, v43
+    v57 = lt v56, v54
+    jumpi v57, bb7, bb11
   bb11:
-    v57 = add v55, v44
-    v58 = lt v57, v55
-    jumpi v58, bb7, bb12
+    v58 = add v56, v45
+    v59 = lt v58, v56
+    jumpi v59, bb7, bb12
   bb12:
-    v59 = add v57, v46
-    v60 = lt v59, v57
-    jumpi v60, bb7, bb13
+    v60 = add v58, v47
+    v61 = lt v60, v58
+    jumpi v61, bb7, bb13
   bb13:
-    v61 = add v59, v48
-    v62 = lt v61, v59
-    jumpi v62, bb7, bb14
+    v62 = add v60, v49
+    v63 = lt v62, v60
+    jumpi v63, bb7, bb14
   bb14:
-    ret v61
+    ret v62
   bb7:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
@@ -340,39 +348,40 @@ fn @aggregate() -> u256 [selector=0xaf36778b, abi_params=[], abi_returns=[word]]
     v7 = alloc memorybytes, exact, uninitialized, infallible, 96
     set_memory_object_len memorybytes, v7, 64
     v8 = memory_object_data memorybytes, v7
-    v9 = abi_encode [], selector 0xf5e34bfa00000000000000000000000000000000000000000000000000000000
-    v10 = slice_ptr v9
-    v11 = slice_len v9
-    v12 = add v10, 32
-    mstore v12, 0
-    v13 = extcodesize v6
-    v14 = iszero v13
-    jumpi v14, bb3, bb4
+    v9 = fmp
+    v10 = add v9, 64
+    mstore v10, 0
+    v11 = abi_encode [], selector 0xf5e34bfa00000000000000000000000000000000000000000000000000000000
+    v12 = slice_ptr v11
+    v13 = slice_len v11
+    v14 = extcodesize v6
+    v15 = iszero v14
+    jumpi v15, bb3, bb4
   bb4:
-    v15 = gas
-    v16 = sub v15, 50
-    v17 = call v16, v6, 0, v10, v11, v10, 64
-    jumpi v17, bb6, bb5
+    v16 = gas
+    v17 = sub v16, 50
+    v18 = call v17, v6, 0, v12, v13, v12, 64
+    jumpi v18, bb6, bb5
   bb5:
     revert_returndata
   bb6:
-    mcopy v8, v10, 64
-    v18 = abi_decode [array<2, u256>], v7
-    v19 = lt 0, 2
-    v20 = iszero v19
-    jumpi v20, bb7, bb8
+    mcopy v8, v12, 64
+    v19 = abi_decode [array<2, u256>], v7
+    v20 = lt 0, 2
+    v21 = iszero v20
+    jumpi v21, bb7, bb8
   bb8:
-    v21 = memory_object_load_element memoryfixedarray<2, 1>, v18, 0
-    v22 = lt 1, 2
-    v23 = iszero v22
-    jumpi v23, bb7, bb9
+    v22 = memory_object_load_element memoryfixedarray<2, 1>, v19, 0
+    v23 = lt 1, 2
+    v24 = iszero v23
+    jumpi v24, bb7, bb9
   bb9:
-    v24 = memory_object_load_element memoryfixedarray<2, 1>, v18, 1
-    v25 = add v21, v24
-    v26 = lt v25, v21
-    jumpi v26, bb10, bb11
+    v25 = memory_object_load_element memoryfixedarray<2, 1>, v19, 1
+    v26 = add v22, v25
+    v27 = lt v26, v22
+    jumpi v27, bb10, bb11
   bb11:
-    ret v25
+    ret v26
   bb10:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)

--- a/tests/ui/codegen/lowering/run-call/external_call_gas_evm_version.homestead.stdout
+++ b/tests/ui/codegen/lowering/run-call/external_call_gas_evm_version.homestead.stdout
@@ -80,7 +80,7 @@ fn @noReturn() -> u256 [selector=0x31794254, abi_params=[], abi_returns=[word]] 
   bb4:
     v12 = gas
     v13 = sub v12, 50
-    v14 = call v13, v6, 0, v8, v9, 0, 0
+    v14 = call v13, v6, 0, v8, v9, v8, 0
     jumpi v14, bb6, bb5
   bb5:
     revert_returndata
@@ -114,14 +114,14 @@ fn @withReturn() -> u256 [selector=0x2149184b, abi_params=[], abi_returns=[word]
   bb4:
     v12 = gas
     v13 = sub v12, 50
-    v14 = call v13, v6, 0, v8, v9, 0, 32
+    v14 = call v13, v6, 0, v8, v9, v8, 32
     jumpi v14, bb6, bb5
   bb5:
     revert_returndata
   bb6:
-    v15 = add 0, 0
+    v15 = add v8, 0
     v16 = mload v15
-    v17 = add 0, 0
+    v17 = add v8, 0
     v18 = mload v17
     ret v18
   bb3:
@@ -152,14 +152,14 @@ fn @withValue() -> u256 [selector=0xd6b69802, abi_params=[], abi_returns=[word]]
   bb4:
     v12 = gas
     v13 = sub v12, 0x235a
-    v14 = call v13, v6, 0, v8, v9, 0, 32
+    v14 = call v13, v6, 0, v8, v9, v8, 32
     jumpi v14, bb6, bb5
   bb5:
     revert_returndata
   bb6:
-    v15 = add 0, 0
+    v15 = add v8, 0
     v16 = mload v15
-    v17 = add 0, 0
+    v17 = add v8, 0
     v18 = mload v17
     ret v18
   bb3:
@@ -184,35 +184,34 @@ fn @twoReturns() -> u256 [selector=0xf7f4979a, abi_params=[], abi_returns=[word]
     v7 = abi_encode [], selector 0xa8aa1b3100000000000000000000000000000000000000000000000000000000
     v8 = slice_ptr v7
     v9 = slice_len v7
-    v10 = alloc raw, exact, uninitialized, infallible, 64
-    v11 = add v10, 32
-    mstore v11, 0
-    v12 = extcodesize v6
-    v13 = iszero v12
-    jumpi v13, bb3, bb4
+    v10 = add v8, 32
+    mstore v10, 0
+    v11 = extcodesize v6
+    v12 = iszero v11
+    jumpi v12, bb3, bb4
   bb4:
-    v14 = gas
-    v15 = sub v14, 50
-    v16 = call v15, v6, 0, v8, v9, v10, 64
-    jumpi v16, bb6, bb5
+    v13 = gas
+    v14 = sub v13, 50
+    v15 = call v14, v6, 0, v8, v9, v8, 64
+    jumpi v15, bb6, bb5
   bb5:
     revert_returndata
   bb6:
-    v17 = add v10, 0
-    v18 = mload v17
-    v19 = add v10, 32
-    v20 = mload v19
-    frame_store multi_return, word, 0, v10 !metadata(memory=scratch)
-    v21 = add v10, 0
-    v22 = mload v21
-    v23 = frame_load multi_return, word, 0 !metadata(memory=scratch)
-    v24 = add v23, 32
-    v25 = mload v24
-    v26 = add v22, v25
-    v27 = lt v26, v22
-    jumpi v27, bb7, bb8
+    v16 = add v8, 0
+    v17 = mload v16
+    v18 = add v8, 32
+    v19 = mload v18
+    frame_store multi_return, word, 0, v8 !metadata(memory=scratch)
+    v20 = add v8, 0
+    v21 = mload v20
+    v22 = frame_load multi_return, word, 0 !metadata(memory=scratch)
+    v23 = add v22, 32
+    v24 = mload v23
+    v25 = add v21, v24
+    v26 = lt v25, v21
+    jumpi v26, bb7, bb8
   bb8:
-    ret v26
+    ret v25
   bb7:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
@@ -239,83 +238,82 @@ fn @eightReturns() -> u256 [selector=0x67b0b213, abi_params=[], abi_returns=[wor
     v7 = abi_encode [], selector 0xcb94343e00000000000000000000000000000000000000000000000000000000
     v8 = slice_ptr v7
     v9 = slice_len v7
-    v10 = alloc raw, exact, uninitialized, infallible, 256
-    v11 = add v10, 224
-    mstore v11, 0
-    v12 = extcodesize v6
-    v13 = iszero v12
-    jumpi v13, bb3, bb4
+    v10 = add v8, 224
+    mstore v10, 0
+    v11 = extcodesize v6
+    v12 = iszero v11
+    jumpi v12, bb3, bb4
   bb4:
-    v14 = gas
-    v15 = sub v14, 50
-    v16 = call v15, v6, 0, v8, v9, v10, 256
-    jumpi v16, bb6, bb5
+    v13 = gas
+    v14 = sub v13, 50
+    v15 = call v14, v6, 0, v8, v9, v8, 256
+    jumpi v15, bb6, bb5
   bb5:
     revert_returndata
   bb6:
-    v17 = add v10, 0
-    v18 = mload v17
-    v19 = add v10, 32
-    v20 = mload v19
-    v21 = add v10, 64
-    v22 = mload v21
-    v23 = add v10, 96
-    v24 = mload v23
-    v25 = add v10, 128
-    v26 = mload v25
-    v27 = add v10, 160
-    v28 = mload v27
-    v29 = add v10, 192
-    v30 = mload v29
-    v31 = add v10, 224
-    v32 = mload v31
-    frame_store multi_return, word, 0, v10 !metadata(memory=scratch)
-    v33 = add v10, 0
-    v34 = mload v33
-    v35 = frame_load multi_return, word, 0 !metadata(memory=scratch)
-    v36 = add v35, 32
-    v37 = mload v36
-    v38 = add v35, 64
-    v39 = mload v38
-    v40 = add v35, 96
-    v41 = mload v40
-    v42 = add v35, 128
-    v43 = mload v42
-    v44 = add v35, 160
-    v45 = mload v44
-    v46 = add v35, 192
-    v47 = mload v46
-    v48 = add v35, 224
-    v49 = mload v48
-    v50 = add v34, v37
-    v51 = lt v50, v34
-    jumpi v51, bb7, bb8
+    v16 = add v8, 0
+    v17 = mload v16
+    v18 = add v8, 32
+    v19 = mload v18
+    v20 = add v8, 64
+    v21 = mload v20
+    v22 = add v8, 96
+    v23 = mload v22
+    v24 = add v8, 128
+    v25 = mload v24
+    v26 = add v8, 160
+    v27 = mload v26
+    v28 = add v8, 192
+    v29 = mload v28
+    v30 = add v8, 224
+    v31 = mload v30
+    frame_store multi_return, word, 0, v8 !metadata(memory=scratch)
+    v32 = add v8, 0
+    v33 = mload v32
+    v34 = frame_load multi_return, word, 0 !metadata(memory=scratch)
+    v35 = add v34, 32
+    v36 = mload v35
+    v37 = add v34, 64
+    v38 = mload v37
+    v39 = add v34, 96
+    v40 = mload v39
+    v41 = add v34, 128
+    v42 = mload v41
+    v43 = add v34, 160
+    v44 = mload v43
+    v45 = add v34, 192
+    v46 = mload v45
+    v47 = add v34, 224
+    v48 = mload v47
+    v49 = add v33, v36
+    v50 = lt v49, v33
+    jumpi v50, bb7, bb8
   bb8:
-    v52 = add v50, v39
-    v53 = lt v52, v50
-    jumpi v53, bb7, bb9
+    v51 = add v49, v38
+    v52 = lt v51, v49
+    jumpi v52, bb7, bb9
   bb9:
-    v54 = add v52, v41
-    v55 = lt v54, v52
-    jumpi v55, bb7, bb10
+    v53 = add v51, v40
+    v54 = lt v53, v51
+    jumpi v54, bb7, bb10
   bb10:
-    v56 = add v54, v43
-    v57 = lt v56, v54
-    jumpi v57, bb7, bb11
+    v55 = add v53, v42
+    v56 = lt v55, v53
+    jumpi v56, bb7, bb11
   bb11:
-    v58 = add v56, v45
-    v59 = lt v58, v56
-    jumpi v59, bb7, bb12
+    v57 = add v55, v44
+    v58 = lt v57, v55
+    jumpi v58, bb7, bb12
   bb12:
-    v60 = add v58, v47
-    v61 = lt v60, v58
-    jumpi v61, bb7, bb13
+    v59 = add v57, v46
+    v60 = lt v59, v57
+    jumpi v60, bb7, bb13
   bb13:
-    v62 = add v60, v49
-    v63 = lt v62, v60
-    jumpi v63, bb7, bb14
+    v61 = add v59, v48
+    v62 = lt v61, v59
+    jumpi v62, bb7, bb14
   bb14:
-    ret v62
+    ret v61
   bb7:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
@@ -339,39 +337,42 @@ fn @aggregate() -> u256 [selector=0xaf36778b, abi_params=[], abi_returns=[word]]
   bb1:
     revert_returndata
   bb2:
-    v7 = abi_encode [], selector 0xf5e34bfa00000000000000000000000000000000000000000000000000000000
-    v8 = slice_ptr v7
-    v9 = slice_len v7
-    v10 = alloc raw, exact, uninitialized, infallible, 64
-    v11 = add v10, 32
-    mstore v11, 0
-    v12 = extcodesize v6
-    v13 = iszero v12
-    jumpi v13, bb3, bb4
+    v7 = alloc memorybytes, exact, uninitialized, infallible, 96
+    set_memory_object_len memorybytes, v7, 64
+    v8 = memory_object_data memorybytes, v7
+    v9 = abi_encode [], selector 0xf5e34bfa00000000000000000000000000000000000000000000000000000000
+    v10 = slice_ptr v9
+    v11 = slice_len v9
+    v12 = add v10, 32
+    mstore v12, 0
+    v13 = extcodesize v6
+    v14 = iszero v13
+    jumpi v14, bb3, bb4
   bb4:
-    v14 = gas
-    v15 = sub v14, 50
-    v16 = call v15, v6, 0, v8, v9, v10, 64
-    jumpi v16, bb6, bb5
+    v15 = gas
+    v16 = sub v15, 50
+    v17 = call v16, v6, 0, v10, v11, v10, 64
+    jumpi v17, bb6, bb5
   bb5:
     revert_returndata
   bb6:
-    v17 = abi_decode [array<2, u256>], v10
-    v18 = lt 0, 2
-    v19 = iszero v18
-    jumpi v19, bb7, bb8
+    mcopy v8, v10, 64
+    v18 = abi_decode [array<2, u256>], v7
+    v19 = lt 0, 2
+    v20 = iszero v19
+    jumpi v20, bb7, bb8
   bb8:
-    v20 = memory_object_load_element memoryfixedarray<2, 1>, v17, 0
-    v21 = lt 1, 2
-    v22 = iszero v21
-    jumpi v22, bb7, bb9
+    v21 = memory_object_load_element memoryfixedarray<2, 1>, v18, 0
+    v22 = lt 1, 2
+    v23 = iszero v22
+    jumpi v23, bb7, bb9
   bb9:
-    v23 = memory_object_load_element memoryfixedarray<2, 1>, v17, 1
-    v24 = add v20, v23
-    v25 = lt v24, v20
-    jumpi v25, bb10, bb11
+    v24 = memory_object_load_element memoryfixedarray<2, 1>, v18, 1
+    v25 = add v21, v24
+    v26 = lt v25, v21
+    jumpi v26, bb10, bb11
   bb11:
-    ret v24
+    ret v25
   bb10:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)

--- a/tests/ui/codegen/lowering/run-call/external_call_gas_evm_version.homestead.stdout
+++ b/tests/ui/codegen/lowering/run-call/external_call_gas_evm_version.homestead.stdout
@@ -1,0 +1,255 @@
+// === ROOT/tests/ui/codegen/lowering/run-call/external_call_gas_evm_version.sol:CallGasCallee ===
+@module CallGasCallee
+fn @noop() [selector=0x5dfc2e4a, abi_params=[], abi_returns=[]] {
+  bb0:
+    stop
+}
+
+fn @value() -> u256 [selector=0x3fa4f245, pure, abi_params=[], abi_returns=[word]] {
+  bb0:
+    ret 42
+}
+
+fn @paid() -> u256 [selector=0x295b4e17, payable, abi_params=[], abi_returns=[word]] {
+  bb0:
+    ret 7
+}
+
+fn @pair() -> (u256, u256) [selector=0xa8aa1b31, pure, abi_params=[], abi_returns=[word, word]] {
+  bb0:
+    ret 1, 2
+}
+
+fn @receive() [receive, payable] {
+  bb0:
+    stop
+}
+
+// === ROOT/tests/ui/codegen/lowering/run-call/external_call_gas_evm_version.sol:CallGasCalls ===
+@module CallGasCalls
+data:
+  CallGasCallee_initcode_0: hex"34600f5760cc8060156000396000f35b60006000fe3660075760cb565b6000357c010000000000000000000000000000000000000000000000000000000090048063295b4e171460565780633fa4f24514605a5780635dfc2e4a14605e578063a8aa1b31146062576066565b6091565b6076565b606b565b60a3565b600080fe5b34607157005b600080fe5b34608c57602a6080526020608001608090036080f35b600080fe5b60076080526020608001608090036080f35b60c06040523460c657600160805260206080016002815260209001608090036080f35b600080fe5b"
+
+fn @noReturn() -> u256 [selector=0x31794254, abi_params=[], abi_returns=[word]] {
+  bb0:
+    v0 = abi_encode []
+    v1 = not 31
+    v2 = and 256, v1
+    v3 = alloc raw, exact, uninitialized, infallible, v2
+    data_copy CallGasCallee_initcode_0, v3, 225
+    v4 = slice_ptr v0
+    v5 = add v3, 225
+    mcopy v5, v4, 0 !metadata(memory=heap)
+    v6 = create 0, v3, 225
+    jumpi v6, bb2, bb1
+  bb1:
+    revert_returndata
+  bb2:
+    v7 = abi_encode [], selector 0x5dfc2e4a00000000000000000000000000000000000000000000000000000000
+    v8 = slice_ptr v7
+    v9 = slice_len v7
+    v10 = extcodesize v6
+    v11 = iszero v10
+    jumpi v11, bb3, bb4
+  bb4:
+    v12 = gas
+    v13 = sub v12, 50
+    v14 = call v13, v6, 0, v8, v9, 0, 0
+    jumpi v14, bb6, bb5
+  bb5:
+    revert_returndata
+  bb6:
+    ret 1
+  bb3:
+    revert 0, 0
+}
+
+fn @withReturn() -> u256 [selector=0x2149184b, abi_params=[], abi_returns=[word]] {
+  bb0:
+    v0 = abi_encode []
+    v1 = not 31
+    v2 = and 256, v1
+    v3 = alloc raw, exact, uninitialized, infallible, v2
+    data_copy CallGasCallee_initcode_0, v3, 225
+    v4 = slice_ptr v0
+    v5 = add v3, 225
+    mcopy v5, v4, 0 !metadata(memory=heap)
+    v6 = create 0, v3, 225
+    jumpi v6, bb2, bb1
+  bb1:
+    revert_returndata
+  bb2:
+    v7 = abi_encode [], selector 0x3fa4f24500000000000000000000000000000000000000000000000000000000
+    v8 = slice_ptr v7
+    v9 = slice_len v7
+    v10 = extcodesize v6
+    v11 = iszero v10
+    jumpi v11, bb3, bb4
+  bb4:
+    v12 = gas
+    v13 = sub v12, 50
+    v14 = call v13, v6, 0, v8, v9, 0, 32
+    jumpi v14, bb6, bb5
+  bb5:
+    revert_returndata
+  bb6:
+    v15 = add 0, 0
+    v16 = mload v15
+    v17 = add 0, 0
+    v18 = mload v17
+    ret v18
+  bb3:
+    revert 0, 0
+}
+
+fn @withValue() -> u256 [selector=0xd6b69802, abi_params=[], abi_returns=[word]] {
+  bb0:
+    v0 = abi_encode []
+    v1 = not 31
+    v2 = and 256, v1
+    v3 = alloc raw, exact, uninitialized, infallible, v2
+    data_copy CallGasCallee_initcode_0, v3, 225
+    v4 = slice_ptr v0
+    v5 = add v3, 225
+    mcopy v5, v4, 0 !metadata(memory=heap)
+    v6 = create 0, v3, 225
+    jumpi v6, bb2, bb1
+  bb1:
+    revert_returndata
+  bb2:
+    v7 = abi_encode [], selector 0x295b4e1700000000000000000000000000000000000000000000000000000000
+    v8 = slice_ptr v7
+    v9 = slice_len v7
+    v10 = extcodesize v6
+    v11 = iszero v10
+    jumpi v11, bb3, bb4
+  bb4:
+    v12 = gas
+    v13 = sub v12, 0x235a
+    v14 = call v13, v6, 0, v8, v9, 0, 32
+    jumpi v14, bb6, bb5
+  bb5:
+    revert_returndata
+  bb6:
+    v15 = add 0, 0
+    v16 = mload v15
+    v17 = add 0, 0
+    v18 = mload v17
+    ret v18
+  bb3:
+    revert 0, 0
+}
+
+fn @twoReturns() -> u256 [selector=0xf7f4979a, abi_params=[], abi_returns=[word]] {
+  bb0:
+    v0 = abi_encode []
+    v1 = not 31
+    v2 = and 256, v1
+    v3 = alloc raw, exact, uninitialized, infallible, v2
+    data_copy CallGasCallee_initcode_0, v3, 225
+    v4 = slice_ptr v0
+    v5 = add v3, 225
+    mcopy v5, v4, 0 !metadata(memory=heap)
+    v6 = create 0, v3, 225
+    jumpi v6, bb2, bb1
+  bb1:
+    revert_returndata
+  bb2:
+    v7 = abi_encode [], selector 0xa8aa1b3100000000000000000000000000000000000000000000000000000000
+    v8 = slice_ptr v7
+    v9 = slice_len v7
+    v10 = alloc raw, exact, uninitialized, infallible, 64
+    v11 = add v10, 32
+    mstore v11, 0
+    v12 = extcodesize v6
+    v13 = iszero v12
+    jumpi v13, bb3, bb4
+  bb4:
+    v14 = gas
+    v15 = sub v14, 50
+    v16 = call v15, v6, 0, v8, v9, v10, 64
+    jumpi v16, bb6, bb5
+  bb5:
+    revert_returndata
+  bb6:
+    v17 = add v10, 0
+    v18 = mload v17
+    v19 = add v10, 32
+    v20 = mload v19
+    frame_store multi_return, word, 0, v10 !metadata(memory=scratch)
+    v21 = add v10, 0
+    v22 = mload v21
+    v23 = frame_load multi_return, word, 0 !metadata(memory=scratch)
+    v24 = add v23, 32
+    v25 = mload v24
+    v26 = add v22, v25
+    v27 = lt v26, v22
+    jumpi v27, bb7, bb8
+  bb8:
+    ret v26
+  bb7:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 17 !metadata(memory=scratch)
+    revert 0, 36
+  bb3:
+    revert 0, 0
+}
+
+fn @bare() -> u256 [selector=0x8095dd0b, abi_params=[], abi_returns=[word]] {
+  bb0:
+    v0 = abi_encode []
+    v1 = not 31
+    v2 = and 256, v1
+    v3 = alloc raw, exact, uninitialized, infallible, v2
+    data_copy CallGasCallee_initcode_0, v3, 225
+    v4 = slice_ptr v0
+    v5 = add v3, 225
+    mcopy v5, v4, 0 !metadata(memory=heap)
+    v6 = create 0, v3, 225
+    jumpi v6, bb2, bb1
+  bb1:
+    revert_returndata
+  bb2:
+    v7 = abi_encode [], object, selector 0x5dfc2e4a00000000000000000000000000000000000000000000000000000000
+    v8 = memory_object_data memorybytes, v7
+    v9 = memory_object_len memorybytes, v7
+    v10 = gas
+    v11 = sub v10, 0x61da
+    v12 = call v11, v6, 0, v8, v9, 0, 0
+    jumpi v12, bb3, bb4
+  bb4:
+    jump bb5
+  bb3:
+    jump bb5
+  bb5:
+    v13 = phi [bb3: 1], [bb4: 0]
+    ret v13
+}
+
+fn @sendZero() -> u256 [selector=0xe857d88b, abi_params=[], abi_returns=[word]] {
+  bb0:
+    v0 = abi_encode []
+    v1 = not 31
+    v2 = and 256, v1
+    v3 = alloc raw, exact, uninitialized, infallible, v2
+    data_copy CallGasCallee_initcode_0, v3, 225
+    v4 = slice_ptr v0
+    v5 = add v3, 225
+    mcopy v5, v4, 0 !metadata(memory=heap)
+    v6 = create 0, v3, 225
+    jumpi v6, bb2, bb1
+  bb1:
+    revert_returndata
+  bb2:
+    v7 = iszero 0
+    v8 = select v7, 0x8fc, 0
+    v9 = call v8, v6, 0, 0, 0, 0, 0
+    jumpi v9, bb3, bb4
+  bb4:
+    jump bb5
+  bb3:
+    jump bb5
+  bb5:
+    v10 = phi [bb3: 1], [bb4: 0]
+    ret v10
+}

--- a/tests/ui/codegen/lowering/run-call/external_call_gas_evm_version.homestead.stdout
+++ b/tests/ui/codegen/lowering/run-call/external_call_gas_evm_version.homestead.stdout
@@ -20,6 +20,32 @@ fn @pair() -> (u256, u256) [selector=0xa8aa1b31, pure, abi_params=[], abi_return
     ret 1, 2
 }
 
+fn @eight() -> (u256, u256, u256, u256, u256, u256, u256, u256) [selector=0xcb94343e, pure, abi_params=[], abi_returns=[word, word, word, word, word, word, word, word]] {
+  bb0:
+    ret 1, 2, 3, 4, 5, 6, 7, 8
+}
+
+fn @agg() -> memoryfixedarray [selector=0xf5e34bfa, pure, abi_params=[], abi_returns=[array<2, word>]] {
+  bb0:
+    v0 = alloc memoryfixedarray<2, 1>, exact, uninitialized, infallible, 64
+    memory_zero v0, 64
+    v1 = lt 0, 2
+    v2 = iszero v1
+    jumpi v2, bb1, bb2
+  bb2:
+    memory_object_store_element memoryfixedarray<2, 1>, v0, 0, 11
+    v3 = lt 1, 2
+    v4 = iszero v3
+    jumpi v4, bb1, bb3
+  bb3:
+    memory_object_store_element memoryfixedarray<2, 1>, v0, 1, 22
+    ret v0
+  bb1:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 50 !metadata(memory=scratch)
+    revert 0, 36
+}
+
 fn @receive() [receive, payable] {
   bb0:
     stop
@@ -28,19 +54,19 @@ fn @receive() [receive, payable] {
 // === ROOT/tests/ui/codegen/lowering/run-call/external_call_gas_evm_version.sol:CallGasCalls ===
 @module CallGasCalls
 data:
-  CallGasCallee_initcode_0: hex"34600f5760cc8060156000396000f35b60006000fe3660075760cb565b6000357c010000000000000000000000000000000000000000000000000000000090048063295b4e171460565780633fa4f24514605a5780635dfc2e4a14605e578063a8aa1b31146062576066565b6091565b6076565b606b565b60a3565b600080fe5b34607157005b600080fe5b34608c57602a6080526020608001608090036080f35b600080fe5b60076080526020608001608090036080f35b60c06040523460c657600160805260206080016002815260209001608090036080f35b600080fe5b"
+  CallGasCallee_initcode_0: hex"346010576102038060166000396000f35b60006000fe36600857610202565b6000357c010000000000000000000000000000000000000000000000000000000090048063295b4e1714606b5780633fa4f24514606f5780635dfc2e4a146073578063a8aa1b31146077578063cb94343e14607b578063f5e34bfa14607f576084565b60af565b6094565b6089565b60c1565b60e9565b610143565b600080fe5b34608f57005b600080fe5b3460aa57602a6080526020608001608090036080f35b600080fe5b60076080526020608001608090036080f35b60c06040523460e457600160805260206080016002815260209001608090036080f35b600080fe5b6101806040523461013e57600160805260206080016002815260209001600381526020900160048152602090016005815260209001600681526020900160078152602090016008815260209001608090036080f35b600080fe5b610120604052346101fd576040518060c0528060c05260408101604052604036828060c05237600260001015156101a4575b7f4e487b7100000000000000000000000000000000000000000000000000000000600052603260045260246000fe5b8060c052600b81526002600110156101755760208101601681525060005b8060e05260028110156101ed576020818060e0520282015160208202608001526001810190506101c2565b6040608001915050608090036080f35b600080fe5b"
 
 fn @noReturn() -> u256 [selector=0x31794254, abi_params=[], abi_returns=[word]] {
   bb0:
     v0 = abi_encode []
     v1 = not 31
-    v2 = and 256, v1
+    v2 = and 568, v1
     v3 = alloc raw, exact, uninitialized, infallible, v2
-    data_copy CallGasCallee_initcode_0, v3, 225
+    data_copy CallGasCallee_initcode_0, v3, 537
     v4 = slice_ptr v0
-    v5 = add v3, 225
+    v5 = add v3, 537
     mcopy v5, v4, 0 !metadata(memory=heap)
-    v6 = create 0, v3, 225
+    v6 = create 0, v3, 537
     jumpi v6, bb2, bb1
   bb1:
     revert_returndata
@@ -68,13 +94,13 @@ fn @withReturn() -> u256 [selector=0x2149184b, abi_params=[], abi_returns=[word]
   bb0:
     v0 = abi_encode []
     v1 = not 31
-    v2 = and 256, v1
+    v2 = and 568, v1
     v3 = alloc raw, exact, uninitialized, infallible, v2
-    data_copy CallGasCallee_initcode_0, v3, 225
+    data_copy CallGasCallee_initcode_0, v3, 537
     v4 = slice_ptr v0
-    v5 = add v3, 225
+    v5 = add v3, 537
     mcopy v5, v4, 0 !metadata(memory=heap)
-    v6 = create 0, v3, 225
+    v6 = create 0, v3, 537
     jumpi v6, bb2, bb1
   bb1:
     revert_returndata
@@ -106,13 +132,13 @@ fn @withValue() -> u256 [selector=0xd6b69802, abi_params=[], abi_returns=[word]]
   bb0:
     v0 = abi_encode []
     v1 = not 31
-    v2 = and 256, v1
+    v2 = and 568, v1
     v3 = alloc raw, exact, uninitialized, infallible, v2
-    data_copy CallGasCallee_initcode_0, v3, 225
+    data_copy CallGasCallee_initcode_0, v3, 537
     v4 = slice_ptr v0
-    v5 = add v3, 225
+    v5 = add v3, 537
     mcopy v5, v4, 0 !metadata(memory=heap)
-    v6 = create 0, v3, 225
+    v6 = create 0, v3, 537
     jumpi v6, bb2, bb1
   bb1:
     revert_returndata
@@ -144,13 +170,13 @@ fn @twoReturns() -> u256 [selector=0xf7f4979a, abi_params=[], abi_returns=[word]
   bb0:
     v0 = abi_encode []
     v1 = not 31
-    v2 = and 256, v1
+    v2 = and 568, v1
     v3 = alloc raw, exact, uninitialized, infallible, v2
-    data_copy CallGasCallee_initcode_0, v3, 225
+    data_copy CallGasCallee_initcode_0, v3, 537
     v4 = slice_ptr v0
-    v5 = add v3, 225
+    v5 = add v3, 537
     mcopy v5, v4, 0 !metadata(memory=heap)
-    v6 = create 0, v3, 225
+    v6 = create 0, v3, 537
     jumpi v6, bb2, bb1
   bb1:
     revert_returndata
@@ -195,17 +221,180 @@ fn @twoReturns() -> u256 [selector=0xf7f4979a, abi_params=[], abi_returns=[word]
     revert 0, 0
 }
 
+fn @eightReturns() -> u256 [selector=0x67b0b213, abi_params=[], abi_returns=[word]] {
+  bb0:
+    v0 = abi_encode []
+    v1 = not 31
+    v2 = and 568, v1
+    v3 = alloc raw, exact, uninitialized, infallible, v2
+    data_copy CallGasCallee_initcode_0, v3, 537
+    v4 = slice_ptr v0
+    v5 = add v3, 537
+    mcopy v5, v4, 0 !metadata(memory=heap)
+    v6 = create 0, v3, 537
+    jumpi v6, bb2, bb1
+  bb1:
+    revert_returndata
+  bb2:
+    v7 = abi_encode [], selector 0xcb94343e00000000000000000000000000000000000000000000000000000000
+    v8 = slice_ptr v7
+    v9 = slice_len v7
+    v10 = alloc raw, exact, uninitialized, infallible, 256
+    v11 = add v10, 224
+    mstore v11, 0
+    v12 = extcodesize v6
+    v13 = iszero v12
+    jumpi v13, bb3, bb4
+  bb4:
+    v14 = gas
+    v15 = sub v14, 50
+    v16 = call v15, v6, 0, v8, v9, v10, 256
+    jumpi v16, bb6, bb5
+  bb5:
+    revert_returndata
+  bb6:
+    v17 = add v10, 0
+    v18 = mload v17
+    v19 = add v10, 32
+    v20 = mload v19
+    v21 = add v10, 64
+    v22 = mload v21
+    v23 = add v10, 96
+    v24 = mload v23
+    v25 = add v10, 128
+    v26 = mload v25
+    v27 = add v10, 160
+    v28 = mload v27
+    v29 = add v10, 192
+    v30 = mload v29
+    v31 = add v10, 224
+    v32 = mload v31
+    frame_store multi_return, word, 0, v10 !metadata(memory=scratch)
+    v33 = add v10, 0
+    v34 = mload v33
+    v35 = frame_load multi_return, word, 0 !metadata(memory=scratch)
+    v36 = add v35, 32
+    v37 = mload v36
+    v38 = add v35, 64
+    v39 = mload v38
+    v40 = add v35, 96
+    v41 = mload v40
+    v42 = add v35, 128
+    v43 = mload v42
+    v44 = add v35, 160
+    v45 = mload v44
+    v46 = add v35, 192
+    v47 = mload v46
+    v48 = add v35, 224
+    v49 = mload v48
+    v50 = add v34, v37
+    v51 = lt v50, v34
+    jumpi v51, bb7, bb8
+  bb8:
+    v52 = add v50, v39
+    v53 = lt v52, v50
+    jumpi v53, bb7, bb9
+  bb9:
+    v54 = add v52, v41
+    v55 = lt v54, v52
+    jumpi v55, bb7, bb10
+  bb10:
+    v56 = add v54, v43
+    v57 = lt v56, v54
+    jumpi v57, bb7, bb11
+  bb11:
+    v58 = add v56, v45
+    v59 = lt v58, v56
+    jumpi v59, bb7, bb12
+  bb12:
+    v60 = add v58, v47
+    v61 = lt v60, v58
+    jumpi v61, bb7, bb13
+  bb13:
+    v62 = add v60, v49
+    v63 = lt v62, v60
+    jumpi v63, bb7, bb14
+  bb14:
+    ret v62
+  bb7:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 17 !metadata(memory=scratch)
+    revert 0, 36
+  bb3:
+    revert 0, 0
+}
+
+fn @aggregate() -> u256 [selector=0xaf36778b, abi_params=[], abi_returns=[word]] {
+  bb0:
+    v0 = abi_encode []
+    v1 = not 31
+    v2 = and 568, v1
+    v3 = alloc raw, exact, uninitialized, infallible, v2
+    data_copy CallGasCallee_initcode_0, v3, 537
+    v4 = slice_ptr v0
+    v5 = add v3, 537
+    mcopy v5, v4, 0 !metadata(memory=heap)
+    v6 = create 0, v3, 537
+    jumpi v6, bb2, bb1
+  bb1:
+    revert_returndata
+  bb2:
+    v7 = abi_encode [], selector 0xf5e34bfa00000000000000000000000000000000000000000000000000000000
+    v8 = slice_ptr v7
+    v9 = slice_len v7
+    v10 = alloc raw, exact, uninitialized, infallible, 64
+    v11 = add v10, 32
+    mstore v11, 0
+    v12 = extcodesize v6
+    v13 = iszero v12
+    jumpi v13, bb3, bb4
+  bb4:
+    v14 = gas
+    v15 = sub v14, 50
+    v16 = call v15, v6, 0, v8, v9, v10, 64
+    jumpi v16, bb6, bb5
+  bb5:
+    revert_returndata
+  bb6:
+    v17 = abi_decode [array<2, u256>], v10
+    v18 = lt 0, 2
+    v19 = iszero v18
+    jumpi v19, bb7, bb8
+  bb8:
+    v20 = memory_object_load_element memoryfixedarray<2, 1>, v17, 0
+    v21 = lt 1, 2
+    v22 = iszero v21
+    jumpi v22, bb7, bb9
+  bb9:
+    v23 = memory_object_load_element memoryfixedarray<2, 1>, v17, 1
+    v24 = add v20, v23
+    v25 = lt v24, v20
+    jumpi v25, bb10, bb11
+  bb11:
+    ret v24
+  bb10:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 17 !metadata(memory=scratch)
+    revert 0, 36
+  bb7:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 50 !metadata(memory=scratch)
+    revert 0, 36
+  bb3:
+    revert 0, 0
+}
+
 fn @bare() -> u256 [selector=0x8095dd0b, abi_params=[], abi_returns=[word]] {
   bb0:
     v0 = abi_encode []
     v1 = not 31
-    v2 = and 256, v1
+    v2 = and 568, v1
     v3 = alloc raw, exact, uninitialized, infallible, v2
-    data_copy CallGasCallee_initcode_0, v3, 225
+    data_copy CallGasCallee_initcode_0, v3, 537
     v4 = slice_ptr v0
-    v5 = add v3, 225
+    v5 = add v3, 537
     mcopy v5, v4, 0 !metadata(memory=heap)
-    v6 = create 0, v3, 225
+    v6 = create 0, v3, 537
     jumpi v6, bb2, bb1
   bb1:
     revert_returndata
@@ -230,13 +419,13 @@ fn @sendZero() -> u256 [selector=0xe857d88b, abi_params=[], abi_returns=[word]] 
   bb0:
     v0 = abi_encode []
     v1 = not 31
-    v2 = and 256, v1
+    v2 = and 568, v1
     v3 = alloc raw, exact, uninitialized, infallible, v2
-    data_copy CallGasCallee_initcode_0, v3, 225
+    data_copy CallGasCallee_initcode_0, v3, 537
     v4 = slice_ptr v0
-    v5 = add v3, 225
+    v5 = add v3, 537
     mcopy v5, v4, 0 !metadata(memory=heap)
-    v6 = create 0, v3, 225
+    v6 = create 0, v3, 537
     jumpi v6, bb2, bb1
   bb1:
     revert_returndata

--- a/tests/ui/codegen/lowering/run-call/external_call_gas_evm_version.sol
+++ b/tests/ui/codegen/lowering/run-call/external_call_gas_evm_version.sol
@@ -1,0 +1,120 @@
+//@ revisions: homestead tangerineWhistle
+//@[homestead] compile-flags: -O none --evm-version homestead -Zdump=mir
+//@[homestead] filecheck: --check-prefix=HOMESTEAD
+//@[tangerineWhistle] compile-flags: -O none --evm-version tangerineWhistle -Zdump=mir
+//@[tangerineWhistle] filecheck: --check-prefix=TANGERINE
+//@[homestead,tangerineWhistle] run-call: CallGasCalls::noReturn => 1
+//@[homestead,tangerineWhistle] run-call: CallGasCalls::withReturn => 42
+//@[homestead,tangerineWhistle] run-call: CallGasCalls::withValue => 7
+//@[homestead,tangerineWhistle] run-call: CallGasCalls::twoReturns => 3
+//@[homestead,tangerineWhistle] run-call: CallGasCalls::bare => 1
+//@[homestead,tangerineWhistle] run-call: CallGasCalls::sendZero => 1
+
+interface CallGasTarget {
+    function noop() external;
+    function value() external returns (uint256);
+    function paid() external payable returns (uint256);
+    function pair() external returns (uint256, uint256);
+}
+
+contract CallGasCallee {
+    function noop() external {}
+
+    function value() external pure returns (uint256) {
+        return 42;
+    }
+
+    function paid() external payable returns (uint256) {
+        return 7;
+    }
+
+    function pair() external pure returns (uint256, uint256) {
+        return (1, 2);
+    }
+
+    receive() external payable {}
+}
+
+contract CallGasCalls {
+    // Before EIP-150 a gas argument above the gas left aborts the call, so the call withholds
+    // its own base cost instead of forwarding `gas()`.
+    // HOMESTEAD-LABEL: fn @noReturn
+    // HOMESTEAD: [[GAS:v[0-9]+]] = gas
+    // HOMESTEAD: [[FWD:v[0-9]+]] = sub [[GAS]], 50
+    // HOMESTEAD: call [[FWD]],
+    // TANGERINE-LABEL: fn @noReturn
+    // TANGERINE: [[GAS:v[0-9]+]] = gas
+    // TANGERINE: call [[GAS]],
+    function noReturn() external returns (uint256) {
+        CallGasTarget(address(new CallGasCallee())).noop();
+        return 1;
+    }
+
+    // HOMESTEAD-LABEL: fn @withReturn
+    // HOMESTEAD: [[GAS:v[0-9]+]] = gas
+    // HOMESTEAD: [[FWD:v[0-9]+]] = sub [[GAS]], 50
+    // HOMESTEAD: call [[FWD]],
+    // TANGERINE-LABEL: fn @withReturn
+    // TANGERINE: [[GAS:v[0-9]+]] = gas
+    // TANGERINE: call [[GAS]],
+    function withReturn() external returns (uint256) {
+        return CallGasTarget(address(new CallGasCallee())).value();
+    }
+
+    // A call with a `value` option also withholds the value-transfer cost, 50 + 9000.
+    // HOMESTEAD-LABEL: fn @withValue
+    // HOMESTEAD: [[GAS:v[0-9]+]] = gas
+    // HOMESTEAD: [[FWD:v[0-9]+]] = sub [[GAS]], 0x235a
+    // HOMESTEAD: call [[FWD]],
+    // TANGERINE-LABEL: fn @withValue
+    // TANGERINE: [[GAS:v[0-9]+]] = gas
+    // TANGERINE: call [[GAS]],
+    function withValue() external returns (uint256) {
+        return CallGasTarget(address(new CallGasCallee())).paid{value: 0}();
+    }
+
+    // The output area of a multi-word return gets its own buffer, whose last word is written
+    // before the gas is read so that the call's memory expansion is not charged against what the
+    // call withholds.
+    // HOMESTEAD-LABEL: fn @twoReturns
+    // HOMESTEAD: [[BUFFER:v[0-9]+]] = alloc raw, exact, uninitialized, infallible, 64
+    // HOMESTEAD: [[LAST:v[0-9]+]] = add [[BUFFER]], 32
+    // HOMESTEAD: mstore [[LAST]], 0
+    // HOMESTEAD: [[GAS:v[0-9]+]] = gas
+    // HOMESTEAD: [[FWD:v[0-9]+]] = sub [[GAS]], 50
+    // HOMESTEAD: call [[FWD]], {{v[0-9]+}}, 0, {{v[0-9]+}}, {{v[0-9]+}}, [[BUFFER]], 64
+    // TANGERINE-LABEL: fn @twoReturns
+    // TANGERINE: [[GAS:v[0-9]+]] = gas
+    // TANGERINE: [[INPUT:v[0-9]+]] = slice_ptr
+    // TANGERINE: call [[GAS]], {{v[0-9]+}}, 0, [[INPUT]], {{v[0-9]+}}, [[INPUT]], 64
+    function twoReturns() external returns (uint256) {
+        (uint256 first, uint256 second) =
+            CallGasTarget(address(new CallGasCallee())).pair();
+        return first + second;
+    }
+
+    // A bare call has no `extcodesize` guard, so it also withholds the account-creation cost,
+    // 50 + 25000.
+    // HOMESTEAD-LABEL: fn @bare
+    // HOMESTEAD: [[GAS:v[0-9]+]] = gas
+    // HOMESTEAD: [[FWD:v[0-9]+]] = sub [[GAS]], 0x61da
+    // HOMESTEAD: call [[FWD]],
+    // TANGERINE-LABEL: fn @bare
+    // TANGERINE: [[GAS:v[0-9]+]] = gas
+    // TANGERINE: call [[GAS]],
+    function bare() external returns (uint256) {
+        (bool ok,) = address(new CallGasCallee()).call(abi.encodeWithSignature("noop()"));
+        return ok ? 1 : 0;
+    }
+
+    // `send` and `transfer` pass a fixed stipend at every version, so they need no reserve.
+    // HOMESTEAD-LABEL: fn @sendZero
+    // HOMESTEAD-NOT: = gas
+    // HOMESTEAD: select {{v[0-9]+}}, 0x8fc, 0
+    // TANGERINE-LABEL: fn @sendZero
+    // TANGERINE-NOT: = gas
+    // TANGERINE: select {{v[0-9]+}}, 0x8fc, 0
+    function sendZero() external returns (uint256) {
+        return payable(address(new CallGasCallee())).send(0) ? 1 : 0;
+    }
+}

--- a/tests/ui/codegen/lowering/run-call/external_call_gas_evm_version.sol
+++ b/tests/ui/codegen/lowering/run-call/external_call_gas_evm_version.sol
@@ -97,16 +97,17 @@ contract CallGasCalls {
         return CallGasTarget(address(new CallGasCallee())).paid{value: 0}();
     }
 
-    // The output area of a multi-word return gets its own buffer, whose last word is written
-    // before the gas is read so that the call's memory expansion is not charged against what the
-    // call withholds.
+    // The output area of a multi-word return overlays the input area, and the word it reaches
+    // past the four-byte input is written before the gas is read so that the call's memory
+    // expansion is not charged against what the call withholds.
     // HOMESTEAD-LABEL: fn @twoReturns
-    // HOMESTEAD: [[BUFFER:v[0-9]+]] = alloc raw, exact, uninitialized, infallible, 64
-    // HOMESTEAD: [[LAST:v[0-9]+]] = add [[BUFFER]], 32
+    // HOMESTEAD: create
+    // HOMESTEAD: [[INPUT:v[0-9]+]] = slice_ptr
+    // HOMESTEAD: [[LAST:v[0-9]+]] = add [[INPUT]], 32
     // HOMESTEAD: mstore [[LAST]], 0
     // HOMESTEAD: [[GAS:v[0-9]+]] = gas
     // HOMESTEAD: [[FWD:v[0-9]+]] = sub [[GAS]], 50
-    // HOMESTEAD: call [[FWD]], {{v[0-9]+}}, 0, {{v[0-9]+}}, {{v[0-9]+}}, [[BUFFER]], 64
+    // HOMESTEAD: call [[FWD]], {{v[0-9]+}}, 0, [[INPUT]], {{v[0-9]+}}, [[INPUT]], 64
     // TANGERINE-LABEL: fn @twoReturns
     // TANGERINE: [[GAS:v[0-9]+]] = gas
     // TANGERINE: [[INPUT:v[0-9]+]] = slice_ptr
@@ -119,12 +120,13 @@ contract CallGasCalls {
 
     // A wider output area is touched at its own last word, not one word further.
     // HOMESTEAD-LABEL: fn @eightReturns
-    // HOMESTEAD: [[BUFFER:v[0-9]+]] = alloc raw, exact, uninitialized, infallible, 256
-    // HOMESTEAD: [[LAST:v[0-9]+]] = add [[BUFFER]], 224
+    // HOMESTEAD: create
+    // HOMESTEAD: [[INPUT:v[0-9]+]] = slice_ptr
+    // HOMESTEAD: [[LAST:v[0-9]+]] = add [[INPUT]], 224
     // HOMESTEAD: mstore [[LAST]], 0
     // HOMESTEAD: [[GAS:v[0-9]+]] = gas
     // HOMESTEAD: [[FWD:v[0-9]+]] = sub [[GAS]], 50
-    // HOMESTEAD: call [[FWD]], {{v[0-9]+}}, 0, {{v[0-9]+}}, {{v[0-9]+}}, [[BUFFER]], 256
+    // HOMESTEAD: call [[FWD]], {{v[0-9]+}}, 0, [[INPUT]], {{v[0-9]+}}, [[INPUT]], 256
     function eightReturns() external returns (uint256) {
         (
             uint256 a1,
@@ -139,9 +141,12 @@ contract CallGasCalls {
         return a1 + a2 + a3 + a4 + a5 + a6 + a7 + a8;
     }
 
-    // A static aggregate return already had a buffer of its own, and its last word is touched too.
+    // A static aggregate return is copied out of the overlaid area into a buffer of its own, and
+    // the word the area reaches past the input is touched too.
     // HOMESTEAD-LABEL: fn @aggregate
-    // HOMESTEAD: [[LAST:v[0-9]+]] = add {{v[0-9]+}}, 32
+    // HOMESTEAD: create
+    // HOMESTEAD: [[INPUT:v[0-9]+]] = slice_ptr
+    // HOMESTEAD: [[LAST:v[0-9]+]] = add [[INPUT]], 32
     // HOMESTEAD: mstore [[LAST]], 0
     // HOMESTEAD: [[GAS:v[0-9]+]] = gas
     // HOMESTEAD: [[FWD:v[0-9]+]] = sub [[GAS]], 50

--- a/tests/ui/codegen/lowering/run-call/external_call_gas_evm_version.sol
+++ b/tests/ui/codegen/lowering/run-call/external_call_gas_evm_version.sol
@@ -1,20 +1,31 @@
-//@ revisions: homestead tangerineWhistle
+//@ revisions: homestead homesteadGas homesteadSize tangerineWhistle
 //@[homestead] compile-flags: -O none --evm-version homestead -Zdump=mir
 //@[homestead] filecheck: --check-prefix=HOMESTEAD
+// The reserve only covers the `SUB` and the `CALL`, and the output-area touch is a store the call
+// itself overwrites, so both survive only as long as no pass moves work between the `GAS` and the
+// call or eliminates the store. The optimized revisions run the same calls on a homestead EVM.
+//@[homesteadGas] compile-flags: -O gas --evm-version homestead
+//@[homesteadSize] compile-flags: -O size --evm-version homestead
 //@[tangerineWhistle] compile-flags: -O none --evm-version tangerineWhistle -Zdump=mir
 //@[tangerineWhistle] filecheck: --check-prefix=TANGERINE
-//@[homestead,tangerineWhistle] run-call: CallGasCalls::noReturn => 1
-//@[homestead,tangerineWhistle] run-call: CallGasCalls::withReturn => 42
-//@[homestead,tangerineWhistle] run-call: CallGasCalls::withValue => 7
-//@[homestead,tangerineWhistle] run-call: CallGasCalls::twoReturns => 3
-//@[homestead,tangerineWhistle] run-call: CallGasCalls::bare => 1
-//@[homestead,tangerineWhistle] run-call: CallGasCalls::sendZero => 1
+//@ run-call: CallGasCalls::noReturn => 1
+//@ run-call: CallGasCalls::withReturn => 42
+//@ run-call: CallGasCalls::withValue => 7
+//@ run-call: CallGasCalls::twoReturns => 3
+//@ run-call: CallGasCalls::eightReturns => 36
+//@ run-call: CallGasCalls::aggregate => 33
+//@ run-call: CallGasCalls::bare => 1
+//@ run-call: CallGasCalls::sendZero => 1
 
 interface CallGasTarget {
     function noop() external;
     function value() external returns (uint256);
     function paid() external payable returns (uint256);
     function pair() external returns (uint256, uint256);
+    function eight()
+        external
+        returns (uint256, uint256, uint256, uint256, uint256, uint256, uint256, uint256);
+    function agg() external returns (uint256[2] memory);
 }
 
 contract CallGasCallee {
@@ -30,6 +41,19 @@ contract CallGasCallee {
 
     function pair() external pure returns (uint256, uint256) {
         return (1, 2);
+    }
+
+    function eight()
+        external
+        pure
+        returns (uint256, uint256, uint256, uint256, uint256, uint256, uint256, uint256)
+    {
+        return (1, 2, 3, 4, 5, 6, 7, 8);
+    }
+
+    function agg() external pure returns (uint256[2] memory r) {
+        r[0] = 11;
+        r[1] = 22;
     }
 
     receive() external payable {}
@@ -91,6 +115,40 @@ contract CallGasCalls {
         (uint256 first, uint256 second) =
             CallGasTarget(address(new CallGasCallee())).pair();
         return first + second;
+    }
+
+    // A wider output area is touched at its own last word, not one word further.
+    // HOMESTEAD-LABEL: fn @eightReturns
+    // HOMESTEAD: [[BUFFER:v[0-9]+]] = alloc raw, exact, uninitialized, infallible, 256
+    // HOMESTEAD: [[LAST:v[0-9]+]] = add [[BUFFER]], 224
+    // HOMESTEAD: mstore [[LAST]], 0
+    // HOMESTEAD: [[GAS:v[0-9]+]] = gas
+    // HOMESTEAD: [[FWD:v[0-9]+]] = sub [[GAS]], 50
+    // HOMESTEAD: call [[FWD]], {{v[0-9]+}}, 0, {{v[0-9]+}}, {{v[0-9]+}}, [[BUFFER]], 256
+    function eightReturns() external returns (uint256) {
+        (
+            uint256 a1,
+            uint256 a2,
+            uint256 a3,
+            uint256 a4,
+            uint256 a5,
+            uint256 a6,
+            uint256 a7,
+            uint256 a8
+        ) = CallGasTarget(address(new CallGasCallee())).eight();
+        return a1 + a2 + a3 + a4 + a5 + a6 + a7 + a8;
+    }
+
+    // A static aggregate return already had a buffer of its own, and its last word is touched too.
+    // HOMESTEAD-LABEL: fn @aggregate
+    // HOMESTEAD: [[LAST:v[0-9]+]] = add {{v[0-9]+}}, 32
+    // HOMESTEAD: mstore [[LAST]], 0
+    // HOMESTEAD: [[GAS:v[0-9]+]] = gas
+    // HOMESTEAD: [[FWD:v[0-9]+]] = sub [[GAS]], 50
+    // HOMESTEAD: call [[FWD]],
+    function aggregate() external returns (uint256) {
+        uint256[2] memory r = CallGasTarget(address(new CallGasCallee())).agg();
+        return r[0] + r[1];
     }
 
     // A bare call has no `extcodesize` guard, so it also withholds the account-creation cost,

--- a/tests/ui/codegen/lowering/run-call/external_call_gas_evm_version.sol
+++ b/tests/ui/codegen/lowering/run-call/external_call_gas_evm_version.sol
@@ -97,14 +97,15 @@ contract CallGasCalls {
         return CallGasTarget(address(new CallGasCallee())).paid{value: 0}();
     }
 
-    // The output area of a multi-word return overlays the input area, and the word it reaches
-    // past the four-byte input is written before the gas is read so that the call's memory
+    // The output area of a multi-word return overlays the input area, and the word above it is
+    // written before the arguments are encoded and the gas is read, so that the call's memory
     // expansion is not charged against what the call withholds.
     // HOMESTEAD-LABEL: fn @twoReturns
     // HOMESTEAD: create
+    // HOMESTEAD: [[AREA:v[0-9]+]] = fmp
+    // HOMESTEAD: [[ABOVE:v[0-9]+]] = add [[AREA]], 64
+    // HOMESTEAD: mstore [[ABOVE]], 0
     // HOMESTEAD: [[INPUT:v[0-9]+]] = slice_ptr
-    // HOMESTEAD: [[LAST:v[0-9]+]] = add [[INPUT]], 32
-    // HOMESTEAD: mstore [[LAST]], 0
     // HOMESTEAD: [[GAS:v[0-9]+]] = gas
     // HOMESTEAD: [[FWD:v[0-9]+]] = sub [[GAS]], 50
     // HOMESTEAD: call [[FWD]], {{v[0-9]+}}, 0, [[INPUT]], {{v[0-9]+}}, [[INPUT]], 64
@@ -118,12 +119,13 @@ contract CallGasCalls {
         return first + second;
     }
 
-    // A wider output area is touched at its own last word, not one word further.
+    // A wider output area is touched one word above its own size, whatever the input encodes to.
     // HOMESTEAD-LABEL: fn @eightReturns
     // HOMESTEAD: create
+    // HOMESTEAD: [[AREA:v[0-9]+]] = fmp
+    // HOMESTEAD: [[ABOVE:v[0-9]+]] = add [[AREA]], 256
+    // HOMESTEAD: mstore [[ABOVE]], 0
     // HOMESTEAD: [[INPUT:v[0-9]+]] = slice_ptr
-    // HOMESTEAD: [[LAST:v[0-9]+]] = add [[INPUT]], 224
-    // HOMESTEAD: mstore [[LAST]], 0
     // HOMESTEAD: [[GAS:v[0-9]+]] = gas
     // HOMESTEAD: [[FWD:v[0-9]+]] = sub [[GAS]], 50
     // HOMESTEAD: call [[FWD]], {{v[0-9]+}}, 0, [[INPUT]], {{v[0-9]+}}, [[INPUT]], 256
@@ -142,12 +144,12 @@ contract CallGasCalls {
     }
 
     // A static aggregate return is copied out of the overlaid area into a buffer of its own, and
-    // the word the area reaches past the input is touched too.
+    // the word above the area is touched too.
     // HOMESTEAD-LABEL: fn @aggregate
     // HOMESTEAD: create
-    // HOMESTEAD: [[INPUT:v[0-9]+]] = slice_ptr
-    // HOMESTEAD: [[LAST:v[0-9]+]] = add [[INPUT]], 32
-    // HOMESTEAD: mstore [[LAST]], 0
+    // HOMESTEAD: [[AREA:v[0-9]+]] = fmp
+    // HOMESTEAD: [[ABOVE:v[0-9]+]] = add [[AREA]], 64
+    // HOMESTEAD: mstore [[ABOVE]], 0
     // HOMESTEAD: [[GAS:v[0-9]+]] = gas
     // HOMESTEAD: [[FWD:v[0-9]+]] = sub [[GAS]], 50
     // HOMESTEAD: call [[FWD]],

--- a/tests/ui/codegen/lowering/run-call/external_call_gas_evm_version.tangerineWhistle.stdout
+++ b/tests/ui/codegen/lowering/run-call/external_call_gas_evm_version.tangerineWhistle.stdout
@@ -1,0 +1,247 @@
+// === ROOT/tests/ui/codegen/lowering/run-call/external_call_gas_evm_version.sol:CallGasCallee ===
+@module CallGasCallee
+fn @noop() [selector=0x5dfc2e4a, abi_params=[], abi_returns=[]] {
+  bb0:
+    stop
+}
+
+fn @value() -> u256 [selector=0x3fa4f245, pure, abi_params=[], abi_returns=[word]] {
+  bb0:
+    ret 42
+}
+
+fn @paid() -> u256 [selector=0x295b4e17, payable, abi_params=[], abi_returns=[word]] {
+  bb0:
+    ret 7
+}
+
+fn @pair() -> (u256, u256) [selector=0xa8aa1b31, pure, abi_params=[], abi_returns=[word, word]] {
+  bb0:
+    ret 1, 2
+}
+
+fn @receive() [receive, payable] {
+  bb0:
+    stop
+}
+
+// === ROOT/tests/ui/codegen/lowering/run-call/external_call_gas_evm_version.sol:CallGasCalls ===
+@module CallGasCalls
+data:
+  CallGasCallee_initcode_0: hex"34600f5760cc8060156000396000f35b60006000fe3660075760cb565b6000357c010000000000000000000000000000000000000000000000000000000090048063295b4e171460565780633fa4f24514605a5780635dfc2e4a14605e578063a8aa1b31146062576066565b6091565b6076565b606b565b60a3565b600080fe5b34607157005b600080fe5b34608c57602a6080526020608001608090036080f35b600080fe5b60076080526020608001608090036080f35b60c06040523460c657600160805260206080016002815260209001608090036080f35b600080fe5b"
+
+fn @noReturn() -> u256 [selector=0x31794254, abi_params=[], abi_returns=[word]] {
+  bb0:
+    v0 = abi_encode []
+    v1 = not 31
+    v2 = and 256, v1
+    v3 = alloc raw, exact, uninitialized, infallible, v2
+    data_copy CallGasCallee_initcode_0, v3, 225
+    v4 = slice_ptr v0
+    v5 = add v3, 225
+    mcopy v5, v4, 0 !metadata(memory=heap)
+    v6 = create 0, v3, 225
+    jumpi v6, bb2, bb1
+  bb1:
+    revert_returndata
+  bb2:
+    v7 = gas
+    v8 = abi_encode [], selector 0x5dfc2e4a00000000000000000000000000000000000000000000000000000000
+    v9 = slice_ptr v8
+    v10 = slice_len v8
+    v11 = extcodesize v6
+    v12 = iszero v11
+    jumpi v12, bb3, bb4
+  bb4:
+    v13 = call v7, v6, 0, v9, v10, 0, 0
+    jumpi v13, bb6, bb5
+  bb5:
+    revert_returndata
+  bb6:
+    ret 1
+  bb3:
+    revert 0, 0
+}
+
+fn @withReturn() -> u256 [selector=0x2149184b, abi_params=[], abi_returns=[word]] {
+  bb0:
+    v0 = abi_encode []
+    v1 = not 31
+    v2 = and 256, v1
+    v3 = alloc raw, exact, uninitialized, infallible, v2
+    data_copy CallGasCallee_initcode_0, v3, 225
+    v4 = slice_ptr v0
+    v5 = add v3, 225
+    mcopy v5, v4, 0 !metadata(memory=heap)
+    v6 = create 0, v3, 225
+    jumpi v6, bb2, bb1
+  bb1:
+    revert_returndata
+  bb2:
+    v7 = gas
+    v8 = abi_encode [], selector 0x3fa4f24500000000000000000000000000000000000000000000000000000000
+    v9 = slice_ptr v8
+    v10 = slice_len v8
+    v11 = extcodesize v6
+    v12 = iszero v11
+    jumpi v12, bb3, bb4
+  bb4:
+    v13 = call v7, v6, 0, v9, v10, 0, 32
+    jumpi v13, bb6, bb5
+  bb5:
+    revert_returndata
+  bb6:
+    v14 = add 0, 0
+    v15 = mload v14
+    v16 = add 0, 0
+    v17 = mload v16
+    ret v17
+  bb3:
+    revert 0, 0
+}
+
+fn @withValue() -> u256 [selector=0xd6b69802, abi_params=[], abi_returns=[word]] {
+  bb0:
+    v0 = abi_encode []
+    v1 = not 31
+    v2 = and 256, v1
+    v3 = alloc raw, exact, uninitialized, infallible, v2
+    data_copy CallGasCallee_initcode_0, v3, 225
+    v4 = slice_ptr v0
+    v5 = add v3, 225
+    mcopy v5, v4, 0 !metadata(memory=heap)
+    v6 = create 0, v3, 225
+    jumpi v6, bb2, bb1
+  bb1:
+    revert_returndata
+  bb2:
+    v7 = gas
+    v8 = abi_encode [], selector 0x295b4e1700000000000000000000000000000000000000000000000000000000
+    v9 = slice_ptr v8
+    v10 = slice_len v8
+    v11 = extcodesize v6
+    v12 = iszero v11
+    jumpi v12, bb3, bb4
+  bb4:
+    v13 = call v7, v6, 0, v9, v10, 0, 32
+    jumpi v13, bb6, bb5
+  bb5:
+    revert_returndata
+  bb6:
+    v14 = add 0, 0
+    v15 = mload v14
+    v16 = add 0, 0
+    v17 = mload v16
+    ret v17
+  bb3:
+    revert 0, 0
+}
+
+fn @twoReturns() -> u256 [selector=0xf7f4979a, abi_params=[], abi_returns=[word]] {
+  bb0:
+    v0 = abi_encode []
+    v1 = not 31
+    v2 = and 256, v1
+    v3 = alloc raw, exact, uninitialized, infallible, v2
+    data_copy CallGasCallee_initcode_0, v3, 225
+    v4 = slice_ptr v0
+    v5 = add v3, 225
+    mcopy v5, v4, 0 !metadata(memory=heap)
+    v6 = create 0, v3, 225
+    jumpi v6, bb2, bb1
+  bb1:
+    revert_returndata
+  bb2:
+    v7 = gas
+    v8 = abi_encode [], selector 0xa8aa1b3100000000000000000000000000000000000000000000000000000000
+    v9 = slice_ptr v8
+    v10 = slice_len v8
+    v11 = extcodesize v6
+    v12 = iszero v11
+    jumpi v12, bb3, bb4
+  bb4:
+    v13 = call v7, v6, 0, v9, v10, v9, 64
+    jumpi v13, bb6, bb5
+  bb5:
+    revert_returndata
+  bb6:
+    v14 = add v9, 0
+    v15 = mload v14
+    v16 = add v9, 32
+    v17 = mload v16
+    frame_store multi_return, word, 0, v9 !metadata(memory=scratch)
+    v18 = add v9, 0
+    v19 = mload v18
+    v20 = frame_load multi_return, word, 0 !metadata(memory=scratch)
+    v21 = add v20, 32
+    v22 = mload v21
+    v23 = add v19, v22
+    v24 = lt v23, v19
+    jumpi v24, bb7, bb8
+  bb8:
+    ret v23
+  bb7:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 17 !metadata(memory=scratch)
+    revert 0, 36
+  bb3:
+    revert 0, 0
+}
+
+fn @bare() -> u256 [selector=0x8095dd0b, abi_params=[], abi_returns=[word]] {
+  bb0:
+    v0 = abi_encode []
+    v1 = not 31
+    v2 = and 256, v1
+    v3 = alloc raw, exact, uninitialized, infallible, v2
+    data_copy CallGasCallee_initcode_0, v3, 225
+    v4 = slice_ptr v0
+    v5 = add v3, 225
+    mcopy v5, v4, 0 !metadata(memory=heap)
+    v6 = create 0, v3, 225
+    jumpi v6, bb2, bb1
+  bb1:
+    revert_returndata
+  bb2:
+    v7 = gas
+    v8 = abi_encode [], object, selector 0x5dfc2e4a00000000000000000000000000000000000000000000000000000000
+    v9 = memory_object_data memorybytes, v8
+    v10 = memory_object_len memorybytes, v8
+    v11 = call v7, v6, 0, v9, v10, 0, 0
+    jumpi v11, bb3, bb4
+  bb4:
+    jump bb5
+  bb3:
+    jump bb5
+  bb5:
+    v12 = phi [bb3: 1], [bb4: 0]
+    ret v12
+}
+
+fn @sendZero() -> u256 [selector=0xe857d88b, abi_params=[], abi_returns=[word]] {
+  bb0:
+    v0 = abi_encode []
+    v1 = not 31
+    v2 = and 256, v1
+    v3 = alloc raw, exact, uninitialized, infallible, v2
+    data_copy CallGasCallee_initcode_0, v3, 225
+    v4 = slice_ptr v0
+    v5 = add v3, 225
+    mcopy v5, v4, 0 !metadata(memory=heap)
+    v6 = create 0, v3, 225
+    jumpi v6, bb2, bb1
+  bb1:
+    revert_returndata
+  bb2:
+    v7 = iszero 0
+    v8 = select v7, 0x8fc, 0
+    v9 = call v8, v6, 0, 0, 0, 0, 0
+    jumpi v9, bb3, bb4
+  bb4:
+    jump bb5
+  bb3:
+    jump bb5
+  bb5:
+    v10 = phi [bb3: 1], [bb4: 0]
+    ret v10
+}

--- a/tests/ui/codegen/lowering/run-call/external_call_gas_evm_version.tangerineWhistle.stdout
+++ b/tests/ui/codegen/lowering/run-call/external_call_gas_evm_version.tangerineWhistle.stdout
@@ -20,6 +20,32 @@ fn @pair() -> (u256, u256) [selector=0xa8aa1b31, pure, abi_params=[], abi_return
     ret 1, 2
 }
 
+fn @eight() -> (u256, u256, u256, u256, u256, u256, u256, u256) [selector=0xcb94343e, pure, abi_params=[], abi_returns=[word, word, word, word, word, word, word, word]] {
+  bb0:
+    ret 1, 2, 3, 4, 5, 6, 7, 8
+}
+
+fn @agg() -> memoryfixedarray [selector=0xf5e34bfa, pure, abi_params=[], abi_returns=[array<2, word>]] {
+  bb0:
+    v0 = alloc memoryfixedarray<2, 1>, exact, uninitialized, infallible, 64
+    memory_zero v0, 64
+    v1 = lt 0, 2
+    v2 = iszero v1
+    jumpi v2, bb1, bb2
+  bb2:
+    memory_object_store_element memoryfixedarray<2, 1>, v0, 0, 11
+    v3 = lt 1, 2
+    v4 = iszero v3
+    jumpi v4, bb1, bb3
+  bb3:
+    memory_object_store_element memoryfixedarray<2, 1>, v0, 1, 22
+    ret v0
+  bb1:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 50 !metadata(memory=scratch)
+    revert 0, 36
+}
+
 fn @receive() [receive, payable] {
   bb0:
     stop
@@ -28,19 +54,19 @@ fn @receive() [receive, payable] {
 // === ROOT/tests/ui/codegen/lowering/run-call/external_call_gas_evm_version.sol:CallGasCalls ===
 @module CallGasCalls
 data:
-  CallGasCallee_initcode_0: hex"34600f5760cc8060156000396000f35b60006000fe3660075760cb565b6000357c010000000000000000000000000000000000000000000000000000000090048063295b4e171460565780633fa4f24514605a5780635dfc2e4a14605e578063a8aa1b31146062576066565b6091565b6076565b606b565b60a3565b600080fe5b34607157005b600080fe5b34608c57602a6080526020608001608090036080f35b600080fe5b60076080526020608001608090036080f35b60c06040523460c657600160805260206080016002815260209001608090036080f35b600080fe5b"
+  CallGasCallee_initcode_0: hex"346010576102038060166000396000f35b60006000fe36600857610202565b6000357c010000000000000000000000000000000000000000000000000000000090048063295b4e1714606b5780633fa4f24514606f5780635dfc2e4a146073578063a8aa1b31146077578063cb94343e14607b578063f5e34bfa14607f576084565b60af565b6094565b6089565b60c1565b60e9565b610143565b600080fe5b34608f57005b600080fe5b3460aa57602a6080526020608001608090036080f35b600080fe5b60076080526020608001608090036080f35b60c06040523460e457600160805260206080016002815260209001608090036080f35b600080fe5b6101806040523461013e57600160805260206080016002815260209001600381526020900160048152602090016005815260209001600681526020900160078152602090016008815260209001608090036080f35b600080fe5b610120604052346101fd576040518060c0528060c05260408101604052604036828060c05237600260001015156101a4575b7f4e487b7100000000000000000000000000000000000000000000000000000000600052603260045260246000fe5b8060c052600b81526002600110156101755760208101601681525060005b8060e05260028110156101ed576020818060e0520282015160208202608001526001810190506101c2565b6040608001915050608090036080f35b600080fe5b"
 
 fn @noReturn() -> u256 [selector=0x31794254, abi_params=[], abi_returns=[word]] {
   bb0:
     v0 = abi_encode []
     v1 = not 31
-    v2 = and 256, v1
+    v2 = and 568, v1
     v3 = alloc raw, exact, uninitialized, infallible, v2
-    data_copy CallGasCallee_initcode_0, v3, 225
+    data_copy CallGasCallee_initcode_0, v3, 537
     v4 = slice_ptr v0
-    v5 = add v3, 225
+    v5 = add v3, 537
     mcopy v5, v4, 0 !metadata(memory=heap)
-    v6 = create 0, v3, 225
+    v6 = create 0, v3, 537
     jumpi v6, bb2, bb1
   bb1:
     revert_returndata
@@ -67,13 +93,13 @@ fn @withReturn() -> u256 [selector=0x2149184b, abi_params=[], abi_returns=[word]
   bb0:
     v0 = abi_encode []
     v1 = not 31
-    v2 = and 256, v1
+    v2 = and 568, v1
     v3 = alloc raw, exact, uninitialized, infallible, v2
-    data_copy CallGasCallee_initcode_0, v3, 225
+    data_copy CallGasCallee_initcode_0, v3, 537
     v4 = slice_ptr v0
-    v5 = add v3, 225
+    v5 = add v3, 537
     mcopy v5, v4, 0 !metadata(memory=heap)
-    v6 = create 0, v3, 225
+    v6 = create 0, v3, 537
     jumpi v6, bb2, bb1
   bb1:
     revert_returndata
@@ -104,13 +130,13 @@ fn @withValue() -> u256 [selector=0xd6b69802, abi_params=[], abi_returns=[word]]
   bb0:
     v0 = abi_encode []
     v1 = not 31
-    v2 = and 256, v1
+    v2 = and 568, v1
     v3 = alloc raw, exact, uninitialized, infallible, v2
-    data_copy CallGasCallee_initcode_0, v3, 225
+    data_copy CallGasCallee_initcode_0, v3, 537
     v4 = slice_ptr v0
-    v5 = add v3, 225
+    v5 = add v3, 537
     mcopy v5, v4, 0 !metadata(memory=heap)
-    v6 = create 0, v3, 225
+    v6 = create 0, v3, 537
     jumpi v6, bb2, bb1
   bb1:
     revert_returndata
@@ -141,13 +167,13 @@ fn @twoReturns() -> u256 [selector=0xf7f4979a, abi_params=[], abi_returns=[word]
   bb0:
     v0 = abi_encode []
     v1 = not 31
-    v2 = and 256, v1
+    v2 = and 568, v1
     v3 = alloc raw, exact, uninitialized, infallible, v2
-    data_copy CallGasCallee_initcode_0, v3, 225
+    data_copy CallGasCallee_initcode_0, v3, 537
     v4 = slice_ptr v0
-    v5 = add v3, 225
+    v5 = add v3, 537
     mcopy v5, v4, 0 !metadata(memory=heap)
-    v6 = create 0, v3, 225
+    v6 = create 0, v3, 537
     jumpi v6, bb2, bb1
   bb1:
     revert_returndata
@@ -188,17 +214,173 @@ fn @twoReturns() -> u256 [selector=0xf7f4979a, abi_params=[], abi_returns=[word]
     revert 0, 0
 }
 
+fn @eightReturns() -> u256 [selector=0x67b0b213, abi_params=[], abi_returns=[word]] {
+  bb0:
+    v0 = abi_encode []
+    v1 = not 31
+    v2 = and 568, v1
+    v3 = alloc raw, exact, uninitialized, infallible, v2
+    data_copy CallGasCallee_initcode_0, v3, 537
+    v4 = slice_ptr v0
+    v5 = add v3, 537
+    mcopy v5, v4, 0 !metadata(memory=heap)
+    v6 = create 0, v3, 537
+    jumpi v6, bb2, bb1
+  bb1:
+    revert_returndata
+  bb2:
+    v7 = gas
+    v8 = abi_encode [], selector 0xcb94343e00000000000000000000000000000000000000000000000000000000
+    v9 = slice_ptr v8
+    v10 = slice_len v8
+    v11 = extcodesize v6
+    v12 = iszero v11
+    jumpi v12, bb3, bb4
+  bb4:
+    v13 = call v7, v6, 0, v9, v10, v9, 256
+    jumpi v13, bb6, bb5
+  bb5:
+    revert_returndata
+  bb6:
+    v14 = add v9, 0
+    v15 = mload v14
+    v16 = add v9, 32
+    v17 = mload v16
+    v18 = add v9, 64
+    v19 = mload v18
+    v20 = add v9, 96
+    v21 = mload v20
+    v22 = add v9, 128
+    v23 = mload v22
+    v24 = add v9, 160
+    v25 = mload v24
+    v26 = add v9, 192
+    v27 = mload v26
+    v28 = add v9, 224
+    v29 = mload v28
+    frame_store multi_return, word, 0, v9 !metadata(memory=scratch)
+    v30 = add v9, 0
+    v31 = mload v30
+    v32 = frame_load multi_return, word, 0 !metadata(memory=scratch)
+    v33 = add v32, 32
+    v34 = mload v33
+    v35 = add v32, 64
+    v36 = mload v35
+    v37 = add v32, 96
+    v38 = mload v37
+    v39 = add v32, 128
+    v40 = mload v39
+    v41 = add v32, 160
+    v42 = mload v41
+    v43 = add v32, 192
+    v44 = mload v43
+    v45 = add v32, 224
+    v46 = mload v45
+    v47 = add v31, v34
+    v48 = lt v47, v31
+    jumpi v48, bb7, bb8
+  bb8:
+    v49 = add v47, v36
+    v50 = lt v49, v47
+    jumpi v50, bb7, bb9
+  bb9:
+    v51 = add v49, v38
+    v52 = lt v51, v49
+    jumpi v52, bb7, bb10
+  bb10:
+    v53 = add v51, v40
+    v54 = lt v53, v51
+    jumpi v54, bb7, bb11
+  bb11:
+    v55 = add v53, v42
+    v56 = lt v55, v53
+    jumpi v56, bb7, bb12
+  bb12:
+    v57 = add v55, v44
+    v58 = lt v57, v55
+    jumpi v58, bb7, bb13
+  bb13:
+    v59 = add v57, v46
+    v60 = lt v59, v57
+    jumpi v60, bb7, bb14
+  bb14:
+    ret v59
+  bb7:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 17 !metadata(memory=scratch)
+    revert 0, 36
+  bb3:
+    revert 0, 0
+}
+
+fn @aggregate() -> u256 [selector=0xaf36778b, abi_params=[], abi_returns=[word]] {
+  bb0:
+    v0 = abi_encode []
+    v1 = not 31
+    v2 = and 568, v1
+    v3 = alloc raw, exact, uninitialized, infallible, v2
+    data_copy CallGasCallee_initcode_0, v3, 537
+    v4 = slice_ptr v0
+    v5 = add v3, 537
+    mcopy v5, v4, 0 !metadata(memory=heap)
+    v6 = create 0, v3, 537
+    jumpi v6, bb2, bb1
+  bb1:
+    revert_returndata
+  bb2:
+    v7 = gas
+    v8 = abi_encode [], selector 0xf5e34bfa00000000000000000000000000000000000000000000000000000000
+    v9 = slice_ptr v8
+    v10 = slice_len v8
+    v11 = alloc raw, exact, uninitialized, infallible, 64
+    v12 = extcodesize v6
+    v13 = iszero v12
+    jumpi v13, bb3, bb4
+  bb4:
+    v14 = call v7, v6, 0, v9, v10, v11, 64
+    jumpi v14, bb6, bb5
+  bb5:
+    revert_returndata
+  bb6:
+    v15 = abi_decode [array<2, u256>], v11
+    v16 = lt 0, 2
+    v17 = iszero v16
+    jumpi v17, bb7, bb8
+  bb8:
+    v18 = memory_object_load_element memoryfixedarray<2, 1>, v15, 0
+    v19 = lt 1, 2
+    v20 = iszero v19
+    jumpi v20, bb7, bb9
+  bb9:
+    v21 = memory_object_load_element memoryfixedarray<2, 1>, v15, 1
+    v22 = add v18, v21
+    v23 = lt v22, v18
+    jumpi v23, bb10, bb11
+  bb11:
+    ret v22
+  bb10:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 17 !metadata(memory=scratch)
+    revert 0, 36
+  bb7:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 50 !metadata(memory=scratch)
+    revert 0, 36
+  bb3:
+    revert 0, 0
+}
+
 fn @bare() -> u256 [selector=0x8095dd0b, abi_params=[], abi_returns=[word]] {
   bb0:
     v0 = abi_encode []
     v1 = not 31
-    v2 = and 256, v1
+    v2 = and 568, v1
     v3 = alloc raw, exact, uninitialized, infallible, v2
-    data_copy CallGasCallee_initcode_0, v3, 225
+    data_copy CallGasCallee_initcode_0, v3, 537
     v4 = slice_ptr v0
-    v5 = add v3, 225
+    v5 = add v3, 537
     mcopy v5, v4, 0 !metadata(memory=heap)
-    v6 = create 0, v3, 225
+    v6 = create 0, v3, 537
     jumpi v6, bb2, bb1
   bb1:
     revert_returndata
@@ -222,13 +404,13 @@ fn @sendZero() -> u256 [selector=0xe857d88b, abi_params=[], abi_returns=[word]] 
   bb0:
     v0 = abi_encode []
     v1 = not 31
-    v2 = and 256, v1
+    v2 = and 568, v1
     v3 = alloc raw, exact, uninitialized, infallible, v2
-    data_copy CallGasCallee_initcode_0, v3, 225
+    data_copy CallGasCallee_initcode_0, v3, 537
     v4 = slice_ptr v0
-    v5 = add v3, 225
+    v5 = add v3, 537
     mcopy v5, v4, 0 !metadata(memory=heap)
-    v6 = create 0, v3, 225
+    v6 = create 0, v3, 537
     jumpi v6, bb2, bb1
   bb1:
     revert_returndata

--- a/tests/ui/codegen/lowering/run-call/external_call_gas_evm_version.tangerineWhistle.stdout
+++ b/tests/ui/codegen/lowering/run-call/external_call_gas_evm_version.tangerineWhistle.stdout
@@ -79,7 +79,7 @@ fn @noReturn() -> u256 [selector=0x31794254, abi_params=[], abi_returns=[word]] 
     v12 = iszero v11
     jumpi v12, bb3, bb4
   bb4:
-    v13 = call v7, v6, 0, v9, v10, 0, 0
+    v13 = call v7, v6, 0, v9, v10, v9, 0
     jumpi v13, bb6, bb5
   bb5:
     revert_returndata
@@ -112,14 +112,14 @@ fn @withReturn() -> u256 [selector=0x2149184b, abi_params=[], abi_returns=[word]
     v12 = iszero v11
     jumpi v12, bb3, bb4
   bb4:
-    v13 = call v7, v6, 0, v9, v10, 0, 32
+    v13 = call v7, v6, 0, v9, v10, v9, 32
     jumpi v13, bb6, bb5
   bb5:
     revert_returndata
   bb6:
-    v14 = add 0, 0
+    v14 = add v9, 0
     v15 = mload v14
-    v16 = add 0, 0
+    v16 = add v9, 0
     v17 = mload v16
     ret v17
   bb3:
@@ -149,14 +149,14 @@ fn @withValue() -> u256 [selector=0xd6b69802, abi_params=[], abi_returns=[word]]
     v12 = iszero v11
     jumpi v12, bb3, bb4
   bb4:
-    v13 = call v7, v6, 0, v9, v10, 0, 32
+    v13 = call v7, v6, 0, v9, v10, v9, 32
     jumpi v13, bb6, bb5
   bb5:
     revert_returndata
   bb6:
-    v14 = add 0, 0
+    v14 = add v9, 0
     v15 = mload v14
-    v16 = add 0, 0
+    v16 = add v9, 0
     v17 = mload v16
     ret v17
   bb3:
@@ -329,35 +329,38 @@ fn @aggregate() -> u256 [selector=0xaf36778b, abi_params=[], abi_returns=[word]]
     revert_returndata
   bb2:
     v7 = gas
-    v8 = abi_encode [], selector 0xf5e34bfa00000000000000000000000000000000000000000000000000000000
-    v9 = slice_ptr v8
-    v10 = slice_len v8
-    v11 = alloc raw, exact, uninitialized, infallible, 64
-    v12 = extcodesize v6
-    v13 = iszero v12
-    jumpi v13, bb3, bb4
+    v8 = alloc memorybytes, exact, uninitialized, infallible, 96
+    set_memory_object_len memorybytes, v8, 64
+    v9 = memory_object_data memorybytes, v8
+    v10 = abi_encode [], selector 0xf5e34bfa00000000000000000000000000000000000000000000000000000000
+    v11 = slice_ptr v10
+    v12 = slice_len v10
+    v13 = extcodesize v6
+    v14 = iszero v13
+    jumpi v14, bb3, bb4
   bb4:
-    v14 = call v7, v6, 0, v9, v10, v11, 64
-    jumpi v14, bb6, bb5
+    v15 = call v7, v6, 0, v11, v12, v11, 64
+    jumpi v15, bb6, bb5
   bb5:
     revert_returndata
   bb6:
-    v15 = abi_decode [array<2, u256>], v11
-    v16 = lt 0, 2
-    v17 = iszero v16
-    jumpi v17, bb7, bb8
+    mcopy v9, v11, 64
+    v16 = abi_decode [array<2, u256>], v8
+    v17 = lt 0, 2
+    v18 = iszero v17
+    jumpi v18, bb7, bb8
   bb8:
-    v18 = memory_object_load_element memoryfixedarray<2, 1>, v15, 0
-    v19 = lt 1, 2
-    v20 = iszero v19
-    jumpi v20, bb7, bb9
+    v19 = memory_object_load_element memoryfixedarray<2, 1>, v16, 0
+    v20 = lt 1, 2
+    v21 = iszero v20
+    jumpi v21, bb7, bb9
   bb9:
-    v21 = memory_object_load_element memoryfixedarray<2, 1>, v15, 1
-    v22 = add v18, v21
-    v23 = lt v22, v18
-    jumpi v23, bb10, bb11
+    v22 = memory_object_load_element memoryfixedarray<2, 1>, v16, 1
+    v23 = add v19, v22
+    v24 = lt v23, v19
+    jumpi v24, bb10, bb11
   bb11:
-    ret v22
+    ret v23
   bb10:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)

--- a/tests/ui/codegen/lowering/run-call/external_function_pointer_higher_order.mir.stdout
+++ b/tests/ui/codegen/lowering/run-call/external_function_pointer_higher_order.mir.stdout
@@ -100,7 +100,7 @@ fn @t() -> u256 [selector=0x92d0d153, abi_params=[], abi_returns=[word]] {
     v24 = sload 0 !metadata(storage=slot(0))
     v25 = shr 64, v24
     v26 = and v25, 0xffffffffffffffffffffffffffffffffffffffffffffffff
-    v27 = internal_call @internal_dispatcher_p_function_r_u256, 1, v23, v26
+    v27 = icall @internal_dispatcher_p_function_r_u256, 1, v23, v26
     ret v27
   bb3:
     revert 0, 0
@@ -115,6 +115,6 @@ fn @internal_dispatcher_p_function_r_u256(arg0: function, arg1: function) -> u25
     mstore 4, 81 !metadata(memory=scratch)
     revert 0, 36
   bb1:
-    v1 = internal_call @eval, 1, arg1
+    v1 = icall @eval, 1, arg1
     ret v1
 }

--- a/tests/ui/codegen/lowering/run-call/external_function_pointer_higher_order.mir.stdout
+++ b/tests/ui/codegen/lowering/run-call/external_function_pointer_higher_order.mir.stdout
@@ -86,18 +86,24 @@ fn @t() -> u256 [selector=0x92d0d153, abi_params=[], abi_returns=[word]] {
     v16 = abi_encode [function], selector 0xf018a0a700000000000000000000000000000000000000000000000000000000, args v15
     v17 = slice_ptr v16
     v18 = slice_len v16
-    v19 = call v6, v5, 0, v17, v18, 0, 0
-    jumpi v19, bb4, bb3
-  bb3:
-    revert_returndata
+    v19 = extcodesize v5
+    v20 = iszero v19
+    jumpi v20, bb3, bb4
   bb4:
-    v20 = sload 0 !metadata(storage=slot(0))
-    v21 = and v20, 0xffffffffffffffff
+    v21 = call v6, v5, 0, v17, v18, 0, 0
+    jumpi v21, bb6, bb5
+  bb5:
+    revert_returndata
+  bb6:
     v22 = sload 0 !metadata(storage=slot(0))
-    v23 = shr 64, v22
-    v24 = and v23, 0xffffffffffffffffffffffffffffffffffffffffffffffff
-    v25 = icall @internal_dispatcher_p_function_r_u256, 1, v21, v24
-    ret v25
+    v23 = and v22, 0xffffffffffffffff
+    v24 = sload 0 !metadata(storage=slot(0))
+    v25 = shr 64, v24
+    v26 = and v25, 0xffffffffffffffffffffffffffffffffffffffffffffffff
+    v27 = internal_call @internal_dispatcher_p_function_r_u256, 1, v23, v26
+    ret v27
+  bb3:
+    revert 0, 0
 }
 
 fn @internal_dispatcher_p_function_r_u256(arg0: function, arg1: function) -> u256 [function_pointer_dispatcher] {
@@ -109,6 +115,6 @@ fn @internal_dispatcher_p_function_r_u256(arg0: function, arg1: function) -> u25
     mstore 4, 81 !metadata(memory=scratch)
     revert 0, 36
   bb1:
-    v1 = icall @eval, 1, arg1
+    v1 = internal_call @eval, 1, arg1
     ret v1
 }

--- a/tests/ui/codegen/lowering/run-call/external_function_pointer_storage_array.mir.stdout
+++ b/tests/ui/codegen/lowering/run-call/external_function_pointer_storage_array.mir.stdout
@@ -374,278 +374,282 @@ fn @runAll() -> memorybytes [selector=0x34ba89a6, abi_params=[], abi_returns=[me
     v98 = abi_encode [memory_array<function>], selector 0x6aabe1c400000000000000000000000000000000000000000000000000000000, args v0
     v99 = slice_ptr v98
     v100 = slice_len v98
-    v101 = call v97, v96, 0, v99, v100, 0, 0
-    jumpi v101, bb22, bb21
+    v101 = extcodesize v96
+    v102 = iszero v101
+    jumpi v102, bb13, bb21
   bb21:
-    revert_returndata
+    v103 = call v97, v96, 0, v99, v100, 0, 0
+    jumpi v103, bb23, bb22
   bb22:
-    v102 = sload 1 !metadata(storage=slot(1))
-    v103 = lt 0, v102
-    v104 = iszero v103
-    jumpi v104, bb1, bb23
+    revert_returndata
   bb23:
-    v105 = storage_array_data_slot 1
-    v106 = div 0, 1
-    v107 = add v105, v106
-    v108 = mod 0, 1
-    v109 = mul v108, 24
-    v110 = sload v107 !metadata(storage=symbolic(v107))
-    v111 = mul v109, 8
-    v112 = shr v111, v110
-    v113 = and v112, 0xffffffffffffffffffffffffffffffffffffffffffffffff
-    v114 = and v113, 0xffffffff
-    v115 = shl 224, v114
-    v116 = shr 32, v113
-    v117 = gas
-    v118 = abi_encode [], selector v115
-    v119 = slice_ptr v118
-    v120 = slice_len v118
-    v121 = extcodesize v116
-    v122 = iszero v121
-    jumpi v122, bb13, bb24
+    v104 = sload 1 !metadata(storage=slot(1))
+    v105 = lt 0, v104
+    v106 = iszero v105
+    jumpi v106, bb1, bb24
   bb24:
-    v123 = call v117, v116, 0, v119, v120, 0, 0
-    jumpi v123, bb26, bb25
+    v107 = storage_array_data_slot 1
+    v108 = div 0, 1
+    v109 = add v107, v108
+    v110 = mod 0, 1
+    v111 = mul v110, 24
+    v112 = sload v109 !metadata(storage=symbolic(v109))
+    v113 = mul v111, 8
+    v114 = shr v113, v112
+    v115 = and v114, 0xffffffffffffffffffffffffffffffffffffffffffffffff
+    v116 = and v115, 0xffffffff
+    v117 = shl 224, v116
+    v118 = shr 32, v115
+    v119 = gas
+    v120 = abi_encode [], selector v117
+    v121 = slice_ptr v120
+    v122 = slice_len v120
+    v123 = extcodesize v118
+    v124 = iszero v123
+    jumpi v124, bb13, bb25
   bb25:
-    revert_returndata
+    v125 = call v119, v118, 0, v121, v122, 0, 0
+    jumpi v125, bb27, bb26
   bb26:
-    v124 = sload 1 !metadata(storage=slot(1))
-    v125 = lt 1, v124
-    v126 = iszero v125
-    jumpi v126, bb1, bb27
-  bb27:
-    v127 = storage_array_data_slot 1
-    v128 = div 1, 1
-    v129 = add v127, v128
-    v130 = mod 1, 1
-    v131 = mul v130, 24
-    v132 = sload v129 !metadata(storage=symbolic(v129))
-    v133 = mul v131, 8
-    v134 = shr v133, v132
-    v135 = and v134, 0xffffffffffffffffffffffffffffffffffffffffffffffff
-    v136 = and v135, 0xffffffff
-    v137 = shl 224, v136
-    v138 = shr 32, v135
-    v139 = gas
-    v140 = abi_encode [], selector v137
-    v141 = slice_ptr v140
-    v142 = slice_len v140
-    v143 = extcodesize v138
-    v144 = iszero v143
-    jumpi v144, bb13, bb28
-  bb28:
-    v145 = call v139, v138, 0, v141, v142, 0, 0
-    jumpi v145, bb30, bb29
-  bb29:
     revert_returndata
+  bb27:
+    v126 = sload 1 !metadata(storage=slot(1))
+    v127 = lt 1, v126
+    v128 = iszero v127
+    jumpi v128, bb1, bb28
+  bb28:
+    v129 = storage_array_data_slot 1
+    v130 = div 1, 1
+    v131 = add v129, v130
+    v132 = mod 1, 1
+    v133 = mul v132, 24
+    v134 = sload v131 !metadata(storage=symbolic(v131))
+    v135 = mul v133, 8
+    v136 = shr v135, v134
+    v137 = and v136, 0xffffffffffffffffffffffffffffffffffffffffffffffff
+    v138 = and v137, 0xffffffff
+    v139 = shl 224, v138
+    v140 = shr 32, v137
+    v141 = gas
+    v142 = abi_encode [], selector v139
+    v143 = slice_ptr v142
+    v144 = slice_len v142
+    v145 = extcodesize v140
+    v146 = iszero v145
+    jumpi v146, bb13, bb29
+  bb29:
+    v147 = call v141, v140, 0, v143, v144, 0, 0
+    jumpi v147, bb31, bb30
   bb30:
-    v146 = sload 1 !metadata(storage=slot(1))
-    v147 = mul v146, 1
-    v148 = iszero 1
-    v149 = div v147, 1
-    v150 = eq v149, v146
-    v151 = or v148, v150
-    v152 = iszero v151
-    jumpi v152, bb31, bb32
-  bb32:
-    v153 = add v147, 1
-    v154 = lt v153, v147
-    jumpi v154, bb31, bb33
+    revert_returndata
+  bb31:
+    v148 = sload 1 !metadata(storage=slot(1))
+    v149 = mul v148, 1
+    v150 = iszero 1
+    v151 = div v149, 1
+    v152 = eq v151, v148
+    v153 = or v150, v152
+    v154 = iszero v153
+    jumpi v154, bb32, bb33
   bb33:
-    v155 = mul v153, 32
-    v156 = iszero 32
-    v157 = div v155, 32
-    v158 = eq v157, v153
-    v159 = or v156, v158
-    v160 = iszero v159
-    jumpi v160, bb31, bb34
+    v155 = add v149, 1
+    v156 = lt v155, v149
+    jumpi v156, bb32, bb34
   bb34:
-    v161 = alloc memoryarray<1>, exact, uninitialized, panic, v155
-    set_memory_object_len memoryarray, v161, v146
-    jump bb35
+    v157 = mul v155, 32
+    v158 = iszero 32
+    v159 = div v157, 32
+    v160 = eq v159, v155
+    v161 = or v158, v160
+    v162 = iszero v161
+    jumpi v162, bb32, bb35
   bb35:
-    v162 = phi [bb34: 0], [bb36: v174]
-    v163 = lt v162, v146
-    jumpi v163, bb36, bb37
-  bb37:
-    v175 = memory_object_len memoryarray, v161
-    v176 = sload 2 !metadata(storage=slot(2))
-    v177 = gt v176, v175
-    jumpi v177, bb38, bb39
+    v163 = alloc memoryarray<1>, exact, uninitialized, panic, v157
+    set_memory_object_len memoryarray, v163, v148
+    jump bb36
+  bb36:
+    v164 = phi [bb35: 0], [bb37: v176]
+    v165 = lt v164, v148
+    jumpi v165, bb37, bb38
   bb38:
+    v177 = memory_object_len memoryarray, v163
+    v178 = sload 2 !metadata(storage=slot(2))
+    v179 = gt v178, v177
+    jumpi v179, bb39, bb40
+  bb39:
+    jump bb41
+  bb41:
+    v180 = phi [bb39: v177], [bb42: v195]
+    v181 = lt v180, v178
+    jumpi v181, bb42, bb43
+  bb43:
     jump bb40
   bb40:
-    v178 = phi [bb38: v175], [bb41: v193]
-    v179 = lt v178, v176
-    jumpi v179, bb41, bb42
-  bb42:
-    jump bb39
-  bb39:
-    sstore 2, v175 !metadata(storage=slot(2))
-    jump bb43
-  bb43:
-    v194 = phi [bb39: 0], [bb44: v211]
-    v195 = lt v194, v175
-    jumpi v195, bb44, bb45
-  bb45:
-    v212 = sload 2 !metadata(storage=slot(2))
-    v213 = lt 0, v212
-    v214 = iszero v213
-    jumpi v214, bb1, bb46
+    sstore 2, v177 !metadata(storage=slot(2))
+    jump bb44
+  bb44:
+    v196 = phi [bb40: 0], [bb45: v213]
+    v197 = lt v196, v177
+    jumpi v197, bb45, bb46
   bb46:
-    v215 = storage_array_data_slot 2
-    v216 = div 0, 1
-    v217 = add v215, v216
-    v218 = mod 0, 1
-    v219 = mul v218, 24
-    v220 = sload v217 !metadata(storage=symbolic(v217))
-    v221 = mul v219, 8
-    v222 = shr v221, v220
-    v223 = and v222, 0xffffffffffffffffffffffffffffffffffffffffffffffff
-    v224 = and v223, 0xffffffff
-    v225 = shl 224, v224
-    v226 = shr 32, v223
-    v227 = gas
-    v228 = abi_encode [], selector v225
-    v229 = slice_ptr v228
-    v230 = slice_len v228
-    v231 = extcodesize v226
-    v232 = iszero v231
-    jumpi v232, bb13, bb47
+    v214 = sload 2 !metadata(storage=slot(2))
+    v215 = lt 0, v214
+    v216 = iszero v215
+    jumpi v216, bb1, bb47
   bb47:
-    v233 = call v227, v226, 0, v229, v230, 0, 0
-    jumpi v233, bb49, bb48
+    v217 = storage_array_data_slot 2
+    v218 = div 0, 1
+    v219 = add v217, v218
+    v220 = mod 0, 1
+    v221 = mul v220, 24
+    v222 = sload v219 !metadata(storage=symbolic(v219))
+    v223 = mul v221, 8
+    v224 = shr v223, v222
+    v225 = and v224, 0xffffffffffffffffffffffffffffffffffffffffffffffff
+    v226 = and v225, 0xffffffff
+    v227 = shl 224, v226
+    v228 = shr 32, v225
+    v229 = gas
+    v230 = abi_encode [], selector v227
+    v231 = slice_ptr v230
+    v232 = slice_len v230
+    v233 = extcodesize v228
+    v234 = iszero v233
+    jumpi v234, bb13, bb48
   bb48:
-    revert_returndata
+    v235 = call v229, v228, 0, v231, v232, 0, 0
+    jumpi v235, bb50, bb49
   bb49:
-    v234 = sload 2 !metadata(storage=slot(2))
-    v235 = lt 1, v234
-    v236 = iszero v235
-    jumpi v236, bb1, bb50
-  bb50:
-    v237 = storage_array_data_slot 2
-    v238 = div 1, 1
-    v239 = add v237, v238
-    v240 = mod 1, 1
-    v241 = mul v240, 24
-    v242 = sload v239 !metadata(storage=symbolic(v239))
-    v243 = mul v241, 8
-    v244 = shr v243, v242
-    v245 = and v244, 0xffffffffffffffffffffffffffffffffffffffffffffffff
-    v246 = and v245, 0xffffffff
-    v247 = shl 224, v246
-    v248 = shr 32, v245
-    v249 = gas
-    v250 = abi_encode [], selector v247
-    v251 = slice_ptr v250
-    v252 = slice_len v250
-    v253 = extcodesize v248
-    v254 = iszero v253
-    jumpi v254, bb13, bb51
-  bb51:
-    v255 = call v249, v248, 0, v251, v252, 0, 0
-    jumpi v255, bb53, bb52
-  bb52:
     revert_returndata
+  bb50:
+    v236 = sload 2 !metadata(storage=slot(2))
+    v237 = lt 1, v236
+    v238 = iszero v237
+    jumpi v238, bb1, bb51
+  bb51:
+    v239 = storage_array_data_slot 2
+    v240 = div 1, 1
+    v241 = add v239, v240
+    v242 = mod 1, 1
+    v243 = mul v242, 24
+    v244 = sload v241 !metadata(storage=symbolic(v241))
+    v245 = mul v243, 8
+    v246 = shr v245, v244
+    v247 = and v246, 0xffffffffffffffffffffffffffffffffffffffffffffffff
+    v248 = and v247, 0xffffffff
+    v249 = shl 224, v248
+    v250 = shr 32, v247
+    v251 = gas
+    v252 = abi_encode [], selector v249
+    v253 = slice_ptr v252
+    v254 = slice_len v252
+    v255 = extcodesize v250
+    v256 = iszero v255
+    jumpi v256, bb13, bb52
+  bb52:
+    v257 = call v251, v250, 0, v253, v254, 0, 0
+    jumpi v257, bb54, bb53
   bb53:
-    v256 = sload 0 !metadata(storage=slot(0))
-    v257 = and v256, 1
-    v258 = eq v257, 1
-    v259 = shr 1, v256
-    v260 = and v259, 127
-    v261 = select v258, v259, v260
-    v262 = lt v261, 32
-    v263 = eq v258, v262
-    jumpi v263, bb54, bb55
-  bb55:
-    v264 = add v261, 31
-    v265 = div v264, 32
-    v266 = add v261, 63
-    v267 = lt v266, v261
-    jumpi v267, bb31, bb56
+    revert_returndata
+  bb54:
+    v258 = sload 0 !metadata(storage=slot(0))
+    v259 = and v258, 1
+    v260 = eq v259, 1
+    v261 = shr 1, v258
+    v262 = and v261, 127
+    v263 = select v260, v261, v262
+    v264 = lt v263, 32
+    v265 = eq v260, v264
+    jumpi v265, bb55, bb56
   bb56:
-    v268 = not 31
-    v269 = and v266, v268
-    v270 = alloc memorybytes, exact, uninitialized, panic, v269
-    set_memory_object_len memorybytes, v270, v261
-    jumpi v258, bb58, bb57
+    v266 = add v263, 31
+    v267 = div v266, 32
+    v268 = add v263, 63
+    v269 = lt v268, v263
+    jumpi v269, bb32, bb57
   bb57:
-    v271 = and v256, 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff00
-    memory_object_store_word memorybytes, v270, 0, v271
-    jump bb59
+    v270 = not 31
+    v271 = and v268, v270
+    v272 = alloc memorybytes, exact, uninitialized, panic, v271
+    set_memory_object_len memorybytes, v272, v263
+    jumpi v260, bb59, bb58
   bb58:
-    v272 = storage_array_data_slot 0
+    v273 = and v258, 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff00
+    memory_object_store_word memorybytes, v272, 0, v273
+    jump bb60
+  bb59:
+    v274 = storage_array_data_slot 0
+    jump bb61
+  bb61:
+    v275 = phi [bb59: 0], [bb62: v280]
+    v276 = lt v275, v267
+    jumpi v276, bb62, bb63
+  bb63:
     jump bb60
   bb60:
-    v273 = phi [bb58: 0], [bb61: v278]
-    v274 = lt v273, v265
-    jumpi v274, bb61, bb62
+    ret v272
   bb62:
-    jump bb59
-  bb59:
-    ret v270
-  bb61:
-    v275 = add v272, v273
-    v276 = sload v275 !metadata(storage=symbolic(v275))
-    v277 = mul v273, 32
-    memory_object_store_word memorybytes, v270, v277, v276
-    v278 = add v273, 1
-    jump bb60
-  bb54:
+    v277 = add v274, v275
+    v278 = sload v277 !metadata(storage=symbolic(v277))
+    v279 = mul v275, 32
+    memory_object_store_word memorybytes, v272, v279, v278
+    v280 = add v275, 1
+    jump bb61
+  bb55:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 34 !metadata(memory=scratch)
     revert 0, 36
-  bb44:
-    v196 = memory_object_load_element memoryarray<1>, v161, v194
-    v197 = shr 64, v196
-    v198 = storage_array_data_slot 2
-    v199 = div v194, 1
-    v200 = add v198, v199
-    v201 = mod v194, 1
-    v202 = mul v201, 24
-    v203 = mul v202, 8
-    v204 = shl v203, 0xffffffffffffffffffffffffffffffffffffffffffffffff
-    v205 = sload v200 !metadata(storage=symbolic(v200))
-    v206 = not v204
-    v207 = and v205, v206
-    v208 = and v197, 0xffffffffffffffffffffffffffffffffffffffffffffffff
-    v209 = shl v203, v208
-    v210 = or v207, v209
-    sstore v200, v210 !metadata(storage=symbolic(v200))
-    v211 = add v194, 1
-    jump bb43
-  bb41:
-    v180 = storage_array_data_slot 2
-    v181 = div v178, 1
-    v182 = add v180, v181
-    v183 = mod v178, 1
-    v184 = mul v183, 24
-    v185 = mul v184, 8
-    v186 = shl v185, 0xffffffffffffffffffffffffffffffffffffffffffffffff
-    v187 = sload v182 !metadata(storage=symbolic(v182))
-    v188 = not v186
-    v189 = and v187, v188
-    v190 = and 0, 0xffffffffffffffffffffffffffffffffffffffffffffffff
-    v191 = shl v185, v190
-    v192 = or v189, v191
-    sstore v182, v192 !metadata(storage=symbolic(v182))
-    v193 = add v178, 1
-    jump bb40
-  bb36:
-    v164 = storage_array_data_slot 1
-    v165 = div v162, 1
-    v166 = add v164, v165
-    v167 = mod v162, 1
-    v168 = mul v167, 24
-    v169 = sload v166 !metadata(storage=symbolic(v166))
-    v170 = mul v168, 8
-    v171 = shr v170, v169
-    v172 = and v171, 0xffffffffffffffffffffffffffffffffffffffffffffffff
-    v173 = shl 64, v172
-    memory_object_store_element memoryarray<1>, v161, v162, v173
-    v174 = add v162, 1
-    jump bb35
-  bb31:
+  bb45:
+    v198 = memory_object_load_element memoryarray<1>, v163, v196
+    v199 = shr 64, v198
+    v200 = storage_array_data_slot 2
+    v201 = div v196, 1
+    v202 = add v200, v201
+    v203 = mod v196, 1
+    v204 = mul v203, 24
+    v205 = mul v204, 8
+    v206 = shl v205, 0xffffffffffffffffffffffffffffffffffffffffffffffff
+    v207 = sload v202 !metadata(storage=symbolic(v202))
+    v208 = not v206
+    v209 = and v207, v208
+    v210 = and v199, 0xffffffffffffffffffffffffffffffffffffffffffffffff
+    v211 = shl v205, v210
+    v212 = or v209, v211
+    sstore v202, v212 !metadata(storage=symbolic(v202))
+    v213 = add v196, 1
+    jump bb44
+  bb42:
+    v182 = storage_array_data_slot 2
+    v183 = div v180, 1
+    v184 = add v182, v183
+    v185 = mod v180, 1
+    v186 = mul v185, 24
+    v187 = mul v186, 8
+    v188 = shl v187, 0xffffffffffffffffffffffffffffffffffffffffffffffff
+    v189 = sload v184 !metadata(storage=symbolic(v184))
+    v190 = not v188
+    v191 = and v189, v190
+    v192 = and 0, 0xffffffffffffffffffffffffffffffffffffffffffffffff
+    v193 = shl v187, v192
+    v194 = or v191, v193
+    sstore v184, v194 !metadata(storage=symbolic(v184))
+    v195 = add v180, 1
+    jump bb41
+  bb37:
+    v166 = storage_array_data_slot 1
+    v167 = div v164, 1
+    v168 = add v166, v167
+    v169 = mod v164, 1
+    v170 = mul v169, 24
+    v171 = sload v168 !metadata(storage=symbolic(v168))
+    v172 = mul v170, 8
+    v173 = shr v172, v171
+    v174 = and v173, 0xffffffffffffffffffffffffffffffffffffffffffffffff
+    v175 = shl 64, v174
+    memory_object_store_element memoryarray<1>, v163, v164, v175
+    v176 = add v164, 1
+    jump bb36
+  bb32:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 65 !metadata(memory=scratch)
     revert 0, 36

--- a/tests/ui/codegen/lowering/run-call/named_arguments.mir.stdout
+++ b/tests/ui/codegen/lowering/run-call/named_arguments.mir.stdout
@@ -258,13 +258,19 @@ fn @externalNamed() -> u256 [selector=0x1747fe5f, abi_params=[], abi_returns=[wo
     v4 = abi_encode [word, word], selector 0xba2f355f00000000000000000000000000000000000000000000000000000000, args v3, v2
     v5 = slice_ptr v4
     v6 = slice_len v4
-    v7 = staticcall v1, v0, v5, v6, 0, 0
-    jumpi v7, bb2, bb1
-  bb1:
-    revert_returndata
+    v7 = extcodesize v0
+    v8 = iszero v7
+    jumpi v8, bb1, bb2
   bb2:
-    v8 = sload 0 !metadata(storage=slot(0))
-    ret v8
+    v9 = staticcall v1, v0, v5, v6, 0, 0
+    jumpi v9, bb4, bb3
+  bb3:
+    revert_returndata
+  bb4:
+    v10 = sload 0 !metadata(storage=slot(0))
+    ret v10
+  bb1:
+    revert 0, 0
 }
 
 fn @receivePair(arg0: u256, arg1: u256) [selector=0xba2f355f, pure, abi_params=[u256, u256], abi_returns=[]] {

--- a/tests/ui/codegen/lowering/run-call/no_code_call_returns_evm_version.homestead.stdout
+++ b/tests/ui/codegen/lowering/run-call/no_code_call_returns_evm_version.homestead.stdout
@@ -33,50 +33,56 @@ data:
 
 fn @direct() -> u256 [selector=0x222b1407, abi_params=[], abi_returns=[word]] {
   bb0:
-    v0 = abi_encode [], selector 0x3fa4f24500000000000000000000000000000000000000000000000000000000
-    v1 = slice_ptr v0
-    v2 = slice_len v0
-    v3 = extcodesize 0
-    v4 = iszero v3
-    jumpi v4, bb1, bb2
+    v0 = fmp
+    v1 = add v0, 32
+    mstore v1, 0
+    v2 = abi_encode [], selector 0x3fa4f24500000000000000000000000000000000000000000000000000000000
+    v3 = slice_ptr v2
+    v4 = slice_len v2
+    v5 = extcodesize 0
+    v6 = iszero v5
+    jumpi v6, bb1, bb2
   bb2:
-    v5 = gas
-    v6 = sub v5, 50
-    v7 = call v6, 0, 0, v1, v2, v1, 32
-    jumpi v7, bb4, bb3
+    v7 = gas
+    v8 = sub v7, 50
+    v9 = call v8, 0, 0, v3, v4, v3, 32
+    jumpi v9, bb4, bb3
   bb3:
     revert_returndata
   bb4:
-    v8 = add v1, 0
-    v9 = mload v8
-    v10 = add v1, 0
+    v10 = add v3, 0
     v11 = mload v10
-    ret v11
+    v12 = add v3, 0
+    v13 = mload v12
+    ret v13
   bb1:
     revert 0, 0
 }
 
 fn @viewCall() -> u256 [selector=0x33fd44fa, view, abi_params=[], abi_returns=[word]] {
   bb0:
-    v0 = abi_encode [], selector 0x3fa4f24500000000000000000000000000000000000000000000000000000000
-    v1 = slice_ptr v0
-    v2 = slice_len v0
-    v3 = extcodesize 0
-    v4 = iszero v3
-    jumpi v4, bb1, bb2
+    v0 = fmp
+    v1 = add v0, 32
+    mstore v1, 0
+    v2 = abi_encode [], selector 0x3fa4f24500000000000000000000000000000000000000000000000000000000
+    v3 = slice_ptr v2
+    v4 = slice_len v2
+    v5 = extcodesize 0
+    v6 = iszero v5
+    jumpi v6, bb1, bb2
   bb2:
-    v5 = gas
-    v6 = sub v5, 50
-    v7 = call v6, 0, 0, v1, v2, v1, 32
-    jumpi v7, bb4, bb3
+    v7 = gas
+    v8 = sub v7, 50
+    v9 = call v8, 0, 0, v3, v4, v3, 32
+    jumpi v9, bb4, bb3
   bb3:
     revert_returndata
   bb4:
-    v8 = add v1, 0
-    v9 = mload v8
-    v10 = add v1, 0
+    v10 = add v3, 0
     v11 = mload v10
-    ret v11
+    v12 = add v3, 0
+    v13 = mload v12
+    ret v13
   bb1:
     revert 0, 0
 }
@@ -86,25 +92,28 @@ fn @pointer() -> u256 [selector=0x2f5f3b3c, abi_params=[], abi_returns=[word]] {
     v0 = and 0, 0xffffffff
     v1 = shl 224, v0
     v2 = shr 32, 0
-    v3 = abi_encode [], selector v1
-    v4 = slice_ptr v3
-    v5 = slice_len v3
-    v6 = extcodesize v2
-    v7 = iszero v6
-    jumpi v7, bb1, bb2
+    v3 = fmp
+    v4 = add v3, 32
+    mstore v4, 0
+    v5 = abi_encode [], selector v1
+    v6 = slice_ptr v5
+    v7 = slice_len v5
+    v8 = extcodesize v2
+    v9 = iszero v8
+    jumpi v9, bb1, bb2
   bb2:
-    v8 = gas
-    v9 = sub v8, 50
-    v10 = call v9, v2, 0, v4, v5, v4, 32
-    jumpi v10, bb4, bb3
+    v10 = gas
+    v11 = sub v10, 50
+    v12 = call v11, v2, 0, v6, v7, v6, 32
+    jumpi v12, bb4, bb3
   bb3:
     revert_returndata
   bb4:
-    v11 = add v4, 0
-    v12 = mload v11
-    v13 = add v4, 0
+    v13 = add v6, 0
     v14 = mload v13
-    ret v14
+    v15 = add v6, 0
+    v16 = mload v15
+    ret v16
   bb1:
     revert 0, 0
 }
@@ -114,30 +123,31 @@ fn @aggregate() -> u256 [selector=0xaf36778b, abi_params=[], abi_returns=[word]]
     v0 = alloc memorybytes, exact, uninitialized, infallible, 96
     set_memory_object_len memorybytes, v0, 64
     v1 = memory_object_data memorybytes, v0
-    v2 = abi_encode [], selector 0xa8aa1b3100000000000000000000000000000000000000000000000000000000
-    v3 = slice_ptr v2
-    v4 = slice_len v2
-    v5 = add v3, 32
-    mstore v5, 0
-    v6 = extcodesize 0
-    v7 = iszero v6
-    jumpi v7, bb1, bb2
+    v2 = fmp
+    v3 = add v2, 64
+    mstore v3, 0
+    v4 = abi_encode [], selector 0xa8aa1b3100000000000000000000000000000000000000000000000000000000
+    v5 = slice_ptr v4
+    v6 = slice_len v4
+    v7 = extcodesize 0
+    v8 = iszero v7
+    jumpi v8, bb1, bb2
   bb2:
-    v8 = gas
-    v9 = sub v8, 50
-    v10 = call v9, 0, 0, v3, v4, v3, 64
-    jumpi v10, bb4, bb3
+    v9 = gas
+    v10 = sub v9, 50
+    v11 = call v10, 0, 0, v5, v6, v5, 64
+    jumpi v11, bb4, bb3
   bb3:
     revert_returndata
   bb4:
-    mcopy v1, v3, 64
-    v11 = abi_decode [array<2, u256>], v0
-    v12 = lt 0, 2
-    v13 = iszero v12
-    jumpi v13, bb5, bb6
+    mcopy v1, v5, 64
+    v12 = abi_decode [array<2, u256>], v0
+    v13 = lt 0, 2
+    v14 = iszero v13
+    jumpi v14, bb5, bb6
   bb6:
-    v14 = memory_object_load_element memoryfixedarray<2, 1>, v11, 0
-    ret v14
+    v15 = memory_object_load_element memoryfixedarray<2, 1>, v12, 0
+    ret v15
   bb5:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 50 !metadata(memory=scratch)
@@ -206,25 +216,28 @@ fn @live() -> u256 [selector=0x957aa58c, abi_params=[], abi_returns=[word]] {
   bb1:
     revert_returndata
   bb2:
-    v7 = abi_encode [], selector 0x3fa4f24500000000000000000000000000000000000000000000000000000000
-    v8 = slice_ptr v7
-    v9 = slice_len v7
-    v10 = extcodesize v6
-    v11 = iszero v10
-    jumpi v11, bb3, bb4
+    v7 = fmp
+    v8 = add v7, 32
+    mstore v8, 0
+    v9 = abi_encode [], selector 0x3fa4f24500000000000000000000000000000000000000000000000000000000
+    v10 = slice_ptr v9
+    v11 = slice_len v9
+    v12 = extcodesize v6
+    v13 = iszero v12
+    jumpi v13, bb3, bb4
   bb4:
-    v12 = gas
-    v13 = sub v12, 50
-    v14 = call v13, v6, 0, v8, v9, v8, 32
-    jumpi v14, bb6, bb5
+    v14 = gas
+    v15 = sub v14, 50
+    v16 = call v15, v6, 0, v10, v11, v10, 32
+    jumpi v16, bb6, bb5
   bb5:
     revert_returndata
   bb6:
-    v15 = add v8, 0
-    v16 = mload v15
-    v17 = add v8, 0
+    v17 = add v10, 0
     v18 = mload v17
-    ret v18
+    v19 = add v10, 0
+    v20 = mload v19
+    ret v20
   bb3:
     revert 0, 0
 }
@@ -247,35 +260,36 @@ fn @liveAggregate() -> (u256, u256) [selector=0xc64a4ee9, abi_params=[], abi_ret
     v7 = alloc memorybytes, exact, uninitialized, infallible, 96
     set_memory_object_len memorybytes, v7, 64
     v8 = memory_object_data memorybytes, v7
-    v9 = abi_encode [], selector 0xa8aa1b3100000000000000000000000000000000000000000000000000000000
-    v10 = slice_ptr v9
-    v11 = slice_len v9
-    v12 = add v10, 32
-    mstore v12, 0
-    v13 = extcodesize v6
-    v14 = iszero v13
-    jumpi v14, bb3, bb4
+    v9 = fmp
+    v10 = add v9, 64
+    mstore v10, 0
+    v11 = abi_encode [], selector 0xa8aa1b3100000000000000000000000000000000000000000000000000000000
+    v12 = slice_ptr v11
+    v13 = slice_len v11
+    v14 = extcodesize v6
+    v15 = iszero v14
+    jumpi v15, bb3, bb4
   bb4:
-    v15 = gas
-    v16 = sub v15, 50
-    v17 = call v16, v6, 0, v10, v11, v10, 64
-    jumpi v17, bb6, bb5
+    v16 = gas
+    v17 = sub v16, 50
+    v18 = call v17, v6, 0, v12, v13, v12, 64
+    jumpi v18, bb6, bb5
   bb5:
     revert_returndata
   bb6:
-    mcopy v8, v10, 64
-    v18 = abi_decode [array<2, u256>], v7
-    v19 = lt 0, 2
-    v20 = iszero v19
-    jumpi v20, bb7, bb8
+    mcopy v8, v12, 64
+    v19 = abi_decode [array<2, u256>], v7
+    v20 = lt 0, 2
+    v21 = iszero v20
+    jumpi v21, bb7, bb8
   bb8:
-    v21 = memory_object_load_element memoryfixedarray<2, 1>, v18, 0
-    v22 = lt 1, 2
-    v23 = iszero v22
-    jumpi v23, bb7, bb9
+    v22 = memory_object_load_element memoryfixedarray<2, 1>, v19, 0
+    v23 = lt 1, 2
+    v24 = iszero v23
+    jumpi v24, bb7, bb9
   bb9:
-    v24 = memory_object_load_element memoryfixedarray<2, 1>, v18, 1
-    ret v21, v24
+    v25 = memory_object_load_element memoryfixedarray<2, 1>, v19, 1
+    ret v22, v25
   bb7:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 50 !metadata(memory=scratch)

--- a/tests/ui/codegen/lowering/run-call/no_code_call_returns_evm_version.homestead.stdout
+++ b/tests/ui/codegen/lowering/run-call/no_code_call_returns_evm_version.homestead.stdout
@@ -42,14 +42,14 @@ fn @direct() -> u256 [selector=0x222b1407, abi_params=[], abi_returns=[word]] {
   bb2:
     v5 = gas
     v6 = sub v5, 50
-    v7 = call v6, 0, 0, v1, v2, 0, 32
+    v7 = call v6, 0, 0, v1, v2, v1, 32
     jumpi v7, bb4, bb3
   bb3:
     revert_returndata
   bb4:
-    v8 = add 0, 0
+    v8 = add v1, 0
     v9 = mload v8
-    v10 = add 0, 0
+    v10 = add v1, 0
     v11 = mload v10
     ret v11
   bb1:
@@ -67,14 +67,14 @@ fn @viewCall() -> u256 [selector=0x33fd44fa, view, abi_params=[], abi_returns=[w
   bb2:
     v5 = gas
     v6 = sub v5, 50
-    v7 = call v6, 0, 0, v1, v2, 0, 32
+    v7 = call v6, 0, 0, v1, v2, v1, 32
     jumpi v7, bb4, bb3
   bb3:
     revert_returndata
   bb4:
-    v8 = add 0, 0
+    v8 = add v1, 0
     v9 = mload v8
-    v10 = add 0, 0
+    v10 = add v1, 0
     v11 = mload v10
     ret v11
   bb1:
@@ -95,14 +95,14 @@ fn @pointer() -> u256 [selector=0x2f5f3b3c, abi_params=[], abi_returns=[word]] {
   bb2:
     v8 = gas
     v9 = sub v8, 50
-    v10 = call v9, v2, 0, v4, v5, 0, 32
+    v10 = call v9, v2, 0, v4, v5, v4, 32
     jumpi v10, bb4, bb3
   bb3:
     revert_returndata
   bb4:
-    v11 = add 0, 0
+    v11 = add v4, 0
     v12 = mload v11
-    v13 = add 0, 0
+    v13 = add v4, 0
     v14 = mload v13
     ret v14
   bb1:
@@ -111,30 +111,33 @@ fn @pointer() -> u256 [selector=0x2f5f3b3c, abi_params=[], abi_returns=[word]] {
 
 fn @aggregate() -> u256 [selector=0xaf36778b, abi_params=[], abi_returns=[word]] {
   bb0:
-    v0 = abi_encode [], selector 0xa8aa1b3100000000000000000000000000000000000000000000000000000000
-    v1 = slice_ptr v0
-    v2 = slice_len v0
-    v3 = alloc raw, exact, uninitialized, infallible, 64
-    v4 = add v3, 32
-    mstore v4, 0
-    v5 = extcodesize 0
-    v6 = iszero v5
-    jumpi v6, bb1, bb2
+    v0 = alloc memorybytes, exact, uninitialized, infallible, 96
+    set_memory_object_len memorybytes, v0, 64
+    v1 = memory_object_data memorybytes, v0
+    v2 = abi_encode [], selector 0xa8aa1b3100000000000000000000000000000000000000000000000000000000
+    v3 = slice_ptr v2
+    v4 = slice_len v2
+    v5 = add v3, 32
+    mstore v5, 0
+    v6 = extcodesize 0
+    v7 = iszero v6
+    jumpi v7, bb1, bb2
   bb2:
-    v7 = gas
-    v8 = sub v7, 50
-    v9 = call v8, 0, 0, v1, v2, v3, 64
-    jumpi v9, bb4, bb3
+    v8 = gas
+    v9 = sub v8, 50
+    v10 = call v9, 0, 0, v3, v4, v3, 64
+    jumpi v10, bb4, bb3
   bb3:
     revert_returndata
   bb4:
-    v10 = abi_decode [array<2, u256>], v3
-    v11 = lt 0, 2
-    v12 = iszero v11
-    jumpi v12, bb5, bb6
+    mcopy v1, v3, 64
+    v11 = abi_decode [array<2, u256>], v0
+    v12 = lt 0, 2
+    v13 = iszero v12
+    jumpi v13, bb5, bb6
   bb6:
-    v13 = memory_object_load_element memoryfixedarray<2, 1>, v10, 0
-    ret v13
+    v14 = memory_object_load_element memoryfixedarray<2, 1>, v11, 0
+    ret v14
   bb5:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 50 !metadata(memory=scratch)
@@ -154,7 +157,7 @@ fn @directNoReturn() [selector=0xda4f8e3a, abi_params=[], abi_returns=[]] {
   bb2:
     v5 = gas
     v6 = sub v5, 50
-    v7 = call v6, 0, 0, v1, v2, 0, 0
+    v7 = call v6, 0, 0, v1, v2, v1, 0
     jumpi v7, bb4, bb3
   bb3:
     revert_returndata
@@ -178,7 +181,7 @@ fn @pointerNoReturn() [selector=0xcf820bfc, abi_params=[], abi_returns=[]] {
   bb2:
     v8 = gas
     v9 = sub v8, 50
-    v10 = call v9, v2, 0, v4, v5, 0, 0
+    v10 = call v9, v2, 0, v4, v5, v4, 0
     jumpi v10, bb4, bb3
   bb3:
     revert_returndata
@@ -212,14 +215,14 @@ fn @live() -> u256 [selector=0x957aa58c, abi_params=[], abi_returns=[word]] {
   bb4:
     v12 = gas
     v13 = sub v12, 50
-    v14 = call v13, v6, 0, v8, v9, 0, 32
+    v14 = call v13, v6, 0, v8, v9, v8, 32
     jumpi v14, bb6, bb5
   bb5:
     revert_returndata
   bb6:
-    v15 = add 0, 0
+    v15 = add v8, 0
     v16 = mload v15
-    v17 = add 0, 0
+    v17 = add v8, 0
     v18 = mload v17
     ret v18
   bb3:
@@ -241,35 +244,38 @@ fn @liveAggregate() -> (u256, u256) [selector=0xc64a4ee9, abi_params=[], abi_ret
   bb1:
     revert_returndata
   bb2:
-    v7 = abi_encode [], selector 0xa8aa1b3100000000000000000000000000000000000000000000000000000000
-    v8 = slice_ptr v7
-    v9 = slice_len v7
-    v10 = alloc raw, exact, uninitialized, infallible, 64
-    v11 = add v10, 32
-    mstore v11, 0
-    v12 = extcodesize v6
-    v13 = iszero v12
-    jumpi v13, bb3, bb4
+    v7 = alloc memorybytes, exact, uninitialized, infallible, 96
+    set_memory_object_len memorybytes, v7, 64
+    v8 = memory_object_data memorybytes, v7
+    v9 = abi_encode [], selector 0xa8aa1b3100000000000000000000000000000000000000000000000000000000
+    v10 = slice_ptr v9
+    v11 = slice_len v9
+    v12 = add v10, 32
+    mstore v12, 0
+    v13 = extcodesize v6
+    v14 = iszero v13
+    jumpi v14, bb3, bb4
   bb4:
-    v14 = gas
-    v15 = sub v14, 50
-    v16 = call v15, v6, 0, v8, v9, v10, 64
-    jumpi v16, bb6, bb5
+    v15 = gas
+    v16 = sub v15, 50
+    v17 = call v16, v6, 0, v10, v11, v10, 64
+    jumpi v17, bb6, bb5
   bb5:
     revert_returndata
   bb6:
-    v17 = abi_decode [array<2, u256>], v10
-    v18 = lt 0, 2
-    v19 = iszero v18
-    jumpi v19, bb7, bb8
+    mcopy v8, v10, 64
+    v18 = abi_decode [array<2, u256>], v7
+    v19 = lt 0, 2
+    v20 = iszero v19
+    jumpi v20, bb7, bb8
   bb8:
-    v20 = memory_object_load_element memoryfixedarray<2, 1>, v17, 0
-    v21 = lt 1, 2
-    v22 = iszero v21
-    jumpi v22, bb7, bb9
+    v21 = memory_object_load_element memoryfixedarray<2, 1>, v18, 0
+    v22 = lt 1, 2
+    v23 = iszero v22
+    jumpi v23, bb7, bb9
   bb9:
-    v23 = memory_object_load_element memoryfixedarray<2, 1>, v17, 1
-    ret v20, v23
+    v24 = memory_object_load_element memoryfixedarray<2, 1>, v18, 1
+    ret v21, v24
   bb7:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 50 !metadata(memory=scratch)

--- a/tests/ui/codegen/lowering/run-call/no_code_call_returns_evm_version.homestead.stdout
+++ b/tests/ui/codegen/lowering/run-call/no_code_call_returns_evm_version.homestead.stdout
@@ -1,0 +1,267 @@
+// === ROOT/tests/ui/codegen/lowering/run-call/no_code_call_returns_evm_version.sol:NoCodeCallee ===
+@module NoCodeCallee
+fn @value() -> u256 [selector=0x3fa4f245, pure, abi_params=[], abi_returns=[word]] {
+  bb0:
+    ret 42
+}
+
+fn @pair() -> memoryfixedarray [selector=0xa8aa1b31, pure, abi_params=[], abi_returns=[array<2, word>]] {
+  bb0:
+    v0 = alloc memoryfixedarray<2, 1>, exact, uninitialized, infallible, 64
+    memory_zero v0, 64
+    v1 = lt 0, 2
+    v2 = iszero v1
+    jumpi v2, bb1, bb2
+  bb2:
+    memory_object_store_element memoryfixedarray<2, 1>, v0, 0, 1
+    v3 = lt 1, 2
+    v4 = iszero v3
+    jumpi v4, bb1, bb3
+  bb3:
+    memory_object_store_element memoryfixedarray<2, 1>, v0, 1, 2
+    ret v0
+  bb1:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 50 !metadata(memory=scratch)
+    revert 0, 36
+}
+
+// === ROOT/tests/ui/codegen/lowering/run-call/no_code_call_returns_evm_version.sol:NoCodeReturnCalls ===
+@module NoCodeReturnCalls
+data:
+  NoCodeCallee_initcode_0: hex"3460105761010e8060166000396000f35b60006000fe346046576000357c0100000000000000000000000000000000000000000000000000000000900480633fa4f24514603e578063a8aa1b31146042576046565b604b565b605d565b600080fe5b602a6080526020608001608090036080f35b6101206040526040518060c0528060c05260408101604052604036828060c052376002600010151560b8575b7f4e487b7100000000000000000000000000000000000000000000000000000000600052603260045260246000fe5b8060c0526001815260026001101560895760208101600281525060005b8060e052600281101560fe576020818060e05202820151602082026080015260018101905060d5565b6040608001915050608090036080f3"
+
+fn @direct() -> u256 [selector=0x222b1407, abi_params=[], abi_returns=[word]] {
+  bb0:
+    v0 = gas
+    v1 = abi_encode [], selector 0x3fa4f24500000000000000000000000000000000000000000000000000000000
+    v2 = slice_ptr v1
+    v3 = slice_len v1
+    v4 = extcodesize 0
+    v5 = iszero v4
+    jumpi v5, bb1, bb2
+  bb2:
+    v6 = call v0, 0, 0, v2, v3, 0, 32
+    jumpi v6, bb4, bb3
+  bb3:
+    revert_returndata
+  bb4:
+    v7 = add 0, 0
+    v8 = mload v7
+    v9 = add 0, 0
+    v10 = mload v9
+    ret v10
+  bb1:
+    revert 0, 0
+}
+
+fn @viewCall() -> u256 [selector=0x33fd44fa, view, abi_params=[], abi_returns=[word]] {
+  bb0:
+    v0 = gas
+    v1 = abi_encode [], selector 0x3fa4f24500000000000000000000000000000000000000000000000000000000
+    v2 = slice_ptr v1
+    v3 = slice_len v1
+    v4 = extcodesize 0
+    v5 = iszero v4
+    jumpi v5, bb1, bb2
+  bb2:
+    v6 = call v0, 0, 0, v2, v3, 0, 32
+    jumpi v6, bb4, bb3
+  bb3:
+    revert_returndata
+  bb4:
+    v7 = add 0, 0
+    v8 = mload v7
+    v9 = add 0, 0
+    v10 = mload v9
+    ret v10
+  bb1:
+    revert 0, 0
+}
+
+fn @pointer() -> u256 [selector=0x2f5f3b3c, abi_params=[], abi_returns=[word]] {
+  bb0:
+    v0 = and 0, 0xffffffff
+    v1 = shl 224, v0
+    v2 = shr 32, 0
+    v3 = gas
+    v4 = abi_encode [], selector v1
+    v5 = slice_ptr v4
+    v6 = slice_len v4
+    v7 = extcodesize v2
+    v8 = iszero v7
+    jumpi v8, bb1, bb2
+  bb2:
+    v9 = call v3, v2, 0, v5, v6, 0, 32
+    jumpi v9, bb4, bb3
+  bb3:
+    revert_returndata
+  bb4:
+    v10 = add 0, 0
+    v11 = mload v10
+    v12 = add 0, 0
+    v13 = mload v12
+    ret v13
+  bb1:
+    revert 0, 0
+}
+
+fn @aggregate() -> u256 [selector=0xaf36778b, abi_params=[], abi_returns=[word]] {
+  bb0:
+    v0 = gas
+    v1 = abi_encode [], selector 0xa8aa1b3100000000000000000000000000000000000000000000000000000000
+    v2 = slice_ptr v1
+    v3 = slice_len v1
+    v4 = alloc raw, exact, uninitialized, infallible, 64
+    v5 = extcodesize 0
+    v6 = iszero v5
+    jumpi v6, bb1, bb2
+  bb2:
+    v7 = call v0, 0, 0, v2, v3, v4, 64
+    jumpi v7, bb4, bb3
+  bb3:
+    revert_returndata
+  bb4:
+    v8 = abi_decode [array<2, u256>], v4
+    v9 = lt 0, 2
+    v10 = iszero v9
+    jumpi v10, bb5, bb6
+  bb6:
+    v11 = memory_object_load_element memoryfixedarray<2, 1>, v8, 0
+    ret v11
+  bb5:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 50 !metadata(memory=scratch)
+    revert 0, 36
+  bb1:
+    revert 0, 0
+}
+
+fn @directNoReturn() [selector=0xda4f8e3a, abi_params=[], abi_returns=[]] {
+  bb0:
+    v0 = gas
+    v1 = abi_encode [], selector 0x5dfc2e4a00000000000000000000000000000000000000000000000000000000
+    v2 = slice_ptr v1
+    v3 = slice_len v1
+    v4 = extcodesize 0
+    v5 = iszero v4
+    jumpi v5, bb1, bb2
+  bb2:
+    v6 = call v0, 0, 0, v2, v3, 0, 0
+    jumpi v6, bb4, bb3
+  bb3:
+    revert_returndata
+  bb4:
+    stop
+  bb1:
+    revert 0, 0
+}
+
+fn @pointerNoReturn() [selector=0xcf820bfc, abi_params=[], abi_returns=[]] {
+  bb0:
+    v0 = and 0, 0xffffffff
+    v1 = shl 224, v0
+    v2 = shr 32, 0
+    v3 = gas
+    v4 = abi_encode [], selector v1
+    v5 = slice_ptr v4
+    v6 = slice_len v4
+    v7 = extcodesize v2
+    v8 = iszero v7
+    jumpi v8, bb1, bb2
+  bb2:
+    v9 = call v3, v2, 0, v5, v6, 0, 0
+    jumpi v9, bb4, bb3
+  bb3:
+    revert_returndata
+  bb4:
+    stop
+  bb1:
+    revert 0, 0
+}
+
+fn @live() -> u256 [selector=0x957aa58c, abi_params=[], abi_returns=[word]] {
+  bb0:
+    v0 = abi_encode []
+    v1 = not 31
+    v2 = and 323, v1
+    v3 = alloc raw, exact, uninitialized, infallible, v2
+    data_copy NoCodeCallee_initcode_0, v3, 292
+    v4 = slice_ptr v0
+    v5 = add v3, 292
+    mcopy v5, v4, 0 !metadata(memory=heap)
+    v6 = create 0, v3, 292
+    jumpi v6, bb2, bb1
+  bb1:
+    revert_returndata
+  bb2:
+    v7 = gas
+    v8 = abi_encode [], selector 0x3fa4f24500000000000000000000000000000000000000000000000000000000
+    v9 = slice_ptr v8
+    v10 = slice_len v8
+    v11 = extcodesize v6
+    v12 = iszero v11
+    jumpi v12, bb3, bb4
+  bb4:
+    v13 = call v7, v6, 0, v9, v10, 0, 32
+    jumpi v13, bb6, bb5
+  bb5:
+    revert_returndata
+  bb6:
+    v14 = add 0, 0
+    v15 = mload v14
+    v16 = add 0, 0
+    v17 = mload v16
+    ret v17
+  bb3:
+    revert 0, 0
+}
+
+fn @liveAggregate() -> (u256, u256) [selector=0xc64a4ee9, abi_params=[], abi_returns=[word, word]] {
+  bb0:
+    v0 = abi_encode []
+    v1 = not 31
+    v2 = and 323, v1
+    v3 = alloc raw, exact, uninitialized, infallible, v2
+    data_copy NoCodeCallee_initcode_0, v3, 292
+    v4 = slice_ptr v0
+    v5 = add v3, 292
+    mcopy v5, v4, 0 !metadata(memory=heap)
+    v6 = create 0, v3, 292
+    jumpi v6, bb2, bb1
+  bb1:
+    revert_returndata
+  bb2:
+    v7 = gas
+    v8 = abi_encode [], selector 0xa8aa1b3100000000000000000000000000000000000000000000000000000000
+    v9 = slice_ptr v8
+    v10 = slice_len v8
+    v11 = alloc raw, exact, uninitialized, infallible, 64
+    v12 = extcodesize v6
+    v13 = iszero v12
+    jumpi v13, bb3, bb4
+  bb4:
+    v14 = call v7, v6, 0, v9, v10, v11, 64
+    jumpi v14, bb6, bb5
+  bb5:
+    revert_returndata
+  bb6:
+    v15 = abi_decode [array<2, u256>], v11
+    v16 = lt 0, 2
+    v17 = iszero v16
+    jumpi v17, bb7, bb8
+  bb8:
+    v18 = memory_object_load_element memoryfixedarray<2, 1>, v15, 0
+    v19 = lt 1, 2
+    v20 = iszero v19
+    jumpi v20, bb7, bb9
+  bb9:
+    v21 = memory_object_load_element memoryfixedarray<2, 1>, v15, 1
+    ret v18, v21
+  bb7:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 50 !metadata(memory=scratch)
+    revert 0, 36
+  bb3:
+    revert 0, 0
+}

--- a/tests/ui/codegen/lowering/run-call/no_code_call_returns_evm_version.homestead.stdout
+++ b/tests/ui/codegen/lowering/run-call/no_code_call_returns_evm_version.homestead.stdout
@@ -33,48 +33,50 @@ data:
 
 fn @direct() -> u256 [selector=0x222b1407, abi_params=[], abi_returns=[word]] {
   bb0:
-    v0 = gas
-    v1 = abi_encode [], selector 0x3fa4f24500000000000000000000000000000000000000000000000000000000
-    v2 = slice_ptr v1
-    v3 = slice_len v1
-    v4 = extcodesize 0
-    v5 = iszero v4
-    jumpi v5, bb1, bb2
+    v0 = abi_encode [], selector 0x3fa4f24500000000000000000000000000000000000000000000000000000000
+    v1 = slice_ptr v0
+    v2 = slice_len v0
+    v3 = extcodesize 0
+    v4 = iszero v3
+    jumpi v4, bb1, bb2
   bb2:
-    v6 = call v0, 0, 0, v2, v3, 0, 32
-    jumpi v6, bb4, bb3
+    v5 = gas
+    v6 = sub v5, 50
+    v7 = call v6, 0, 0, v1, v2, 0, 32
+    jumpi v7, bb4, bb3
   bb3:
     revert_returndata
   bb4:
-    v7 = add 0, 0
-    v8 = mload v7
-    v9 = add 0, 0
-    v10 = mload v9
-    ret v10
+    v8 = add 0, 0
+    v9 = mload v8
+    v10 = add 0, 0
+    v11 = mload v10
+    ret v11
   bb1:
     revert 0, 0
 }
 
 fn @viewCall() -> u256 [selector=0x33fd44fa, view, abi_params=[], abi_returns=[word]] {
   bb0:
-    v0 = gas
-    v1 = abi_encode [], selector 0x3fa4f24500000000000000000000000000000000000000000000000000000000
-    v2 = slice_ptr v1
-    v3 = slice_len v1
-    v4 = extcodesize 0
-    v5 = iszero v4
-    jumpi v5, bb1, bb2
+    v0 = abi_encode [], selector 0x3fa4f24500000000000000000000000000000000000000000000000000000000
+    v1 = slice_ptr v0
+    v2 = slice_len v0
+    v3 = extcodesize 0
+    v4 = iszero v3
+    jumpi v4, bb1, bb2
   bb2:
-    v6 = call v0, 0, 0, v2, v3, 0, 32
-    jumpi v6, bb4, bb3
+    v5 = gas
+    v6 = sub v5, 50
+    v7 = call v6, 0, 0, v1, v2, 0, 32
+    jumpi v7, bb4, bb3
   bb3:
     revert_returndata
   bb4:
-    v7 = add 0, 0
-    v8 = mload v7
-    v9 = add 0, 0
-    v10 = mload v9
-    ret v10
+    v8 = add 0, 0
+    v9 = mload v8
+    v10 = add 0, 0
+    v11 = mload v10
+    ret v11
   bb1:
     revert 0, 0
 }
@@ -84,51 +86,55 @@ fn @pointer() -> u256 [selector=0x2f5f3b3c, abi_params=[], abi_returns=[word]] {
     v0 = and 0, 0xffffffff
     v1 = shl 224, v0
     v2 = shr 32, 0
-    v3 = gas
-    v4 = abi_encode [], selector v1
-    v5 = slice_ptr v4
-    v6 = slice_len v4
-    v7 = extcodesize v2
-    v8 = iszero v7
-    jumpi v8, bb1, bb2
+    v3 = abi_encode [], selector v1
+    v4 = slice_ptr v3
+    v5 = slice_len v3
+    v6 = extcodesize v2
+    v7 = iszero v6
+    jumpi v7, bb1, bb2
   bb2:
-    v9 = call v3, v2, 0, v5, v6, 0, 32
-    jumpi v9, bb4, bb3
+    v8 = gas
+    v9 = sub v8, 50
+    v10 = call v9, v2, 0, v4, v5, 0, 32
+    jumpi v10, bb4, bb3
   bb3:
     revert_returndata
   bb4:
-    v10 = add 0, 0
-    v11 = mload v10
-    v12 = add 0, 0
-    v13 = mload v12
-    ret v13
+    v11 = add 0, 0
+    v12 = mload v11
+    v13 = add 0, 0
+    v14 = mload v13
+    ret v14
   bb1:
     revert 0, 0
 }
 
 fn @aggregate() -> u256 [selector=0xaf36778b, abi_params=[], abi_returns=[word]] {
   bb0:
-    v0 = gas
-    v1 = abi_encode [], selector 0xa8aa1b3100000000000000000000000000000000000000000000000000000000
-    v2 = slice_ptr v1
-    v3 = slice_len v1
-    v4 = alloc raw, exact, uninitialized, infallible, 64
+    v0 = abi_encode [], selector 0xa8aa1b3100000000000000000000000000000000000000000000000000000000
+    v1 = slice_ptr v0
+    v2 = slice_len v0
+    v3 = alloc raw, exact, uninitialized, infallible, 64
+    v4 = add v3, 32
+    mstore v4, 0
     v5 = extcodesize 0
     v6 = iszero v5
     jumpi v6, bb1, bb2
   bb2:
-    v7 = call v0, 0, 0, v2, v3, v4, 64
-    jumpi v7, bb4, bb3
+    v7 = gas
+    v8 = sub v7, 50
+    v9 = call v8, 0, 0, v1, v2, v3, 64
+    jumpi v9, bb4, bb3
   bb3:
     revert_returndata
   bb4:
-    v8 = abi_decode [array<2, u256>], v4
-    v9 = lt 0, 2
-    v10 = iszero v9
-    jumpi v10, bb5, bb6
+    v10 = abi_decode [array<2, u256>], v3
+    v11 = lt 0, 2
+    v12 = iszero v11
+    jumpi v12, bb5, bb6
   bb6:
-    v11 = memory_object_load_element memoryfixedarray<2, 1>, v8, 0
-    ret v11
+    v13 = memory_object_load_element memoryfixedarray<2, 1>, v10, 0
+    ret v13
   bb5:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 50 !metadata(memory=scratch)
@@ -139,16 +145,17 @@ fn @aggregate() -> u256 [selector=0xaf36778b, abi_params=[], abi_returns=[word]]
 
 fn @directNoReturn() [selector=0xda4f8e3a, abi_params=[], abi_returns=[]] {
   bb0:
-    v0 = gas
-    v1 = abi_encode [], selector 0x5dfc2e4a00000000000000000000000000000000000000000000000000000000
-    v2 = slice_ptr v1
-    v3 = slice_len v1
-    v4 = extcodesize 0
-    v5 = iszero v4
-    jumpi v5, bb1, bb2
+    v0 = abi_encode [], selector 0x5dfc2e4a00000000000000000000000000000000000000000000000000000000
+    v1 = slice_ptr v0
+    v2 = slice_len v0
+    v3 = extcodesize 0
+    v4 = iszero v3
+    jumpi v4, bb1, bb2
   bb2:
-    v6 = call v0, 0, 0, v2, v3, 0, 0
-    jumpi v6, bb4, bb3
+    v5 = gas
+    v6 = sub v5, 50
+    v7 = call v6, 0, 0, v1, v2, 0, 0
+    jumpi v7, bb4, bb3
   bb3:
     revert_returndata
   bb4:
@@ -162,16 +169,17 @@ fn @pointerNoReturn() [selector=0xcf820bfc, abi_params=[], abi_returns=[]] {
     v0 = and 0, 0xffffffff
     v1 = shl 224, v0
     v2 = shr 32, 0
-    v3 = gas
-    v4 = abi_encode [], selector v1
-    v5 = slice_ptr v4
-    v6 = slice_len v4
-    v7 = extcodesize v2
-    v8 = iszero v7
-    jumpi v8, bb1, bb2
+    v3 = abi_encode [], selector v1
+    v4 = slice_ptr v3
+    v5 = slice_len v3
+    v6 = extcodesize v2
+    v7 = iszero v6
+    jumpi v7, bb1, bb2
   bb2:
-    v9 = call v3, v2, 0, v5, v6, 0, 0
-    jumpi v9, bb4, bb3
+    v8 = gas
+    v9 = sub v8, 50
+    v10 = call v9, v2, 0, v4, v5, 0, 0
+    jumpi v10, bb4, bb3
   bb3:
     revert_returndata
   bb4:
@@ -195,24 +203,25 @@ fn @live() -> u256 [selector=0x957aa58c, abi_params=[], abi_returns=[word]] {
   bb1:
     revert_returndata
   bb2:
-    v7 = gas
-    v8 = abi_encode [], selector 0x3fa4f24500000000000000000000000000000000000000000000000000000000
-    v9 = slice_ptr v8
-    v10 = slice_len v8
-    v11 = extcodesize v6
-    v12 = iszero v11
-    jumpi v12, bb3, bb4
+    v7 = abi_encode [], selector 0x3fa4f24500000000000000000000000000000000000000000000000000000000
+    v8 = slice_ptr v7
+    v9 = slice_len v7
+    v10 = extcodesize v6
+    v11 = iszero v10
+    jumpi v11, bb3, bb4
   bb4:
-    v13 = call v7, v6, 0, v9, v10, 0, 32
-    jumpi v13, bb6, bb5
+    v12 = gas
+    v13 = sub v12, 50
+    v14 = call v13, v6, 0, v8, v9, 0, 32
+    jumpi v14, bb6, bb5
   bb5:
     revert_returndata
   bb6:
-    v14 = add 0, 0
-    v15 = mload v14
-    v16 = add 0, 0
-    v17 = mload v16
-    ret v17
+    v15 = add 0, 0
+    v16 = mload v15
+    v17 = add 0, 0
+    v18 = mload v17
+    ret v18
   bb3:
     revert 0, 0
 }
@@ -232,32 +241,35 @@ fn @liveAggregate() -> (u256, u256) [selector=0xc64a4ee9, abi_params=[], abi_ret
   bb1:
     revert_returndata
   bb2:
-    v7 = gas
-    v8 = abi_encode [], selector 0xa8aa1b3100000000000000000000000000000000000000000000000000000000
-    v9 = slice_ptr v8
-    v10 = slice_len v8
-    v11 = alloc raw, exact, uninitialized, infallible, 64
+    v7 = abi_encode [], selector 0xa8aa1b3100000000000000000000000000000000000000000000000000000000
+    v8 = slice_ptr v7
+    v9 = slice_len v7
+    v10 = alloc raw, exact, uninitialized, infallible, 64
+    v11 = add v10, 32
+    mstore v11, 0
     v12 = extcodesize v6
     v13 = iszero v12
     jumpi v13, bb3, bb4
   bb4:
-    v14 = call v7, v6, 0, v9, v10, v11, 64
-    jumpi v14, bb6, bb5
+    v14 = gas
+    v15 = sub v14, 50
+    v16 = call v15, v6, 0, v8, v9, v10, 64
+    jumpi v16, bb6, bb5
   bb5:
     revert_returndata
   bb6:
-    v15 = abi_decode [array<2, u256>], v11
-    v16 = lt 0, 2
-    v17 = iszero v16
-    jumpi v17, bb7, bb8
+    v17 = abi_decode [array<2, u256>], v10
+    v18 = lt 0, 2
+    v19 = iszero v18
+    jumpi v19, bb7, bb8
   bb8:
-    v18 = memory_object_load_element memoryfixedarray<2, 1>, v15, 0
-    v19 = lt 1, 2
-    v20 = iszero v19
-    jumpi v20, bb7, bb9
+    v20 = memory_object_load_element memoryfixedarray<2, 1>, v17, 0
+    v21 = lt 1, 2
+    v22 = iszero v21
+    jumpi v22, bb7, bb9
   bb9:
-    v21 = memory_object_load_element memoryfixedarray<2, 1>, v15, 1
-    ret v18, v21
+    v23 = memory_object_load_element memoryfixedarray<2, 1>, v17, 1
+    ret v20, v23
   bb7:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 50 !metadata(memory=scratch)

--- a/tests/ui/codegen/lowering/run-call/no_code_call_returns_evm_version.osaka.stdout
+++ b/tests/ui/codegen/lowering/run-call/no_code_call_returns_evm_version.osaka.stdout
@@ -1,0 +1,267 @@
+// === ROOT/tests/ui/codegen/lowering/run-call/no_code_call_returns_evm_version.sol:NoCodeCallee ===
+@module NoCodeCallee
+fn @value() -> u256 [selector=0x3fa4f245, pure, abi_params=[], abi_returns=[word]] {
+  bb0:
+    ret 42
+}
+
+fn @pair() -> memoryfixedarray [selector=0xa8aa1b31, pure, abi_params=[], abi_returns=[array<2, word>]] {
+  bb0:
+    v0 = alloc memoryfixedarray<2, 1>, exact, uninitialized, infallible, 64
+    memory_zero v0, 64
+    v1 = lt 0, 2
+    v2 = iszero v1
+    jumpi v2, bb1, bb2
+  bb2:
+    memory_object_store_element memoryfixedarray<2, 1>, v0, 0, 1
+    v3 = lt 1, 2
+    v4 = iszero v3
+    jumpi v4, bb1, bb3
+  bb3:
+    memory_object_store_element memoryfixedarray<2, 1>, v0, 1, 2
+    ret v0
+  bb1:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 50 !metadata(memory=scratch)
+    revert 0, 36
+}
+
+// === ROOT/tests/ui/codegen/lowering/run-call/no_code_call_returns_evm_version.sol:NoCodeReturnCalls ===
+@module NoCodeReturnCalls
+data:
+  NoCodeCallee_initcode_0: hex"34600d5760eb8060115f395ff35b5f5ffd346028575f3560e01c80633fa4f245146020578063a8aa1b31146024576028565b602c565b603e565b5f5ffd5b602a6080526020608001608090036080f35b6101206040526040518060c0528060c05260408101604052604036828060c0523760025f1015156096575b7f4e487b71000000000000000000000000000000000000000000000000000000005f52603260045260245ffd5b8060c052600181526002600110156069576020810160028152505f5b8060e052600281101560db576020818060e05202820151602082026080015260018101905060b2565b6040608001915050608090036080f3"
+
+fn @direct() -> u256 [selector=0x222b1407, abi_params=[], abi_returns=[word]] {
+  bb0:
+    v0 = gas
+    v1 = abi_encode [], selector 0x3fa4f24500000000000000000000000000000000000000000000000000000000
+    v2 = slice_ptr v1
+    v3 = slice_len v1
+    v4 = call v0, 0, 0, v2, v3, 0, 32
+    jumpi v4, bb2, bb1
+  bb1:
+    revert_returndata
+  bb2:
+    v5 = returndatasize
+    v6 = lt v5, 32
+    jumpi v6, bb3, bb4
+  bb4:
+    v7 = add 0, 0
+    v8 = mload v7
+    v9 = add 0, 0
+    v10 = mload v9
+    ret v10
+  bb3:
+    revert 0, 0
+}
+
+fn @viewCall() -> u256 [selector=0x33fd44fa, view, abi_params=[], abi_returns=[word]] {
+  bb0:
+    v0 = gas
+    v1 = abi_encode [], selector 0x3fa4f24500000000000000000000000000000000000000000000000000000000
+    v2 = slice_ptr v1
+    v3 = slice_len v1
+    v4 = staticcall v0, 0, v2, v3, 0, 32
+    jumpi v4, bb2, bb1
+  bb1:
+    revert_returndata
+  bb2:
+    v5 = returndatasize
+    v6 = lt v5, 32
+    jumpi v6, bb3, bb4
+  bb4:
+    v7 = add 0, 0
+    v8 = mload v7
+    v9 = add 0, 0
+    v10 = mload v9
+    ret v10
+  bb3:
+    revert 0, 0
+}
+
+fn @pointer() -> u256 [selector=0x2f5f3b3c, abi_params=[], abi_returns=[word]] {
+  bb0:
+    v0 = and 0, 0xffffffff
+    v1 = shl 224, v0
+    v2 = shr 32, 0
+    v3 = gas
+    v4 = abi_encode [], selector v1
+    v5 = slice_ptr v4
+    v6 = slice_len v4
+    v7 = call v3, v2, 0, v5, v6, 0, 32
+    jumpi v7, bb2, bb1
+  bb1:
+    revert_returndata
+  bb2:
+    v8 = returndatasize
+    v9 = lt v8, 32
+    jumpi v9, bb3, bb4
+  bb4:
+    v10 = add 0, 0
+    v11 = mload v10
+    v12 = add 0, 0
+    v13 = mload v12
+    ret v13
+  bb3:
+    revert 0, 0
+}
+
+fn @aggregate() -> u256 [selector=0xaf36778b, abi_params=[], abi_returns=[word]] {
+  bb0:
+    v0 = gas
+    v1 = abi_encode [], selector 0xa8aa1b3100000000000000000000000000000000000000000000000000000000
+    v2 = slice_ptr v1
+    v3 = slice_len v1
+    v4 = alloc raw, exact, uninitialized, infallible, 64
+    v5 = call v0, 0, 0, v2, v3, v4, 64
+    jumpi v5, bb2, bb1
+  bb1:
+    revert_returndata
+  bb2:
+    v6 = returndatasize
+    v7 = lt v6, 64
+    jumpi v7, bb3, bb4
+  bb4:
+    v8 = abi_decode [array<2, u256>], v4
+    v9 = lt 0, 2
+    v10 = iszero v9
+    jumpi v10, bb5, bb6
+  bb6:
+    v11 = memory_object_load_element memoryfixedarray<2, 1>, v8, 0
+    ret v11
+  bb5:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 50 !metadata(memory=scratch)
+    revert 0, 36
+  bb3:
+    revert 0, 0
+}
+
+fn @directNoReturn() [selector=0xda4f8e3a, abi_params=[], abi_returns=[]] {
+  bb0:
+    v0 = gas
+    v1 = abi_encode [], selector 0x5dfc2e4a00000000000000000000000000000000000000000000000000000000
+    v2 = slice_ptr v1
+    v3 = slice_len v1
+    v4 = extcodesize 0
+    v5 = iszero v4
+    jumpi v5, bb1, bb2
+  bb2:
+    v6 = call v0, 0, 0, v2, v3, 0, 0
+    jumpi v6, bb4, bb3
+  bb3:
+    revert_returndata
+  bb4:
+    stop
+  bb1:
+    revert 0, 0
+}
+
+fn @pointerNoReturn() [selector=0xcf820bfc, abi_params=[], abi_returns=[]] {
+  bb0:
+    v0 = and 0, 0xffffffff
+    v1 = shl 224, v0
+    v2 = shr 32, 0
+    v3 = gas
+    v4 = abi_encode [], selector v1
+    v5 = slice_ptr v4
+    v6 = slice_len v4
+    v7 = extcodesize v2
+    v8 = iszero v7
+    jumpi v8, bb1, bb2
+  bb2:
+    v9 = call v3, v2, 0, v5, v6, 0, 0
+    jumpi v9, bb4, bb3
+  bb3:
+    revert_returndata
+  bb4:
+    stop
+  bb1:
+    revert 0, 0
+}
+
+fn @live() -> u256 [selector=0x957aa58c, abi_params=[], abi_returns=[word]] {
+  bb0:
+    v0 = abi_encode []
+    v1 = not 31
+    v2 = and 283, v1
+    v3 = alloc raw, exact, uninitialized, infallible, v2
+    data_copy NoCodeCallee_initcode_0, v3, 252
+    v4 = slice_ptr v0
+    v5 = add v3, 252
+    mcopy v5, v4, 0 !metadata(memory=heap)
+    v6 = create 0, v3, 252
+    jumpi v6, bb2, bb1
+  bb1:
+    revert_returndata
+  bb2:
+    v7 = gas
+    v8 = abi_encode [], selector 0x3fa4f24500000000000000000000000000000000000000000000000000000000
+    v9 = slice_ptr v8
+    v10 = slice_len v8
+    v11 = call v7, v6, 0, v9, v10, 0, 32
+    jumpi v11, bb4, bb3
+  bb3:
+    revert_returndata
+  bb4:
+    v12 = returndatasize
+    v13 = lt v12, 32
+    jumpi v13, bb5, bb6
+  bb6:
+    v14 = add 0, 0
+    v15 = mload v14
+    v16 = add 0, 0
+    v17 = mload v16
+    ret v17
+  bb5:
+    revert 0, 0
+}
+
+fn @liveAggregate() -> (u256, u256) [selector=0xc64a4ee9, abi_params=[], abi_returns=[word, word]] {
+  bb0:
+    v0 = abi_encode []
+    v1 = not 31
+    v2 = and 283, v1
+    v3 = alloc raw, exact, uninitialized, infallible, v2
+    data_copy NoCodeCallee_initcode_0, v3, 252
+    v4 = slice_ptr v0
+    v5 = add v3, 252
+    mcopy v5, v4, 0 !metadata(memory=heap)
+    v6 = create 0, v3, 252
+    jumpi v6, bb2, bb1
+  bb1:
+    revert_returndata
+  bb2:
+    v7 = gas
+    v8 = abi_encode [], selector 0xa8aa1b3100000000000000000000000000000000000000000000000000000000
+    v9 = slice_ptr v8
+    v10 = slice_len v8
+    v11 = alloc raw, exact, uninitialized, infallible, 64
+    v12 = call v7, v6, 0, v9, v10, v11, 64
+    jumpi v12, bb4, bb3
+  bb3:
+    revert_returndata
+  bb4:
+    v13 = returndatasize
+    v14 = lt v13, 64
+    jumpi v14, bb5, bb6
+  bb6:
+    v15 = abi_decode [array<2, u256>], v11
+    v16 = lt 0, 2
+    v17 = iszero v16
+    jumpi v17, bb7, bb8
+  bb8:
+    v18 = memory_object_load_element memoryfixedarray<2, 1>, v15, 0
+    v19 = lt 1, 2
+    v20 = iszero v19
+    jumpi v20, bb7, bb9
+  bb9:
+    v21 = memory_object_load_element memoryfixedarray<2, 1>, v15, 1
+    ret v18, v21
+  bb7:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 50 !metadata(memory=scratch)
+    revert 0, 36
+  bb5:
+    revert 0, 0
+}

--- a/tests/ui/codegen/lowering/run-call/no_code_call_returns_evm_version.sol
+++ b/tests/ui/codegen/lowering/run-call/no_code_call_returns_evm_version.sol
@@ -1,6 +1,7 @@
-//@ revisions: homestead spuriousDragon byzantium osaka
+//@ revisions: homestead tangerineWhistle spuriousDragon byzantium osaka
 //@[homestead] compile-flags: -O none --evm-version homestead -Zdump=mir
 //@[homestead] filecheck: --check-prefix=HOMESTEAD
+//@[tangerineWhistle] compile-flags: -O none --evm-version tangerineWhistle
 //@[spuriousDragon] compile-flags: -O none --evm-version spuriousDragon
 //@[byzantium] compile-flags: -O none --evm-version byzantium
 //@[osaka] compile-flags: -O none --evm-version osaka -Zdump=mir
@@ -13,8 +14,8 @@
 //@ run-call-fail: NoCodeReturnCalls::pointerNoReturn => 0x
 // Before Tangerine Whistle a call cannot request all the remaining gas, so the
 // succeeding cases skip the homestead revision.
-//@[spuriousDragon,byzantium,osaka] run-call: NoCodeReturnCalls::live => 42
-//@[spuriousDragon,byzantium,osaka] run-call: NoCodeReturnCalls::liveAggregate => 1, 2
+//@[tangerineWhistle,spuriousDragon,byzantium,osaka] run-call: NoCodeReturnCalls::live => 42
+//@[tangerineWhistle,spuriousDragon,byzantium,osaka] run-call: NoCodeReturnCalls::liveAggregate => 1, 2
 
 interface NoCodeTarget {
     function value() external returns (uint256);

--- a/tests/ui/codegen/lowering/run-call/no_code_call_returns_evm_version.sol
+++ b/tests/ui/codegen/lowering/run-call/no_code_call_returns_evm_version.sol
@@ -1,0 +1,126 @@
+//@ revisions: homestead spuriousDragon byzantium osaka
+//@[homestead] compile-flags: -O none --evm-version homestead -Zdump=mir
+//@[homestead] filecheck: --check-prefix=HOMESTEAD
+//@[spuriousDragon] compile-flags: -O none --evm-version spuriousDragon
+//@[byzantium] compile-flags: -O none --evm-version byzantium
+//@[osaka] compile-flags: -O none --evm-version osaka -Zdump=mir
+//@[osaka] filecheck: --check-prefix=OSAKA
+//@ run-call-fail: NoCodeReturnCalls::direct => 0x
+//@ run-call-fail: NoCodeReturnCalls::viewCall => 0x
+//@ run-call-fail: NoCodeReturnCalls::pointer => 0x
+//@ run-call-fail: NoCodeReturnCalls::aggregate => 0x
+//@ run-call-fail: NoCodeReturnCalls::directNoReturn => 0x
+//@ run-call-fail: NoCodeReturnCalls::pointerNoReturn => 0x
+// Before Tangerine Whistle a call cannot request all the remaining gas, so the
+// succeeding cases skip the homestead revision.
+//@[spuriousDragon,byzantium,osaka] run-call: NoCodeReturnCalls::live => 42
+//@[spuriousDragon,byzantium,osaka] run-call: NoCodeReturnCalls::liveAggregate => 1, 2
+
+interface NoCodeTarget {
+    function value() external returns (uint256);
+    function noop() external;
+}
+
+interface NoCodeViewTarget {
+    function value() external view returns (uint256);
+}
+
+interface NoCodeAggregateTarget {
+    function pair() external returns (uint256[2] memory);
+}
+
+contract NoCodeCallee {
+    function value() external pure returns (uint256) {
+        return 42;
+    }
+
+    function pair() external pure returns (uint256[2] memory values) {
+        values[0] = 1;
+        values[1] = 2;
+    }
+}
+
+contract NoCodeReturnCalls {
+    // A call that expects return data needs no `extcodesize` check from Byzantium on: the
+    // return-data length check already reverts for a code-less callee.
+    // HOMESTEAD-LABEL: fn @direct
+    // HOMESTEAD: extcodesize
+    // HOMESTEAD: call
+    // HOMESTEAD-NOT: returndatasize
+    // OSAKA-LABEL: fn @direct
+    // OSAKA-NOT: extcodesize
+    // OSAKA: call
+    // OSAKA: returndatasize
+    // OSAKA-NOT: extcodesize
+    function direct() external returns (uint256) {
+        return NoCodeTarget(address(0)).value();
+    }
+
+    // Pre-Byzantium has no `STATICCALL` either, so the view call is a `CALL`.
+    // HOMESTEAD-LABEL: fn @viewCall
+    // HOMESTEAD: extcodesize
+    // HOMESTEAD: call
+    // HOMESTEAD-NOT: staticcall
+    // OSAKA-LABEL: fn @viewCall
+    // OSAKA-NOT: extcodesize
+    // OSAKA: staticcall
+    // OSAKA: returndatasize
+    function viewCall() external view returns (uint256) {
+        return NoCodeViewTarget(address(0)).value();
+    }
+
+    // HOMESTEAD-LABEL: fn @pointer
+    // HOMESTEAD: extcodesize
+    // HOMESTEAD: call
+    // OSAKA-LABEL: fn @pointer
+    // OSAKA-NOT: extcodesize
+    // OSAKA: call
+    // OSAKA: returndatasize
+    function pointer() external returns (uint256) {
+        function() external returns (uint256) target;
+        return target();
+    }
+
+    // HOMESTEAD-LABEL: fn @aggregate
+    // HOMESTEAD: extcodesize
+    // HOMESTEAD: call
+    // OSAKA-LABEL: fn @aggregate
+    // OSAKA-NOT: extcodesize
+    // OSAKA: call
+    // OSAKA: returndatasize
+    function aggregate() external returns (uint256) {
+        return NoCodeAggregateTarget(address(0)).pair()[0];
+    }
+
+    // A call without return data always needs the check.
+    // HOMESTEAD-LABEL: fn @directNoReturn
+    // HOMESTEAD: extcodesize
+    // HOMESTEAD: call
+    // OSAKA-LABEL: fn @directNoReturn
+    // OSAKA: extcodesize
+    // OSAKA: call
+    function directNoReturn() external {
+        NoCodeTarget(address(0)).noop();
+    }
+
+    // HOMESTEAD-LABEL: fn @pointerNoReturn
+    // HOMESTEAD: extcodesize
+    // HOMESTEAD: call
+    // OSAKA-LABEL: fn @pointerNoReturn
+    // OSAKA: extcodesize
+    // OSAKA: call
+    function pointerNoReturn() external {
+        function() external target;
+        target();
+    }
+
+    function live() external returns (uint256) {
+        return NoCodeTarget(address(new NoCodeCallee())).value();
+    }
+
+    function liveAggregate() external returns (uint256, uint256) {
+        uint256[2] memory values =
+            NoCodeAggregateTarget(address(new NoCodeCallee())).pair();
+        return (values[0], values[1]);
+    }
+}

--- a/tests/ui/codegen/lowering/run-call/no_code_call_returns_evm_version.sol
+++ b/tests/ui/codegen/lowering/run-call/no_code_call_returns_evm_version.sol
@@ -12,10 +12,8 @@
 //@ run-call-fail: NoCodeReturnCalls::aggregate => 0x
 //@ run-call-fail: NoCodeReturnCalls::directNoReturn => 0x
 //@ run-call-fail: NoCodeReturnCalls::pointerNoReturn => 0x
-// Before Tangerine Whistle a call cannot request all the remaining gas, so the
-// succeeding cases skip the homestead revision.
-//@[tangerineWhistle,spuriousDragon,byzantium,osaka] run-call: NoCodeReturnCalls::live => 42
-//@[tangerineWhistle,spuriousDragon,byzantium,osaka] run-call: NoCodeReturnCalls::liveAggregate => 1, 2
+//@ run-call: NoCodeReturnCalls::live => 42
+//@ run-call: NoCodeReturnCalls::liveAggregate => 1, 2
 
 interface NoCodeTarget {
     function value() external returns (uint256);

--- a/tests/ui/codegen/lowering/run-call/pre_byzantium_dynamic_argument_expansion.homestead.stdout
+++ b/tests/ui/codegen/lowering/run-call/pre_byzantium_dynamic_argument_expansion.homestead.stdout
@@ -1,0 +1,262 @@
+// === ROOT/tests/ui/codegen/lowering/run-call/pre_byzantium_dynamic_argument_expansion.sol:WideCallee ===
+@module WideCallee
+fn @six(arg0: memorybytes) -> (u256, u256, u256, u256, u256, u256) [selector=0xb84d18fb, pure, abi_params=[bytes], abi_returns=[word, word, word, word, word, word]] {
+  bb0:
+    v0 = memory_object_len memorybytes, arg0
+    v1 = add v0, 4
+    v2 = lt v1, v0
+    jumpi v2, bb1, bb2
+  bb2:
+    ret v1, 1, 2, 3, 4, 5
+  bb1:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 17 !metadata(memory=scratch)
+    revert 0, 36
+}
+
+fn @sixString(arg0: memorybytes) -> (u256, u256, u256, u256, u256, u256) [selector=0xa52f51f1, pure, abi_params=[bytes], abi_returns=[word, word, word, word, word, word]] {
+  bb0:
+    v0 = memory_object_len memorybytes, arg0
+    v1 = add v0, 4
+    v2 = lt v1, v0
+    jumpi v2, bb1, bb2
+  bb2:
+    ret v1, 1, 2, 3, 4, 5
+  bb1:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 17 !metadata(memory=scratch)
+    revert 0, 36
+}
+
+// === ROOT/tests/ui/codegen/lowering/run-call/pre_byzantium_dynamic_argument_expansion.sol:WideCalls ===
+@module WideCalls
+data:
+  WideCallee_initcode_0: hex"346010576103578060166000396000f35b60006000fe346047576000357c010000000000000000000000000000000000000000000000000000000090048063a52f51f114603e578063b84d18fb146043576047565b610111565b604c565b600080fe5b6102c0604052602436101560f55760f0565b6101605180610160525160048101806101405280610140528181109150501560af577f4e487b7100000000000000000000000000000000000000000000000000000000600052601160045260246000fe5b610140518061014052608052602060800160018152602090016002815260209001600381526020900160048152602090016005815260209001608090036080f35b600080fe5b60fe60046101db565b6101a0518061016052806101605250605e565b6102c060405260243610156101bd576101b8565b61016051806101605251600481018061014052806101405281811091505015610177577f4e487b7100000000000000000000000000000000000000000000000000000000600052601160045260246000fe5b610140518061014052608052602060800160018152602090016002815260209001600381526020900160048152602090016005815260209001608090036080f35b600080fe5b6101c760046101db565b6101a0518061016052806101605250610125565b610180526101805135806102a052600401806101e052806101e0526020810167ffffffffffffffff6102a0511136806101c05282119150171561021e575b600080fe5b806101e052358061020052806102005260206101e0510180610220528061022052603f820180610240528061024052828061020052811015610289577f4e487b7100000000000000000000000000000000000000000000000000000000600052604160045260246000fe5b601f1981169050604051806102605280610260528181018061028052915081610280528061026052811067ffffffffffffffff821181179050156102f657610328565b602061026051016101e0513580610200526101e0516020018061022052823750610260516101a052565b80610280526040528161020052818061020052610260515280610220528061022052360381119050156102cc57610219565b7f4e487b7100000000000000000000000000000000000000000000000000000000600052604160045260246000fe"
+
+fn @plainCall() -> u256 [selector=0x707bf9ed, abi_params=[], abi_returns=[word]] {
+  bb0:
+    v0 = abi_encode []
+    v1 = not 31
+    v2 = and 908, v1
+    v3 = alloc raw, exact, uninitialized, infallible, v2
+    data_copy WideCallee_initcode_0, v3, 877
+    v4 = slice_ptr v0
+    v5 = add v3, 877
+    mcopy v5, v4, 0 !metadata(memory=heap)
+    v6 = create 0, v3, 877
+    jumpi v6, bb2, bb1
+  bb1:
+    revert_returndata
+  bb2:
+    v7 = alloc memorybytes, exact, uninitialized, infallible, 32
+    set_memory_object_len memorybytes, v7, 0
+    v8 = memory_object_data memorybytes, v7
+    v9 = fmp
+    v10 = add v9, 192
+    mstore v10, 0
+    v11 = abi_encode [memory_bytes], selector 0xb84d18fb00000000000000000000000000000000000000000000000000000000, args v7
+    v12 = slice_ptr v11
+    v13 = slice_len v11
+    v14 = extcodesize v6
+    v15 = iszero v14
+    jumpi v15, bb3, bb4
+  bb4:
+    v16 = gas
+    v17 = sub v16, 50
+    v18 = call v17, v6, 0, v12, v13, v12, 192
+    jumpi v18, bb6, bb5
+  bb5:
+    revert_returndata
+  bb6:
+    v19 = add v12, 0
+    v20 = mload v19
+    v21 = add v12, 32
+    v22 = mload v21
+    v23 = add v12, 64
+    v24 = mload v23
+    v25 = add v12, 96
+    v26 = mload v25
+    v27 = add v12, 128
+    v28 = mload v27
+    v29 = add v12, 160
+    v30 = mload v29
+    frame_store multi_return, word, 0, v12 !metadata(memory=scratch)
+    v31 = add v12, 0
+    v32 = mload v31
+    v33 = frame_load multi_return, word, 0 !metadata(memory=scratch)
+    v34 = add v33, 32
+    v35 = mload v34
+    v36 = add v33, 64
+    v37 = mload v36
+    v38 = add v33, 96
+    v39 = mload v38
+    v40 = add v33, 128
+    v41 = mload v40
+    v42 = add v33, 160
+    v43 = mload v42
+    v44 = add v32, v43
+    v45 = lt v44, v32
+    jumpi v45, bb7, bb8
+  bb8:
+    ret v44
+  bb7:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 17 !metadata(memory=scratch)
+    revert 0, 36
+  bb3:
+    revert 0, 0
+}
+
+fn @tryCall() -> u256 [selector=0x118dfb0e, abi_params=[], abi_returns=[word]] {
+  bb0:
+    v0 = abi_encode []
+    v1 = not 31
+    v2 = and 908, v1
+    v3 = alloc raw, exact, uninitialized, infallible, v2
+    data_copy WideCallee_initcode_0, v3, 877
+    v4 = slice_ptr v0
+    v5 = add v3, 877
+    mcopy v5, v4, 0 !metadata(memory=heap)
+    v6 = create 0, v3, 877
+    jumpi v6, bb2, bb1
+  bb1:
+    revert_returndata
+  bb2:
+    v7 = alloc memorybytes, exact, uninitialized, infallible, 32
+    set_memory_object_len memorybytes, v7, 0
+    v8 = memory_object_data memorybytes, v7
+    v9 = fmp
+    v10 = add v9, 192
+    mstore v10, 0
+    v11 = abi_encode [memory_bytes], selector 0xb84d18fb00000000000000000000000000000000000000000000000000000000, args v7
+    v12 = slice_ptr v11
+    v13 = slice_len v11
+    v14 = extcodesize v6
+    v15 = iszero v14
+    jumpi v15, bb3, bb4
+  bb4:
+    v16 = gas
+    v17 = sub v16, 50
+    v18 = call v17, v6, 0, v12, v13, v12, 192
+    jumpi v18, bb5, bb6
+  bb6:
+    jumpi 1, bb10, bb11
+  bb11:
+    revert 0, 0
+  bb10:
+    jump bb7
+  bb5:
+    v19 = add v12, 0
+    v20 = mload v19
+    v21 = add v12, 32
+    v22 = mload v21
+    v23 = add v12, 64
+    v24 = mload v23
+    v25 = add v12, 96
+    v26 = mload v25
+    v27 = add v12, 128
+    v28 = mload v27
+    v29 = add v12, 160
+    v30 = mload v29
+    frame_store multi_return, word, 0, v12 !metadata(memory=scratch)
+    v31 = add v12, 0
+    v32 = mload v31
+    v33 = add v12, 32
+    v34 = mload v33
+    v35 = add v12, 64
+    v36 = mload v35
+    v37 = add v12, 96
+    v38 = mload v37
+    v39 = add v12, 128
+    v40 = mload v39
+    v41 = add v12, 160
+    v42 = mload v41
+    v43 = add v32, v42
+    v44 = lt v43, v32
+    jumpi v44, bb8, bb9
+  bb9:
+    jump bb7
+  bb7:
+    v45 = phi [bb9: v43], [bb10: 7]
+    ret v45
+  bb8:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 17 !metadata(memory=scratch)
+    revert 0, 36
+  bb3:
+    revert 0, 0
+}
+
+fn @stringCall() -> u256 [selector=0xbdbbac6d, abi_params=[], abi_returns=[word]] {
+  bb0:
+    v0 = abi_encode []
+    v1 = not 31
+    v2 = and 908, v1
+    v3 = alloc raw, exact, uninitialized, infallible, v2
+    data_copy WideCallee_initcode_0, v3, 877
+    v4 = slice_ptr v0
+    v5 = add v3, 877
+    mcopy v5, v4, 0 !metadata(memory=heap)
+    v6 = create 0, v3, 877
+    jumpi v6, bb2, bb1
+  bb1:
+    revert_returndata
+  bb2:
+    v7 = alloc memorybytes, exact, uninitialized, infallible, 32
+    set_memory_object_len memorybytes, v7, 0
+    v8 = memory_object_data memorybytes, v7
+    v9 = fmp
+    v10 = add v9, 192
+    mstore v10, 0
+    v11 = abi_encode [memory_bytes], selector 0xa52f51f100000000000000000000000000000000000000000000000000000000, args v7
+    v12 = slice_ptr v11
+    v13 = slice_len v11
+    v14 = extcodesize v6
+    v15 = iszero v14
+    jumpi v15, bb3, bb4
+  bb4:
+    v16 = gas
+    v17 = sub v16, 50
+    v18 = call v17, v6, 0, v12, v13, v12, 192
+    jumpi v18, bb6, bb5
+  bb5:
+    revert_returndata
+  bb6:
+    v19 = add v12, 0
+    v20 = mload v19
+    v21 = add v12, 32
+    v22 = mload v21
+    v23 = add v12, 64
+    v24 = mload v23
+    v25 = add v12, 96
+    v26 = mload v25
+    v27 = add v12, 128
+    v28 = mload v27
+    v29 = add v12, 160
+    v30 = mload v29
+    frame_store multi_return, word, 0, v12 !metadata(memory=scratch)
+    v31 = add v12, 0
+    v32 = mload v31
+    v33 = frame_load multi_return, word, 0 !metadata(memory=scratch)
+    v34 = add v33, 32
+    v35 = mload v34
+    v36 = add v33, 64
+    v37 = mload v36
+    v38 = add v33, 96
+    v39 = mload v38
+    v40 = add v33, 128
+    v41 = mload v40
+    v42 = add v33, 160
+    v43 = mload v42
+    v44 = add v32, v43
+    v45 = lt v44, v32
+    jumpi v45, bb7, bb8
+  bb8:
+    ret v44
+  bb7:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 17 !metadata(memory=scratch)
+    revert 0, 36
+  bb3:
+    revert 0, 0
+}

--- a/tests/ui/codegen/lowering/run-call/pre_byzantium_dynamic_argument_expansion.sol
+++ b/tests/ui/codegen/lowering/run-call/pre_byzantium_dynamic_argument_expansion.sol
@@ -1,0 +1,98 @@
+//@ revisions: homestead homesteadGas homesteadSize tangerineWhistle
+//@[homestead] compile-flags: -O none --evm-version homestead -Zdump=mir
+//@[homestead] filecheck: --check-prefix=HOMESTEAD
+//@[homesteadGas] compile-flags: -O gas --evm-version homestead
+//@[homesteadSize] compile-flags: -O size --evm-version homestead
+//@[tangerineWhistle] compile-flags: -O none --evm-version tangerineWhistle -Zdump=mir
+//@[tangerineWhistle] filecheck: --check-prefix=TANGERINE
+//@ run-call: WideCalls::plainCall => 9
+//@ run-call: WideCalls::tryCall => 9
+//@ run-call: WideCalls::stringCall => 9
+
+// A pre-EIP-150 `CALL` is charged its own memory expansion out of the gas left before the
+// forwarded gas is compared against the remainder, and `sub(gas(), 50)` leaves seven gas for it,
+// two words at most. A six-word output area behind a dynamically encoded argument reaches far
+// enough past the argument's last word to overrun that, so the word above the area is touched
+// before the arguments are encoded, where its address does not depend on what they encode to.
+
+interface Wide {
+    function six(bytes memory b)
+        external
+        returns (uint256, uint256, uint256, uint256, uint256, uint256);
+    function sixString(string memory s)
+        external
+        returns (uint256, uint256, uint256, uint256, uint256, uint256);
+}
+
+contract WideCallee {
+    function six(bytes memory b)
+        external
+        pure
+        returns (uint256, uint256, uint256, uint256, uint256, uint256)
+    {
+        return (b.length + 4, 1, 2, 3, 4, 5);
+    }
+
+    function sixString(string memory s)
+        external
+        pure
+        returns (uint256, uint256, uint256, uint256, uint256, uint256)
+    {
+        return (bytes(s).length + 4, 1, 2, 3, 4, 5);
+    }
+}
+
+contract WideCalls {
+    // The touch is `mstore(add(fmp(), 192), 0)`, six words above the area's own start, and it
+    // precedes the encoding it would otherwise write over.
+    // HOMESTEAD-LABEL: fn @plainCall
+    // HOMESTEAD: create
+    // HOMESTEAD: [[AREA:v[0-9]+]] = fmp
+    // HOMESTEAD: [[ABOVE:v[0-9]+]] = add [[AREA]], 192
+    // HOMESTEAD: mstore [[ABOVE]], 0
+    // HOMESTEAD: [[INPUT:v[0-9]+]] = slice_ptr
+    // HOMESTEAD: [[GAS:v[0-9]+]] = gas
+    // HOMESTEAD: [[FWD:v[0-9]+]] = sub [[GAS]], 50
+    // HOMESTEAD: call [[FWD]], {{v[0-9]+}}, 0, [[INPUT]], {{v[0-9]+}}, [[INPUT]], 192
+    // From EIP-150 on the forwarded gas is capped instead of rejected, so neither the reserve nor
+    // the touch is needed.
+    // TANGERINE-LABEL: fn @plainCall
+    // TANGERINE-NOT: = fmp
+    // TANGERINE: [[GAS:v[0-9]+]] = gas
+    // TANGERINE: call [[GAS]],
+    function plainCall() external returns (uint256) {
+        (uint256 a,,,,, uint256 f) = Wide(address(new WideCallee())).six("");
+        return a + f;
+    }
+
+    // A `try` around the same call touches the area the same way; its catch clause cannot absorb
+    // an out-of-gas.
+    // HOMESTEAD-LABEL: fn @tryCall
+    // HOMESTEAD: create
+    // HOMESTEAD: [[AREA:v[0-9]+]] = fmp
+    // HOMESTEAD: [[ABOVE:v[0-9]+]] = add [[AREA]], 192
+    // HOMESTEAD: mstore [[ABOVE]], 0
+    // HOMESTEAD: [[INPUT:v[0-9]+]] = slice_ptr
+    // HOMESTEAD: [[GAS:v[0-9]+]] = gas
+    // HOMESTEAD: [[FWD:v[0-9]+]] = sub [[GAS]], 50
+    // HOMESTEAD: call [[FWD]], {{v[0-9]+}}, 0, [[INPUT]], {{v[0-9]+}}, [[INPUT]], 192
+    function tryCall() external returns (uint256 r) {
+        try Wide(address(new WideCallee())).six("") returns (
+            uint256 a, uint256, uint256, uint256, uint256, uint256 f
+        ) {
+            r = a + f;
+        } catch {
+            r = 7;
+        }
+    }
+
+    // HOMESTEAD-LABEL: fn @stringCall
+    // HOMESTEAD: create
+    // HOMESTEAD: [[AREA:v[0-9]+]] = fmp
+    // HOMESTEAD: [[ABOVE:v[0-9]+]] = add [[AREA]], 192
+    // HOMESTEAD: mstore [[ABOVE]], 0
+    function stringCall() external returns (uint256) {
+        (uint256 a,,,,, uint256 f) = Wide(address(new WideCallee())).sixString("");
+        return a + f;
+    }
+}

--- a/tests/ui/codegen/lowering/run-call/pre_byzantium_dynamic_argument_expansion.tangerineWhistle.stdout
+++ b/tests/ui/codegen/lowering/run-call/pre_byzantium_dynamic_argument_expansion.tangerineWhistle.stdout
@@ -1,0 +1,250 @@
+// === ROOT/tests/ui/codegen/lowering/run-call/pre_byzantium_dynamic_argument_expansion.sol:WideCallee ===
+@module WideCallee
+fn @six(arg0: memorybytes) -> (u256, u256, u256, u256, u256, u256) [selector=0xb84d18fb, pure, abi_params=[bytes], abi_returns=[word, word, word, word, word, word]] {
+  bb0:
+    v0 = memory_object_len memorybytes, arg0
+    v1 = add v0, 4
+    v2 = lt v1, v0
+    jumpi v2, bb1, bb2
+  bb2:
+    ret v1, 1, 2, 3, 4, 5
+  bb1:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 17 !metadata(memory=scratch)
+    revert 0, 36
+}
+
+fn @sixString(arg0: memorybytes) -> (u256, u256, u256, u256, u256, u256) [selector=0xa52f51f1, pure, abi_params=[bytes], abi_returns=[word, word, word, word, word, word]] {
+  bb0:
+    v0 = memory_object_len memorybytes, arg0
+    v1 = add v0, 4
+    v2 = lt v1, v0
+    jumpi v2, bb1, bb2
+  bb2:
+    ret v1, 1, 2, 3, 4, 5
+  bb1:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 17 !metadata(memory=scratch)
+    revert 0, 36
+}
+
+// === ROOT/tests/ui/codegen/lowering/run-call/pre_byzantium_dynamic_argument_expansion.sol:WideCalls ===
+@module WideCalls
+data:
+  WideCallee_initcode_0: hex"346010576103578060166000396000f35b60006000fe346047576000357c010000000000000000000000000000000000000000000000000000000090048063a52f51f114603e578063b84d18fb146043576047565b610111565b604c565b600080fe5b6102c0604052602436101560f55760f0565b6101605180610160525160048101806101405280610140528181109150501560af577f4e487b7100000000000000000000000000000000000000000000000000000000600052601160045260246000fe5b610140518061014052608052602060800160018152602090016002815260209001600381526020900160048152602090016005815260209001608090036080f35b600080fe5b60fe60046101db565b6101a0518061016052806101605250605e565b6102c060405260243610156101bd576101b8565b61016051806101605251600481018061014052806101405281811091505015610177577f4e487b7100000000000000000000000000000000000000000000000000000000600052601160045260246000fe5b610140518061014052608052602060800160018152602090016002815260209001600381526020900160048152602090016005815260209001608090036080f35b600080fe5b6101c760046101db565b6101a0518061016052806101605250610125565b610180526101805135806102a052600401806101e052806101e0526020810167ffffffffffffffff6102a0511136806101c05282119150171561021e575b600080fe5b806101e052358061020052806102005260206101e0510180610220528061022052603f820180610240528061024052828061020052811015610289577f4e487b7100000000000000000000000000000000000000000000000000000000600052604160045260246000fe5b601f1981169050604051806102605280610260528181018061028052915081610280528061026052811067ffffffffffffffff821181179050156102f657610328565b602061026051016101e0513580610200526101e0516020018061022052823750610260516101a052565b80610280526040528161020052818061020052610260515280610220528061022052360381119050156102cc57610219565b7f4e487b7100000000000000000000000000000000000000000000000000000000600052604160045260246000fe"
+
+fn @plainCall() -> u256 [selector=0x707bf9ed, abi_params=[], abi_returns=[word]] {
+  bb0:
+    v0 = abi_encode []
+    v1 = not 31
+    v2 = and 908, v1
+    v3 = alloc raw, exact, uninitialized, infallible, v2
+    data_copy WideCallee_initcode_0, v3, 877
+    v4 = slice_ptr v0
+    v5 = add v3, 877
+    mcopy v5, v4, 0 !metadata(memory=heap)
+    v6 = create 0, v3, 877
+    jumpi v6, bb2, bb1
+  bb1:
+    revert_returndata
+  bb2:
+    v7 = gas
+    v8 = alloc memorybytes, exact, uninitialized, infallible, 32
+    set_memory_object_len memorybytes, v8, 0
+    v9 = memory_object_data memorybytes, v8
+    v10 = abi_encode [memory_bytes], selector 0xb84d18fb00000000000000000000000000000000000000000000000000000000, args v8
+    v11 = slice_ptr v10
+    v12 = slice_len v10
+    v13 = extcodesize v6
+    v14 = iszero v13
+    jumpi v14, bb3, bb4
+  bb4:
+    v15 = call v7, v6, 0, v11, v12, v11, 192
+    jumpi v15, bb6, bb5
+  bb5:
+    revert_returndata
+  bb6:
+    v16 = add v11, 0
+    v17 = mload v16
+    v18 = add v11, 32
+    v19 = mload v18
+    v20 = add v11, 64
+    v21 = mload v20
+    v22 = add v11, 96
+    v23 = mload v22
+    v24 = add v11, 128
+    v25 = mload v24
+    v26 = add v11, 160
+    v27 = mload v26
+    frame_store multi_return, word, 0, v11 !metadata(memory=scratch)
+    v28 = add v11, 0
+    v29 = mload v28
+    v30 = frame_load multi_return, word, 0 !metadata(memory=scratch)
+    v31 = add v30, 32
+    v32 = mload v31
+    v33 = add v30, 64
+    v34 = mload v33
+    v35 = add v30, 96
+    v36 = mload v35
+    v37 = add v30, 128
+    v38 = mload v37
+    v39 = add v30, 160
+    v40 = mload v39
+    v41 = add v29, v40
+    v42 = lt v41, v29
+    jumpi v42, bb7, bb8
+  bb8:
+    ret v41
+  bb7:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 17 !metadata(memory=scratch)
+    revert 0, 36
+  bb3:
+    revert 0, 0
+}
+
+fn @tryCall() -> u256 [selector=0x118dfb0e, abi_params=[], abi_returns=[word]] {
+  bb0:
+    v0 = abi_encode []
+    v1 = not 31
+    v2 = and 908, v1
+    v3 = alloc raw, exact, uninitialized, infallible, v2
+    data_copy WideCallee_initcode_0, v3, 877
+    v4 = slice_ptr v0
+    v5 = add v3, 877
+    mcopy v5, v4, 0 !metadata(memory=heap)
+    v6 = create 0, v3, 877
+    jumpi v6, bb2, bb1
+  bb1:
+    revert_returndata
+  bb2:
+    v7 = gas
+    v8 = alloc memorybytes, exact, uninitialized, infallible, 32
+    set_memory_object_len memorybytes, v8, 0
+    v9 = memory_object_data memorybytes, v8
+    v10 = abi_encode [memory_bytes], selector 0xb84d18fb00000000000000000000000000000000000000000000000000000000, args v8
+    v11 = slice_ptr v10
+    v12 = slice_len v10
+    v13 = extcodesize v6
+    v14 = iszero v13
+    jumpi v14, bb3, bb4
+  bb4:
+    v15 = call v7, v6, 0, v11, v12, v11, 192
+    jumpi v15, bb5, bb6
+  bb6:
+    jumpi 1, bb10, bb11
+  bb11:
+    revert 0, 0
+  bb10:
+    jump bb7
+  bb5:
+    v16 = add v11, 0
+    v17 = mload v16
+    v18 = add v11, 32
+    v19 = mload v18
+    v20 = add v11, 64
+    v21 = mload v20
+    v22 = add v11, 96
+    v23 = mload v22
+    v24 = add v11, 128
+    v25 = mload v24
+    v26 = add v11, 160
+    v27 = mload v26
+    frame_store multi_return, word, 0, v11 !metadata(memory=scratch)
+    v28 = add v11, 0
+    v29 = mload v28
+    v30 = add v11, 32
+    v31 = mload v30
+    v32 = add v11, 64
+    v33 = mload v32
+    v34 = add v11, 96
+    v35 = mload v34
+    v36 = add v11, 128
+    v37 = mload v36
+    v38 = add v11, 160
+    v39 = mload v38
+    v40 = add v29, v39
+    v41 = lt v40, v29
+    jumpi v41, bb8, bb9
+  bb9:
+    jump bb7
+  bb7:
+    v42 = phi [bb9: v40], [bb10: 7]
+    ret v42
+  bb8:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 17 !metadata(memory=scratch)
+    revert 0, 36
+  bb3:
+    revert 0, 0
+}
+
+fn @stringCall() -> u256 [selector=0xbdbbac6d, abi_params=[], abi_returns=[word]] {
+  bb0:
+    v0 = abi_encode []
+    v1 = not 31
+    v2 = and 908, v1
+    v3 = alloc raw, exact, uninitialized, infallible, v2
+    data_copy WideCallee_initcode_0, v3, 877
+    v4 = slice_ptr v0
+    v5 = add v3, 877
+    mcopy v5, v4, 0 !metadata(memory=heap)
+    v6 = create 0, v3, 877
+    jumpi v6, bb2, bb1
+  bb1:
+    revert_returndata
+  bb2:
+    v7 = gas
+    v8 = alloc memorybytes, exact, uninitialized, infallible, 32
+    set_memory_object_len memorybytes, v8, 0
+    v9 = memory_object_data memorybytes, v8
+    v10 = abi_encode [memory_bytes], selector 0xa52f51f100000000000000000000000000000000000000000000000000000000, args v8
+    v11 = slice_ptr v10
+    v12 = slice_len v10
+    v13 = extcodesize v6
+    v14 = iszero v13
+    jumpi v14, bb3, bb4
+  bb4:
+    v15 = call v7, v6, 0, v11, v12, v11, 192
+    jumpi v15, bb6, bb5
+  bb5:
+    revert_returndata
+  bb6:
+    v16 = add v11, 0
+    v17 = mload v16
+    v18 = add v11, 32
+    v19 = mload v18
+    v20 = add v11, 64
+    v21 = mload v20
+    v22 = add v11, 96
+    v23 = mload v22
+    v24 = add v11, 128
+    v25 = mload v24
+    v26 = add v11, 160
+    v27 = mload v26
+    frame_store multi_return, word, 0, v11 !metadata(memory=scratch)
+    v28 = add v11, 0
+    v29 = mload v28
+    v30 = frame_load multi_return, word, 0 !metadata(memory=scratch)
+    v31 = add v30, 32
+    v32 = mload v31
+    v33 = add v30, 64
+    v34 = mload v33
+    v35 = add v30, 96
+    v36 = mload v35
+    v37 = add v30, 128
+    v38 = mload v37
+    v39 = add v30, 160
+    v40 = mload v39
+    v41 = add v29, v40
+    v42 = lt v41, v29
+    jumpi v42, bb7, bb8
+  bb8:
+    ret v41
+  bb7:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 17 !metadata(memory=scratch)
+    revert 0, 36
+  bb3:
+    revert 0, 0
+}

--- a/tests/ui/codegen/lowering/run-call/pre_byzantium_short_return.homestead.stdout
+++ b/tests/ui/codegen/lowering/run-call/pre_byzantium_short_return.homestead.stdout
@@ -27,25 +27,28 @@ fn @emptySingle() -> u256 [selector=0x52635aa1, abi_params=[], abi_returns=[word
   bb0:
     mstore 0, 42 !metadata(memory=scratch)
     v0 = address
-    v1 = abi_encode [], selector 0x3fa4f24500000000000000000000000000000000000000000000000000000000
-    v2 = slice_ptr v1
-    v3 = slice_len v1
-    v4 = extcodesize v0
-    v5 = iszero v4
-    jumpi v5, bb1, bb2
+    v1 = fmp
+    v2 = add v1, 32
+    mstore v2, 0
+    v3 = abi_encode [], selector 0x3fa4f24500000000000000000000000000000000000000000000000000000000
+    v4 = slice_ptr v3
+    v5 = slice_len v3
+    v6 = extcodesize v0
+    v7 = iszero v6
+    jumpi v7, bb1, bb2
   bb2:
-    v6 = gas
-    v7 = sub v6, 50
-    v8 = call v7, v0, 0, v2, v3, v2, 32
-    jumpi v8, bb4, bb3
+    v8 = gas
+    v9 = sub v8, 50
+    v10 = call v9, v0, 0, v4, v5, v4, 32
+    jumpi v10, bb4, bb3
   bb3:
     revert_returndata
   bb4:
-    v9 = add v2, 0
-    v10 = mload v9
-    v11 = add v2, 0
+    v11 = add v4, 0
     v12 = mload v11
-    ret v12
+    v13 = add v4, 0
+    v14 = mload v13
+    ret v14
   bb1:
     revert 0, 0
 }
@@ -53,25 +56,28 @@ fn @emptySingle() -> u256 [selector=0x52635aa1, abi_params=[], abi_returns=[word
 fn @emptySingleArg() -> u256 [selector=0x44cc61d5, abi_params=[], abi_returns=[word]] {
   bb0:
     v0 = address
-    v1 = abi_encode [word], selector 0x8308677200000000000000000000000000000000000000000000000000000000, args 0xdead
-    v2 = slice_ptr v1
-    v3 = slice_len v1
-    v4 = extcodesize v0
-    v5 = iszero v4
-    jumpi v5, bb1, bb2
+    v1 = fmp
+    v2 = add v1, 32
+    mstore v2, 0
+    v3 = abi_encode [word], selector 0x8308677200000000000000000000000000000000000000000000000000000000, args 0xdead
+    v4 = slice_ptr v3
+    v5 = slice_len v3
+    v6 = extcodesize v0
+    v7 = iszero v6
+    jumpi v7, bb1, bb2
   bb2:
-    v6 = gas
-    v7 = sub v6, 50
-    v8 = call v7, v0, 0, v2, v3, v2, 32
-    jumpi v8, bb4, bb3
+    v8 = gas
+    v9 = sub v8, 50
+    v10 = call v9, v0, 0, v4, v5, v4, 32
+    jumpi v10, bb4, bb3
   bb3:
     revert_returndata
   bb4:
-    v9 = add v2, 0
-    v10 = mload v9
-    v11 = add v2, 0
+    v11 = add v4, 0
     v12 = mload v11
-    ret v12
+    v13 = add v4, 0
+    v14 = mload v13
+    ret v14
   bb1:
     revert 0, 0
 }
@@ -81,33 +87,34 @@ fn @emptyPair() -> (u256, u256) [selector=0xa086baae, abi_params=[], abi_returns
     mstore 0, 42 !metadata(memory=scratch)
     mstore 32, 43 !metadata(memory=scratch)
     v0 = address
-    v1 = abi_encode [], selector 0xa8aa1b3100000000000000000000000000000000000000000000000000000000
-    v2 = slice_ptr v1
-    v3 = slice_len v1
-    v4 = add v2, 32
-    mstore v4, 0
-    v5 = extcodesize v0
-    v6 = iszero v5
-    jumpi v6, bb1, bb2
+    v1 = fmp
+    v2 = add v1, 64
+    mstore v2, 0
+    v3 = abi_encode [], selector 0xa8aa1b3100000000000000000000000000000000000000000000000000000000
+    v4 = slice_ptr v3
+    v5 = slice_len v3
+    v6 = extcodesize v0
+    v7 = iszero v6
+    jumpi v7, bb1, bb2
   bb2:
-    v7 = gas
-    v8 = sub v7, 50
-    v9 = call v8, v0, 0, v2, v3, v2, 64
-    jumpi v9, bb4, bb3
+    v8 = gas
+    v9 = sub v8, 50
+    v10 = call v9, v0, 0, v4, v5, v4, 64
+    jumpi v10, bb4, bb3
   bb3:
     revert_returndata
   bb4:
-    v10 = add v2, 0
-    v11 = mload v10
-    v12 = add v2, 32
-    v13 = mload v12
-    frame_store multi_return, word, 0, v2 !metadata(memory=scratch)
-    v14 = add v2, 0
-    v15 = mload v14
-    v16 = frame_load multi_return, word, 0 !metadata(memory=scratch)
-    v17 = add v16, 32
-    v18 = mload v17
-    ret v15, v18
+    v11 = add v4, 0
+    v12 = mload v11
+    v13 = add v4, 32
+    v14 = mload v13
+    frame_store multi_return, word, 0, v4 !metadata(memory=scratch)
+    v15 = add v4, 0
+    v16 = mload v15
+    v17 = frame_load multi_return, word, 0 !metadata(memory=scratch)
+    v18 = add v17, 32
+    v19 = mload v18
+    ret v16, v19
   bb1:
     revert 0, 0
 }
@@ -115,41 +122,42 @@ fn @emptyPair() -> (u256, u256) [selector=0xa086baae, abi_params=[], abi_returns
 fn @emptyFour() -> (u256, u256, u256, u256) [selector=0x7bcee116, abi_params=[], abi_returns=[word, word, word, word]] {
   bb0:
     v0 = address
-    v1 = abi_encode [], selector 0xa1fca2b600000000000000000000000000000000000000000000000000000000
-    v2 = slice_ptr v1
-    v3 = slice_len v1
-    v4 = add v2, 96
-    mstore v4, 0
-    v5 = extcodesize v0
-    v6 = iszero v5
-    jumpi v6, bb1, bb2
+    v1 = fmp
+    v2 = add v1, 128
+    mstore v2, 0
+    v3 = abi_encode [], selector 0xa1fca2b600000000000000000000000000000000000000000000000000000000
+    v4 = slice_ptr v3
+    v5 = slice_len v3
+    v6 = extcodesize v0
+    v7 = iszero v6
+    jumpi v7, bb1, bb2
   bb2:
-    v7 = gas
-    v8 = sub v7, 50
-    v9 = call v8, v0, 0, v2, v3, v2, 128
-    jumpi v9, bb4, bb3
+    v8 = gas
+    v9 = sub v8, 50
+    v10 = call v9, v0, 0, v4, v5, v4, 128
+    jumpi v10, bb4, bb3
   bb3:
     revert_returndata
   bb4:
-    v10 = add v2, 0
-    v11 = mload v10
-    v12 = add v2, 32
-    v13 = mload v12
-    v14 = add v2, 64
-    v15 = mload v14
-    v16 = add v2, 96
-    v17 = mload v16
-    frame_store multi_return, word, 0, v2 !metadata(memory=scratch)
-    v18 = add v2, 0
-    v19 = mload v18
-    v20 = frame_load multi_return, word, 0 !metadata(memory=scratch)
-    v21 = add v20, 32
-    v22 = mload v21
-    v23 = add v20, 64
-    v24 = mload v23
-    v25 = add v20, 96
-    v26 = mload v25
-    ret v19, v22, v24, v26
+    v11 = add v4, 0
+    v12 = mload v11
+    v13 = add v4, 32
+    v14 = mload v13
+    v15 = add v4, 64
+    v16 = mload v15
+    v17 = add v4, 96
+    v18 = mload v17
+    frame_store multi_return, word, 0, v4 !metadata(memory=scratch)
+    v19 = add v4, 0
+    v20 = mload v19
+    v21 = frame_load multi_return, word, 0 !metadata(memory=scratch)
+    v22 = add v21, 32
+    v23 = mload v22
+    v24 = add v21, 64
+    v25 = mload v24
+    v26 = add v21, 96
+    v27 = mload v26
+    ret v20, v23, v25, v27
   bb1:
     revert 0, 0
 }
@@ -162,25 +170,26 @@ fn @emptyAgg() -> memoryfixedarray [selector=0x06df237b, abi_params=[], abi_retu
     v2 = alloc memorybytes, exact, uninitialized, infallible, 96
     set_memory_object_len memorybytes, v2, 64
     v3 = memory_object_data memorybytes, v2
-    v4 = abi_encode [], selector 0xf5e34bfa00000000000000000000000000000000000000000000000000000000
-    v5 = slice_ptr v4
-    v6 = slice_len v4
-    v7 = add v5, 32
-    mstore v7, 0
-    v8 = extcodesize v1
-    v9 = iszero v8
-    jumpi v9, bb1, bb2
+    v4 = fmp
+    v5 = add v4, 64
+    mstore v5, 0
+    v6 = abi_encode [], selector 0xf5e34bfa00000000000000000000000000000000000000000000000000000000
+    v7 = slice_ptr v6
+    v8 = slice_len v6
+    v9 = extcodesize v1
+    v10 = iszero v9
+    jumpi v10, bb1, bb2
   bb2:
-    v10 = gas
-    v11 = sub v10, 50
-    v12 = call v11, v1, 0, v5, v6, v5, 64
-    jumpi v12, bb4, bb3
+    v11 = gas
+    v12 = sub v11, 50
+    v13 = call v12, v1, 0, v7, v8, v7, 64
+    jumpi v13, bb4, bb3
   bb3:
     revert_returndata
   bb4:
-    mcopy v3, v5, 64
-    v13 = abi_decode [array<2, u256>], v2
-    ret v13
+    mcopy v3, v7, 64
+    v14 = abi_decode [array<2, u256>], v2
+    ret v14
   bb1:
     revert 0, 0
 }
@@ -193,23 +202,26 @@ fn @emptyAggArg() -> memoryfixedarray [selector=0x3dd9064d, abi_params=[], abi_r
     v2 = alloc memorybytes, exact, uninitialized, infallible, 96
     set_memory_object_len memorybytes, v2, 64
     v3 = memory_object_data memorybytes, v2
-    v4 = abi_encode [word, word, word], selector 0xf5a636f000000000000000000000000000000000000000000000000000000000, args 1, 2, 3
-    v5 = slice_ptr v4
-    v6 = slice_len v4
-    v7 = extcodesize v1
-    v8 = iszero v7
-    jumpi v8, bb1, bb2
+    v4 = fmp
+    v5 = add v4, 64
+    mstore v5, 0
+    v6 = abi_encode [word, word, word], selector 0xf5a636f000000000000000000000000000000000000000000000000000000000, args 1, 2, 3
+    v7 = slice_ptr v6
+    v8 = slice_len v6
+    v9 = extcodesize v1
+    v10 = iszero v9
+    jumpi v10, bb1, bb2
   bb2:
-    v9 = gas
-    v10 = sub v9, 50
-    v11 = call v10, v1, 0, v5, v6, v5, 64
-    jumpi v11, bb4, bb3
+    v11 = gas
+    v12 = sub v11, 50
+    v13 = call v12, v1, 0, v7, v8, v7, 64
+    jumpi v13, bb4, bb3
   bb3:
     revert_returndata
   bb4:
-    mcopy v3, v5, 64
-    v12 = abi_decode [array<2, u256>], v2
-    ret v12
+    mcopy v3, v7, 64
+    v14 = abi_decode [array<2, u256>], v2
+    ret v14
   bb1:
     revert 0, 0
 }
@@ -217,25 +229,28 @@ fn @emptyAggArg() -> memoryfixedarray [selector=0x3dd9064d, abi_params=[], abi_r
 fn @partialSingle() -> u256 [selector=0xe1e2fed5, abi_params=[], abi_returns=[word]] {
   bb0:
     v0 = address
-    v1 = abi_encode [], selector 0x818f584000000000000000000000000000000000000000000000000000000000
-    v2 = slice_ptr v1
-    v3 = slice_len v1
-    v4 = extcodesize v0
-    v5 = iszero v4
-    jumpi v5, bb1, bb2
+    v1 = fmp
+    v2 = add v1, 32
+    mstore v2, 0
+    v3 = abi_encode [], selector 0x818f584000000000000000000000000000000000000000000000000000000000
+    v4 = slice_ptr v3
+    v5 = slice_len v3
+    v6 = extcodesize v0
+    v7 = iszero v6
+    jumpi v7, bb1, bb2
   bb2:
-    v6 = gas
-    v7 = sub v6, 50
-    v8 = call v7, v0, 0, v2, v3, v2, 32
-    jumpi v8, bb4, bb3
+    v8 = gas
+    v9 = sub v8, 50
+    v10 = call v9, v0, 0, v4, v5, v4, 32
+    jumpi v10, bb4, bb3
   bb3:
     revert_returndata
   bb4:
-    v9 = add v2, 0
-    v10 = mload v9
-    v11 = add v2, 0
+    v11 = add v4, 0
     v12 = mload v11
-    ret v12
+    v13 = add v4, 0
+    v14 = mload v13
+    ret v14
   bb1:
     revert 0, 0
 }
@@ -243,33 +258,34 @@ fn @partialSingle() -> u256 [selector=0xe1e2fed5, abi_params=[], abi_returns=[wo
 fn @partialPair() -> (u256, u256) [selector=0x94ae8541, abi_params=[], abi_returns=[word, word]] {
   bb0:
     v0 = address
-    v1 = abi_encode [], selector 0x80cc043300000000000000000000000000000000000000000000000000000000
-    v2 = slice_ptr v1
-    v3 = slice_len v1
-    v4 = add v2, 32
-    mstore v4, 0
-    v5 = extcodesize v0
-    v6 = iszero v5
-    jumpi v6, bb1, bb2
+    v1 = fmp
+    v2 = add v1, 64
+    mstore v2, 0
+    v3 = abi_encode [], selector 0x80cc043300000000000000000000000000000000000000000000000000000000
+    v4 = slice_ptr v3
+    v5 = slice_len v3
+    v6 = extcodesize v0
+    v7 = iszero v6
+    jumpi v7, bb1, bb2
   bb2:
-    v7 = gas
-    v8 = sub v7, 50
-    v9 = call v8, v0, 0, v2, v3, v2, 64
-    jumpi v9, bb4, bb3
+    v8 = gas
+    v9 = sub v8, 50
+    v10 = call v9, v0, 0, v4, v5, v4, 64
+    jumpi v10, bb4, bb3
   bb3:
     revert_returndata
   bb4:
-    v10 = add v2, 0
-    v11 = mload v10
-    v12 = add v2, 32
-    v13 = mload v12
-    frame_store multi_return, word, 0, v2 !metadata(memory=scratch)
-    v14 = add v2, 0
-    v15 = mload v14
-    v16 = frame_load multi_return, word, 0 !metadata(memory=scratch)
-    v17 = add v16, 32
-    v18 = mload v17
-    ret v15, v18
+    v11 = add v4, 0
+    v12 = mload v11
+    v13 = add v4, 32
+    v14 = mload v13
+    frame_store multi_return, word, 0, v4 !metadata(memory=scratch)
+    v15 = add v4, 0
+    v16 = mload v15
+    v17 = frame_load multi_return, word, 0 !metadata(memory=scratch)
+    v18 = add v17, 32
+    v19 = mload v18
+    ret v16, v19
   bb1:
     revert 0, 0
 }
@@ -282,25 +298,26 @@ fn @partialAgg() -> memoryfixedarray [selector=0xbf0809fa, abi_params=[], abi_re
     v2 = alloc memorybytes, exact, uninitialized, infallible, 96
     set_memory_object_len memorybytes, v2, 64
     v3 = memory_object_data memorybytes, v2
-    v4 = abi_encode [], selector 0x391c2d2800000000000000000000000000000000000000000000000000000000
-    v5 = slice_ptr v4
-    v6 = slice_len v4
-    v7 = add v5, 32
-    mstore v7, 0
-    v8 = extcodesize v1
-    v9 = iszero v8
-    jumpi v9, bb1, bb2
+    v4 = fmp
+    v5 = add v4, 64
+    mstore v5, 0
+    v6 = abi_encode [], selector 0x391c2d2800000000000000000000000000000000000000000000000000000000
+    v7 = slice_ptr v6
+    v8 = slice_len v6
+    v9 = extcodesize v1
+    v10 = iszero v9
+    jumpi v10, bb1, bb2
   bb2:
-    v10 = gas
-    v11 = sub v10, 50
-    v12 = call v11, v1, 0, v5, v6, v5, 64
-    jumpi v12, bb4, bb3
+    v11 = gas
+    v12 = sub v11, 50
+    v13 = call v12, v1, 0, v7, v8, v7, 64
+    jumpi v13, bb4, bb3
   bb3:
     revert_returndata
   bb4:
-    mcopy v3, v5, 64
-    v13 = abi_decode [array<2, u256>], v2
-    ret v13
+    mcopy v3, v7, 64
+    v14 = abi_decode [array<2, u256>], v2
+    ret v14
   bb1:
     revert 0, 0
 }

--- a/tests/ui/codegen/lowering/run-call/pre_byzantium_short_return.homestead.stdout
+++ b/tests/ui/codegen/lowering/run-call/pre_byzantium_short_return.homestead.stdout
@@ -1,0 +1,306 @@
+// === ROOT/tests/ui/codegen/lowering/run-call/pre_byzantium_short_return.sol:ShortReturns ===
+@module ShortReturns
+fn @fallback() [fallback] {
+  bb0:
+    stop
+}
+
+fn @shortWord() [selector=0x818f5840, pure, abi_params=[], abi_returns=[]] {
+  bb0:
+    mstore 0, 0x1122334455667788990011223344556677889900112233445566778899001122 !metadata(memory=scratch)
+    returndata 0, 4
+}
+
+fn @shortPair() [selector=0x80cc0433, pure, abi_params=[], abi_returns=[]] {
+  bb0:
+    mstore 0, 0x1122334455667788990011223344556677889900112233445566778899001122 !metadata(memory=scratch)
+    returndata 0, 36
+}
+
+fn @shortAgg() [selector=0x391c2d28, pure, abi_params=[], abi_returns=[]] {
+  bb0:
+    mstore 0, 0x1122334455667788990011223344556677889900112233445566778899001122 !metadata(memory=scratch)
+    returndata 0, 36
+}
+
+fn @emptySingle() -> u256 [selector=0x52635aa1, abi_params=[], abi_returns=[word]] {
+  bb0:
+    mstore 0, 42 !metadata(memory=scratch)
+    v0 = address
+    v1 = abi_encode [], selector 0x3fa4f24500000000000000000000000000000000000000000000000000000000
+    v2 = slice_ptr v1
+    v3 = slice_len v1
+    v4 = extcodesize v0
+    v5 = iszero v4
+    jumpi v5, bb1, bb2
+  bb2:
+    v6 = gas
+    v7 = sub v6, 50
+    v8 = call v7, v0, 0, v2, v3, v2, 32
+    jumpi v8, bb4, bb3
+  bb3:
+    revert_returndata
+  bb4:
+    v9 = add v2, 0
+    v10 = mload v9
+    v11 = add v2, 0
+    v12 = mload v11
+    ret v12
+  bb1:
+    revert 0, 0
+}
+
+fn @emptySingleArg() -> u256 [selector=0x44cc61d5, abi_params=[], abi_returns=[word]] {
+  bb0:
+    v0 = address
+    v1 = abi_encode [word], selector 0x8308677200000000000000000000000000000000000000000000000000000000, args 0xdead
+    v2 = slice_ptr v1
+    v3 = slice_len v1
+    v4 = extcodesize v0
+    v5 = iszero v4
+    jumpi v5, bb1, bb2
+  bb2:
+    v6 = gas
+    v7 = sub v6, 50
+    v8 = call v7, v0, 0, v2, v3, v2, 32
+    jumpi v8, bb4, bb3
+  bb3:
+    revert_returndata
+  bb4:
+    v9 = add v2, 0
+    v10 = mload v9
+    v11 = add v2, 0
+    v12 = mload v11
+    ret v12
+  bb1:
+    revert 0, 0
+}
+
+fn @emptyPair() -> (u256, u256) [selector=0xa086baae, abi_params=[], abi_returns=[word, word]] {
+  bb0:
+    mstore 0, 42 !metadata(memory=scratch)
+    mstore 32, 43 !metadata(memory=scratch)
+    v0 = address
+    v1 = abi_encode [], selector 0xa8aa1b3100000000000000000000000000000000000000000000000000000000
+    v2 = slice_ptr v1
+    v3 = slice_len v1
+    v4 = add v2, 32
+    mstore v4, 0
+    v5 = extcodesize v0
+    v6 = iszero v5
+    jumpi v6, bb1, bb2
+  bb2:
+    v7 = gas
+    v8 = sub v7, 50
+    v9 = call v8, v0, 0, v2, v3, v2, 64
+    jumpi v9, bb4, bb3
+  bb3:
+    revert_returndata
+  bb4:
+    v10 = add v2, 0
+    v11 = mload v10
+    v12 = add v2, 32
+    v13 = mload v12
+    frame_store multi_return, word, 0, v2 !metadata(memory=scratch)
+    v14 = add v2, 0
+    v15 = mload v14
+    v16 = frame_load multi_return, word, 0 !metadata(memory=scratch)
+    v17 = add v16, 32
+    v18 = mload v17
+    ret v15, v18
+  bb1:
+    revert 0, 0
+}
+
+fn @emptyFour() -> (u256, u256, u256, u256) [selector=0x7bcee116, abi_params=[], abi_returns=[word, word, word, word]] {
+  bb0:
+    v0 = address
+    v1 = abi_encode [], selector 0xa1fca2b600000000000000000000000000000000000000000000000000000000
+    v2 = slice_ptr v1
+    v3 = slice_len v1
+    v4 = add v2, 96
+    mstore v4, 0
+    v5 = extcodesize v0
+    v6 = iszero v5
+    jumpi v6, bb1, bb2
+  bb2:
+    v7 = gas
+    v8 = sub v7, 50
+    v9 = call v8, v0, 0, v2, v3, v2, 128
+    jumpi v9, bb4, bb3
+  bb3:
+    revert_returndata
+  bb4:
+    v10 = add v2, 0
+    v11 = mload v10
+    v12 = add v2, 32
+    v13 = mload v12
+    v14 = add v2, 64
+    v15 = mload v14
+    v16 = add v2, 96
+    v17 = mload v16
+    frame_store multi_return, word, 0, v2 !metadata(memory=scratch)
+    v18 = add v2, 0
+    v19 = mload v18
+    v20 = frame_load multi_return, word, 0 !metadata(memory=scratch)
+    v21 = add v20, 32
+    v22 = mload v21
+    v23 = add v20, 64
+    v24 = mload v23
+    v25 = add v20, 96
+    v26 = mload v25
+    ret v19, v22, v24, v26
+  bb1:
+    revert 0, 0
+}
+
+fn @emptyAgg() -> memoryfixedarray [selector=0x06df237b, abi_params=[], abi_returns=[array<2, word>]] {
+  bb0:
+    v0 = alloc memoryfixedarray<2, 1>, exact, uninitialized, infallible, 64
+    memory_zero v0, 64
+    v1 = address
+    v2 = alloc memorybytes, exact, uninitialized, infallible, 96
+    set_memory_object_len memorybytes, v2, 64
+    v3 = memory_object_data memorybytes, v2
+    v4 = abi_encode [], selector 0xf5e34bfa00000000000000000000000000000000000000000000000000000000
+    v5 = slice_ptr v4
+    v6 = slice_len v4
+    v7 = add v5, 32
+    mstore v7, 0
+    v8 = extcodesize v1
+    v9 = iszero v8
+    jumpi v9, bb1, bb2
+  bb2:
+    v10 = gas
+    v11 = sub v10, 50
+    v12 = call v11, v1, 0, v5, v6, v5, 64
+    jumpi v12, bb4, bb3
+  bb3:
+    revert_returndata
+  bb4:
+    mcopy v3, v5, 64
+    v13 = abi_decode [array<2, u256>], v2
+    ret v13
+  bb1:
+    revert 0, 0
+}
+
+fn @emptyAggArg() -> memoryfixedarray [selector=0x3dd9064d, abi_params=[], abi_returns=[array<2, word>]] {
+  bb0:
+    v0 = alloc memoryfixedarray<2, 1>, exact, uninitialized, infallible, 64
+    memory_zero v0, 64
+    v1 = address
+    v2 = alloc memorybytes, exact, uninitialized, infallible, 96
+    set_memory_object_len memorybytes, v2, 64
+    v3 = memory_object_data memorybytes, v2
+    v4 = abi_encode [word, word, word], selector 0xf5a636f000000000000000000000000000000000000000000000000000000000, args 1, 2, 3
+    v5 = slice_ptr v4
+    v6 = slice_len v4
+    v7 = extcodesize v1
+    v8 = iszero v7
+    jumpi v8, bb1, bb2
+  bb2:
+    v9 = gas
+    v10 = sub v9, 50
+    v11 = call v10, v1, 0, v5, v6, v5, 64
+    jumpi v11, bb4, bb3
+  bb3:
+    revert_returndata
+  bb4:
+    mcopy v3, v5, 64
+    v12 = abi_decode [array<2, u256>], v2
+    ret v12
+  bb1:
+    revert 0, 0
+}
+
+fn @partialSingle() -> u256 [selector=0xe1e2fed5, abi_params=[], abi_returns=[word]] {
+  bb0:
+    v0 = address
+    v1 = abi_encode [], selector 0x818f584000000000000000000000000000000000000000000000000000000000
+    v2 = slice_ptr v1
+    v3 = slice_len v1
+    v4 = extcodesize v0
+    v5 = iszero v4
+    jumpi v5, bb1, bb2
+  bb2:
+    v6 = gas
+    v7 = sub v6, 50
+    v8 = call v7, v0, 0, v2, v3, v2, 32
+    jumpi v8, bb4, bb3
+  bb3:
+    revert_returndata
+  bb4:
+    v9 = add v2, 0
+    v10 = mload v9
+    v11 = add v2, 0
+    v12 = mload v11
+    ret v12
+  bb1:
+    revert 0, 0
+}
+
+fn @partialPair() -> (u256, u256) [selector=0x94ae8541, abi_params=[], abi_returns=[word, word]] {
+  bb0:
+    v0 = address
+    v1 = abi_encode [], selector 0x80cc043300000000000000000000000000000000000000000000000000000000
+    v2 = slice_ptr v1
+    v3 = slice_len v1
+    v4 = add v2, 32
+    mstore v4, 0
+    v5 = extcodesize v0
+    v6 = iszero v5
+    jumpi v6, bb1, bb2
+  bb2:
+    v7 = gas
+    v8 = sub v7, 50
+    v9 = call v8, v0, 0, v2, v3, v2, 64
+    jumpi v9, bb4, bb3
+  bb3:
+    revert_returndata
+  bb4:
+    v10 = add v2, 0
+    v11 = mload v10
+    v12 = add v2, 32
+    v13 = mload v12
+    frame_store multi_return, word, 0, v2 !metadata(memory=scratch)
+    v14 = add v2, 0
+    v15 = mload v14
+    v16 = frame_load multi_return, word, 0 !metadata(memory=scratch)
+    v17 = add v16, 32
+    v18 = mload v17
+    ret v15, v18
+  bb1:
+    revert 0, 0
+}
+
+fn @partialAgg() -> memoryfixedarray [selector=0xbf0809fa, abi_params=[], abi_returns=[array<2, word>]] {
+  bb0:
+    v0 = alloc memoryfixedarray<2, 1>, exact, uninitialized, infallible, 64
+    memory_zero v0, 64
+    v1 = address
+    v2 = alloc memorybytes, exact, uninitialized, infallible, 96
+    set_memory_object_len memorybytes, v2, 64
+    v3 = memory_object_data memorybytes, v2
+    v4 = abi_encode [], selector 0x391c2d2800000000000000000000000000000000000000000000000000000000
+    v5 = slice_ptr v4
+    v6 = slice_len v4
+    v7 = add v5, 32
+    mstore v7, 0
+    v8 = extcodesize v1
+    v9 = iszero v8
+    jumpi v9, bb1, bb2
+  bb2:
+    v10 = gas
+    v11 = sub v10, 50
+    v12 = call v11, v1, 0, v5, v6, v5, 64
+    jumpi v12, bb4, bb3
+  bb3:
+    revert_returndata
+  bb4:
+    mcopy v3, v5, 64
+    v13 = abi_decode [array<2, u256>], v2
+    ret v13
+  bb1:
+    revert 0, 0
+}

--- a/tests/ui/codegen/lowering/run-call/pre_byzantium_short_return.homestead.stdout
+++ b/tests/ui/codegen/lowering/run-call/pre_byzantium_short_return.homestead.stdout
@@ -23,6 +23,12 @@ fn @shortAgg() [selector=0x391c2d28, pure, abi_params=[], abi_returns=[]] {
     returndata 0, 36
 }
 
+fn @shortFour() [selector=0xfb8720fc, pure, abi_params=[], abi_returns=[]] {
+  bb0:
+    mstore 0, 0x1122334455667788990011223344556677889900112233445566778899001122 !metadata(memory=scratch)
+    returndata 0, 4
+}
+
 fn @emptySingle() -> u256 [selector=0x52635aa1, abi_params=[], abi_returns=[word]] {
   bb0:
     mstore 0, 42 !metadata(memory=scratch)
@@ -318,6 +324,57 @@ fn @partialAgg() -> memoryfixedarray [selector=0xbf0809fa, abi_params=[], abi_re
     mcopy v3, v7, 64
     v14 = abi_decode [array<2, u256>], v2
     ret v14
+  bb1:
+    revert 0, 0
+}
+
+fn @dirtyFour() -> (u256, u256, u256, u256) [selector=0x42fc804f, abi_params=[], abi_returns=[word, word, word, word]] {
+  bb0:
+    v0 = mload 64 !metadata(memory=scratch)
+    v1 = not 0
+    v2 = add v0, 32
+    mstore v2, v1
+    v3 = add v0, 64
+    mstore v3, 0xdeadbeef
+    v4 = add v0, 96
+    mstore v4, 0x1234
+    v5 = address
+    v6 = fmp
+    v7 = add v6, 128
+    mstore v7, 0
+    v8 = abi_encode [], selector 0xfb8720fc00000000000000000000000000000000000000000000000000000000
+    v9 = slice_ptr v8
+    v10 = slice_len v8
+    v11 = extcodesize v5
+    v12 = iszero v11
+    jumpi v12, bb1, bb2
+  bb2:
+    v13 = gas
+    v14 = sub v13, 50
+    v15 = call v14, v5, 0, v9, v10, v9, 128
+    jumpi v15, bb4, bb3
+  bb3:
+    revert_returndata
+  bb4:
+    v16 = add v9, 0
+    v17 = mload v16
+    v18 = add v9, 32
+    v19 = mload v18
+    v20 = add v9, 64
+    v21 = mload v20
+    v22 = add v9, 96
+    v23 = mload v22
+    frame_store multi_return, word, 0, v9 !metadata(memory=scratch)
+    v24 = add v9, 0
+    v25 = mload v24
+    v26 = frame_load multi_return, word, 0 !metadata(memory=scratch)
+    v27 = add v26, 32
+    v28 = mload v27
+    v29 = add v26, 64
+    v30 = mload v29
+    v31 = add v26, 96
+    v32 = mload v31
+    ret v25, v28, v30, v32
   bb1:
     revert 0, 0
 }

--- a/tests/ui/codegen/lowering/run-call/pre_byzantium_short_return.sol
+++ b/tests/ui/codegen/lowering/run-call/pre_byzantium_short_return.sol
@@ -14,6 +14,7 @@
 //@ run-call: ShortReturns::partialSingle => 0x1122334400000000000000000000000000000000000000000000000000000000
 //@ run-call: ShortReturns::partialPair => 0x1122334455667788990011223344556677889900112233445566778899001122, 0
 //@ run-call: ShortReturns::partialAgg => [0x1122334455667788990011223344556677889900112233445566778899001122, 0]
+//@ run-call: ShortReturns::dirtyFour => 0x1122334400000000000000000000000000000000000000000000000000000000, 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff, 0xdeadbeef, 0x1234
 
 // Before Byzantium a callee that returns fewer bytes than it declares cannot be detected: there
 // is no `RETURNDATASIZE` to compare against, so the decoded values are whatever the output area
@@ -30,6 +31,7 @@ interface Target {
     function shortWord() external returns (uint256);
     function shortPair() external returns (uint256, uint256);
     function shortAgg() external returns (uint256[2] memory);
+    function shortFour() external returns (uint256, uint256, uint256, uint256);
 }
 
 // Every call targets this contract itself, whose fallback returns no data at all and whose
@@ -55,6 +57,13 @@ contract ShortReturns {
         assembly {
             mstore(0, 0x1122334455667788990011223344556677889900112233445566778899001122)
             return(0, 36)
+        }
+    }
+
+    function shortFour() external pure {
+        assembly {
+            mstore(0, 0x1122334455667788990011223344556677889900112233445566778899001122)
+            return(0, 4)
         }
     }
 
@@ -128,5 +137,24 @@ contract ShortReturns {
 
     function partialAgg() external returns (uint256[2] memory) {
         return Target(address(this)).shortAgg();
+    }
+
+    // The words the callee leaves untouched are read back as whatever memory above the free
+    // pointer already held, which is what the touch above the output area preserves: a store
+    // inside the area would hand back zeros where solc hands back the assembly's writes.
+    // HOMESTEAD-LABEL: fn @dirtyFour
+    // HOMESTEAD: [[AREA:v[0-9]+]] = fmp
+    // HOMESTEAD: [[ABOVE:v[0-9]+]] = add [[AREA]], 128
+    // HOMESTEAD: mstore [[ABOVE]], 0
+    // HOMESTEAD: [[INPUT:v[0-9]+]] = slice_ptr
+    // HOMESTEAD: call {{.*}}, [[INPUT]], {{v[0-9]+}}, [[INPUT]], 128
+    function dirtyFour() external returns (uint256, uint256, uint256, uint256) {
+        assembly {
+            let p := mload(0x40)
+            mstore(add(p, 32), not(0))
+            mstore(add(p, 64), 0xdeadbeef)
+            mstore(add(p, 96), 0x1234)
+        }
+        return Target(address(this)).shortFour();
     }
 }

--- a/tests/ui/codegen/lowering/run-call/pre_byzantium_short_return.sol
+++ b/tests/ui/codegen/lowering/run-call/pre_byzantium_short_return.sol
@@ -1,0 +1,131 @@
+//@ revisions: homestead homesteadGas homesteadSize tangerineWhistle spuriousDragon
+//@[homestead] compile-flags: -O none --evm-version homestead -Zdump=mir
+//@[homestead] filecheck: --check-prefix=HOMESTEAD
+//@[homesteadGas] compile-flags: -O gas --evm-version homestead
+//@[homesteadSize] compile-flags: -O size --evm-version homestead
+//@[tangerineWhistle] compile-flags: -O none --evm-version tangerineWhistle
+//@[spuriousDragon] compile-flags: -O none --evm-version spuriousDragon
+//@ run-call: ShortReturns::emptySingle => 0x3fa4f24500000000000000000000000000000000000000000000000000000000
+//@ run-call: ShortReturns::emptySingleArg => 0x8308677200000000000000000000000000000000000000000000000000000000
+//@ run-call: ShortReturns::emptyPair => 0xa8aa1b3100000000000000000000000000000000000000000000000000000000, 0
+//@ run-call: ShortReturns::emptyFour => 0xa1fca2b600000000000000000000000000000000000000000000000000000000, 0, 0, 0
+//@ run-call: ShortReturns::emptyAgg => [0xf5e34bfa00000000000000000000000000000000000000000000000000000000, 0]
+//@ run-call: ShortReturns::emptyAggArg => [0xf5a636f000000000000000000000000000000000000000000000000000000000, 0x0000000100000000000000000000000000000000000000000000000000000000]
+//@ run-call: ShortReturns::partialSingle => 0x1122334400000000000000000000000000000000000000000000000000000000
+//@ run-call: ShortReturns::partialPair => 0x1122334455667788990011223344556677889900112233445566778899001122, 0
+//@ run-call: ShortReturns::partialAgg => [0x1122334455667788990011223344556677889900112233445566778899001122, 0]
+
+// Before Byzantium a callee that returns fewer bytes than it declares cannot be detected: there
+// is no `RETURNDATASIZE` to compare against, so the decoded values are whatever the output area
+// holds. solc overlays that area on the call's own input area, so the missing bytes read back as
+// the selector and arguments the call left there, and every value below is solc 0.8.36's.
+
+interface Target {
+    function value() external returns (uint256);
+    function valueArg(uint256 a) external returns (uint256);
+    function pair() external returns (uint256, uint256);
+    function four() external returns (uint256, uint256, uint256, uint256);
+    function agg() external returns (uint256[2] memory);
+    function aggArg(uint256 a, uint256 b, uint256 c) external returns (uint256[2] memory);
+    function shortWord() external returns (uint256);
+    function shortPair() external returns (uint256, uint256);
+    function shortAgg() external returns (uint256[2] memory);
+}
+
+// Every call targets this contract itself, whose fallback returns no data at all and whose
+// `short*` functions return a truncated word.
+contract ShortReturns {
+    fallback() external {}
+
+    function shortWord() external pure {
+        assembly {
+            mstore(0, 0x1122334455667788990011223344556677889900112233445566778899001122)
+            return(0, 4)
+        }
+    }
+
+    function shortPair() external pure {
+        assembly {
+            mstore(0, 0x1122334455667788990011223344556677889900112233445566778899001122)
+            return(0, 36)
+        }
+    }
+
+    function shortAgg() external pure {
+        assembly {
+            mstore(0, 0x1122334455667788990011223344556677889900112233445566778899001122)
+            return(0, 36)
+        }
+    }
+
+    // A single-word output area starts at the input area, so the word the call reads back keeps
+    // the selector, and the store to the scratch word below the heap is not part of it.
+    // HOMESTEAD-LABEL: fn @emptySingle
+    // HOMESTEAD: mstore 0, 42
+    // HOMESTEAD: [[INPUT:v[0-9]+]] = slice_ptr
+    // HOMESTEAD: call {{v[0-9]+}}, {{v[0-9]+}}, 0, [[INPUT]], {{v[0-9]+}}, [[INPUT]], 32
+    function emptySingle() external returns (uint256) {
+        assembly {
+            mstore(0, 42)
+        }
+        return Target(address(this)).value();
+    }
+
+    // The argument stays in the area the output overlays, so its own leading bytes read back.
+    function emptySingleArg() external returns (uint256) {
+        return Target(address(this)).valueArg(0xdead);
+    }
+
+    // HOMESTEAD-LABEL: fn @emptyPair
+    // HOMESTEAD: [[INPUT:v[0-9]+]] = slice_ptr
+    // HOMESTEAD: call {{v[0-9]+}}, {{v[0-9]+}}, 0, [[INPUT]], {{v[0-9]+}}, [[INPUT]], 64
+    function emptyPair() external returns (uint256, uint256) {
+        assembly {
+            mstore(0, 42)
+            mstore(32, 43)
+        }
+        return Target(address(this)).pair();
+    }
+
+    // This output area reaches past the four-byte input, so its last word is written before the
+    // gas is read and the call is not charged the expansion out of what it withholds.
+    // HOMESTEAD-LABEL: fn @emptyFour
+    // HOMESTEAD: [[INPUT:v[0-9]+]] = slice_ptr
+    // HOMESTEAD: [[LAST:v[0-9]+]] = add [[INPUT]], 96
+    // HOMESTEAD: mstore [[LAST]], 0
+    // HOMESTEAD: [[GAS:v[0-9]+]] = gas
+    // HOMESTEAD: [[FWD:v[0-9]+]] = sub [[GAS]], 50
+    // HOMESTEAD: call [[FWD]], {{v[0-9]+}}, 0, [[INPUT]], {{v[0-9]+}}, [[INPUT]], 128
+    function emptyFour() external returns (uint256, uint256, uint256, uint256) {
+        return Target(address(this)).four();
+    }
+
+    // An aggregate return decodes out of a buffer taken before the arguments, so the copy out of
+    // the overlaid area cannot run into memory the decoding allocates above it.
+    // HOMESTEAD-LABEL: fn @emptyAgg
+    // HOMESTEAD: [[BUFFER:v[0-9]+]] = alloc memorybytes
+    // HOMESTEAD: [[DATA:v[0-9]+]] = memory_object_data memorybytes, [[BUFFER]]
+    // HOMESTEAD: [[INPUT:v[0-9]+]] = slice_ptr
+    // HOMESTEAD: call {{v[0-9]+}}, {{v[0-9]+}}, 0, [[INPUT]], {{v[0-9]+}}, [[INPUT]], 64
+    // HOMESTEAD: mcopy [[DATA]], [[INPUT]], 64
+    // HOMESTEAD: abi_decode {{.*}}, [[BUFFER]]
+    function emptyAgg() external returns (uint256[2] memory) {
+        return Target(address(this)).agg();
+    }
+
+    function emptyAggArg() external returns (uint256[2] memory) {
+        return Target(address(this)).aggArg(1, 2, 3);
+    }
+
+    function partialSingle() external returns (uint256) {
+        return Target(address(this)).shortWord();
+    }
+
+    function partialPair() external returns (uint256, uint256) {
+        return Target(address(this)).shortPair();
+    }
+
+    function partialAgg() external returns (uint256[2] memory) {
+        return Target(address(this)).shortAgg();
+    }
+}

--- a/tests/ui/codegen/lowering/run-call/pre_byzantium_short_return.sol
+++ b/tests/ui/codegen/lowering/run-call/pre_byzantium_short_return.sol
@@ -87,12 +87,13 @@ contract ShortReturns {
         return Target(address(this)).pair();
     }
 
-    // This output area reaches past the four-byte input, so its last word is written before the
-    // gas is read and the call is not charged the expansion out of what it withholds.
+    // The word above this output area is written before the arguments are encoded and the gas is
+    // read, so the call is not charged the expansion out of what it withholds.
     // HOMESTEAD-LABEL: fn @emptyFour
+    // HOMESTEAD: [[AREA:v[0-9]+]] = fmp
+    // HOMESTEAD: [[ABOVE:v[0-9]+]] = add [[AREA]], 128
+    // HOMESTEAD: mstore [[ABOVE]], 0
     // HOMESTEAD: [[INPUT:v[0-9]+]] = slice_ptr
-    // HOMESTEAD: [[LAST:v[0-9]+]] = add [[INPUT]], 96
-    // HOMESTEAD: mstore [[LAST]], 0
     // HOMESTEAD: [[GAS:v[0-9]+]] = gas
     // HOMESTEAD: [[FWD:v[0-9]+]] = sub [[GAS]], 50
     // HOMESTEAD: call [[FWD]], {{v[0-9]+}}, 0, [[INPUT]], {{v[0-9]+}}, [[INPUT]], 128

--- a/tests/ui/codegen/lowering/run-call/this_call_creation_code_guard.mir.stdout
+++ b/tests/ui/codegen/lowering/run-call/this_call_creation_code_guard.mir.stdout
@@ -1,0 +1,357 @@
+// === ROOT/tests/ui/codegen/lowering/run-call/this_call_creation_code_guard.sol:CreationHelper ===
+@module CreationHelper
+fn @seen() -> u256 [selector=0xd99aa8e2, view, abi_params=[], abi_returns=[word]] {
+  bb0:
+    v0 = sload 0 !metadata(storage=slot(0))
+    ret v0
+}
+
+fn @constructor() [constructor] {
+  bb0:
+    internal_call @helper, 0
+    stop
+}
+
+fn @helper() {
+  bb0:
+    v0 = address
+    v1 = gas
+    v2 = abi_encode [], selector 0x5fb1149200000000000000000000000000000000000000000000000000000000
+    v3 = slice_ptr v2
+    v4 = slice_len v2
+    v5 = extcodesize v0
+    v6 = iszero v5
+    jumpi v6, bb1, bb2
+  bb2:
+    v7 = call v1, v0, 0, v3, v4, 0, 0
+    jumpi v7, bb4, bb3
+  bb3:
+    revert_returndata
+  bb4:
+    stop
+  bb1:
+    revert 0, 0
+}
+
+fn @setIt() [selector=0x5fb11492, abi_params=[], abi_returns=[]] {
+  bb0:
+    v0 = sload 0 !metadata(storage=slot(0))
+    v1 = add v0, 1
+    v2 = lt v1, v0
+    jumpi v2, bb1, bb2
+  bb2:
+    sstore 0, v1 !metadata(storage=slot(0))
+    stop
+  bb1:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 17 !metadata(memory=scratch)
+    revert 0, 36
+}
+
+// === ROOT/tests/ui/codegen/lowering/run-call/this_call_creation_code_guard.sol:CreationDirect ===
+@module CreationDirect
+fn @seen() -> u256 [selector=0xd99aa8e2, view, abi_params=[], abi_returns=[word]] {
+  bb0:
+    v0 = sload 0 !metadata(storage=slot(0))
+    ret v0
+}
+
+fn @constructor() [constructor] {
+  bb0:
+    v0 = address
+    v1 = gas
+    v2 = abi_encode [], selector 0x5fb1149200000000000000000000000000000000000000000000000000000000
+    v3 = slice_ptr v2
+    v4 = slice_len v2
+    v5 = extcodesize v0
+    v6 = iszero v5
+    jumpi v6, bb1, bb2
+  bb2:
+    v7 = call v1, v0, 0, v3, v4, 0, 0
+    jumpi v7, bb4, bb3
+  bb3:
+    revert_returndata
+  bb4:
+    stop
+  bb1:
+    revert 0, 0
+}
+
+fn @setIt() [selector=0x5fb11492, abi_params=[], abi_returns=[]] {
+  bb0:
+    v0 = sload 0 !metadata(storage=slot(0))
+    v1 = add v0, 1
+    v2 = lt v1, v0
+    jumpi v2, bb1, bb2
+  bb2:
+    sstore 0, v1 !metadata(storage=slot(0))
+    stop
+  bb1:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 17 !metadata(memory=scratch)
+    revert 0, 36
+}
+
+// === ROOT/tests/ui/codegen/lowering/run-call/this_call_creation_code_guard.sol:CreationModifier ===
+@module CreationModifier
+fn @seen() -> u256 [selector=0xd99aa8e2, view, abi_params=[], abi_returns=[word]] {
+  bb0:
+    v0 = sload 0 !metadata(storage=slot(0))
+    ret v0
+}
+
+fn @constructor() [constructor] {
+  bb0:
+    v0 = address
+    v1 = gas
+    v2 = abi_encode [], selector 0x5fb1149200000000000000000000000000000000000000000000000000000000
+    v3 = slice_ptr v2
+    v4 = slice_len v2
+    v5 = extcodesize v0
+    v6 = iszero v5
+    jumpi v6, bb2, bb3
+  bb3:
+    v7 = call v1, v0, 0, v3, v4, 0, 0
+    jumpi v7, bb5, bb4
+  bb4:
+    revert_returndata
+  bb5:
+    jump bb6
+  bb6:
+    jump bb1
+  bb1:
+    stop
+  bb2:
+    revert 0, 0
+}
+
+fn @setIt() [selector=0x5fb11492, abi_params=[], abi_returns=[]] {
+  bb0:
+    v0 = sload 0 !metadata(storage=slot(0))
+    v1 = add v0, 1
+    v2 = lt v1, v0
+    jumpi v2, bb1, bb2
+  bb2:
+    sstore 0, v1 !metadata(storage=slot(0))
+    stop
+  bb1:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 17 !metadata(memory=scratch)
+    revert 0, 36
+}
+
+// === ROOT/tests/ui/codegen/lowering/run-call/this_call_creation_code_guard.sol:CreationBase ===
+@module CreationBase
+fn @seen() -> u256 [selector=0xd99aa8e2, view, abi_params=[], abi_returns=[word]] {
+  bb0:
+    v0 = sload 0 !metadata(storage=slot(0))
+    ret v0
+}
+
+fn @constructor() [constructor] {
+  bb0:
+    v0 = address
+    v1 = gas
+    v2 = abi_encode [], selector 0x5fb1149200000000000000000000000000000000000000000000000000000000
+    v3 = slice_ptr v2
+    v4 = slice_len v2
+    v5 = extcodesize v0
+    v6 = iszero v5
+    jumpi v6, bb1, bb2
+  bb2:
+    v7 = call v1, v0, 0, v3, v4, 0, 0
+    jumpi v7, bb4, bb3
+  bb3:
+    revert_returndata
+  bb4:
+    stop
+  bb1:
+    revert 0, 0
+}
+
+fn @setIt() [selector=0x5fb11492, abi_params=[], abi_returns=[]] {
+  bb0:
+    v0 = sload 0 !metadata(storage=slot(0))
+    v1 = add v0, 1
+    v2 = lt v1, v0
+    jumpi v2, bb1, bb2
+  bb2:
+    sstore 0, v1 !metadata(storage=slot(0))
+    stop
+  bb1:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 17 !metadata(memory=scratch)
+    revert 0, 36
+}
+
+// === ROOT/tests/ui/codegen/lowering/run-call/this_call_creation_code_guard.sol:CreationDerived ===
+@module CreationDerived
+fn @constructor() [constructor] {
+  bb0:
+    v0 = address
+    v1 = gas
+    v2 = abi_encode [], selector 0x5fb1149200000000000000000000000000000000000000000000000000000000
+    v3 = slice_ptr v2
+    v4 = slice_len v2
+    v5 = extcodesize v0
+    v6 = iszero v5
+    jumpi v6, bb2, bb3
+  bb3:
+    v7 = call v1, v0, 0, v3, v4, 0, 0
+    jumpi v7, bb5, bb4
+  bb4:
+    revert_returndata
+  bb5:
+    jump bb1
+  bb1:
+    jump bb6
+  bb6:
+    stop
+  bb2:
+    revert 0, 0
+}
+
+fn @seen() -> u256 [selector=0xd99aa8e2, view, abi_params=[], abi_returns=[word]] {
+  bb0:
+    v0 = sload 0 !metadata(storage=slot(0))
+    ret v0
+}
+
+fn @setIt() [selector=0x5fb11492, abi_params=[], abi_returns=[]] {
+  bb0:
+    v0 = sload 0 !metadata(storage=slot(0))
+    v1 = add v0, 1
+    v2 = lt v1, v0
+    jumpi v2, bb1, bb2
+  bb2:
+    sstore 0, v1 !metadata(storage=slot(0))
+    stop
+  bb1:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 17 !metadata(memory=scratch)
+    revert 0, 36
+}
+
+// === ROOT/tests/ui/codegen/lowering/run-call/this_call_creation_code_guard.sol:Runtime ===
+@module Runtime
+fn @seen() -> u256 [selector=0xd99aa8e2, view, abi_params=[], abi_returns=[word]] {
+  bb0:
+    v0 = sload 0 !metadata(storage=slot(0))
+    ret v0
+}
+
+fn @helper() {
+  bb0:
+    v0 = address
+    v1 = gas
+    v2 = abi_encode [], selector 0x5fb1149200000000000000000000000000000000000000000000000000000000
+    v3 = slice_ptr v2
+    v4 = slice_len v2
+    v5 = call v1, v0, 0, v3, v4, 0, 0
+    jumpi v5, bb2, bb1
+  bb1:
+    revert_returndata
+  bb2:
+    stop
+}
+
+fn @viaHelper() -> u256 [selector=0x9c6f4ff5, abi_params=[], abi_returns=[word]] {
+  bb0:
+    internal_call @helper, 0
+    v0 = sload 0 !metadata(storage=slot(0))
+    ret v0
+}
+
+fn @setIt() [selector=0x5fb11492, abi_params=[], abi_returns=[]] {
+  bb0:
+    v0 = sload 0 !metadata(storage=slot(0))
+    v1 = add v0, 1
+    v2 = lt v1, v0
+    jumpi v2, bb1, bb2
+  bb2:
+    sstore 0, v1 !metadata(storage=slot(0))
+    stop
+  bb1:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 17 !metadata(memory=scratch)
+    revert 0, 36
+}
+
+// === ROOT/tests/ui/codegen/lowering/run-call/this_call_creation_code_guard.sol:Deployer ===
+@module Deployer
+data:
+  CreationHelper_initcode_0: hex"60c06040526097565b5a8060a051606001528060a051606001526040518060a051608001528060a05160800152602081016040527f5fb114920000000000000000000000000000000000000000000000000000000081526004810150308060a051604001523b1515606e575f5ffd5b8160a051606001528060a051608001525f5f6004835f3087f19150506095573d5f5f3e3d5ffd5b565b3460ca5760405160a05181602001528060a05260a00160405260b66008565b60a05160405260a0516020015160a05260ce565b5f5ffd5b608d8060d85f395ff3346028575f3560e01c80635fb11492146020578063d99aa8e2146024576028565b603e565b602c565b5f5ffd5b5f546080526020608001608090036080f35b5f54600181018060805280608052818110915050156083577f4e487b71000000000000000000000000000000000000000000000000000000005f52601160045260245ffd5b608051806080525f55"
+  CreationDirect_initcode_1: hex"610120604052346081575a8060e0528060e05260405180610100528061010052602081016040527f5fb114920000000000000000000000000000000000000000000000000000000081526004810150308060c0523b1515605d575f5ffd5b8160e05280610100525f5f6004835f3087f1915050607d573d5f5f3e3d5ffd5b6085565b5f5ffd5b608d80608f5f395ff3346028575f3560e01c80635fb11492146020578063d99aa8e2146024576028565b603e565b602c565b5f5ffd5b5f546080526020608001608090036080f35b5f54600181018060805280608052818110915050156083577f4e487b71000000000000000000000000000000000000000000000000000000005f52601160045260245ffd5b608051806080525f55"
+  CreationModifier_initcode_2: hex"610120604052346089575a8060e0528060e05260405180610100528061010052602081016040527f5fb114920000000000000000000000000000000000000000000000000000000081526004810150308060c0523b15156065576061565b608d565b5f5ffd5b8160e05280610100525f5f6004835f3087f19150506085573d5f5f3e3d5ffd5b605d565b5f5ffd5b608d8060975f395ff3346028575f3560e01c80635fb11492146020578063d99aa8e2146024576028565b603e565b602c565b5f5ffd5b5f546080526020608001608090036080f35b5f54600181018060805280608052818110915050156083577f4e487b71000000000000000000000000000000000000000000000000000000005f52601160045260245ffd5b608051806080525f55"
+
+fn @viaHelper() [selector=0x9c6f4ff5, abi_params=[], abi_returns=[]] {
+  bb0:
+    v0 = abi_encode []
+    v1 = not 31
+    v2 = and 388, v1
+    v3 = alloc raw, exact, uninitialized, infallible, v2
+    data_copy CreationHelper_initcode_0, v3, 357
+    v4 = slice_ptr v0
+    v5 = add v3, 357
+    mcopy v5, v4, 0 !metadata(memory=heap)
+    v6 = create 0, v3, 357
+    jumpi v6, bb2, bb1
+  bb1:
+    revert_returndata
+  bb2:
+    stop
+}
+
+fn @direct() [selector=0x222b1407, abi_params=[], abi_returns=[]] {
+  bb0:
+    v0 = abi_encode []
+    v1 = not 31
+    v2 = and 315, v1
+    v3 = alloc raw, exact, uninitialized, infallible, v2
+    data_copy CreationDirect_initcode_1, v3, 284
+    v4 = slice_ptr v0
+    v5 = add v3, 284
+    mcopy v5, v4, 0 !metadata(memory=heap)
+    v6 = create 0, v3, 284
+    jumpi v6, bb2, bb1
+  bb1:
+    revert_returndata
+  bb2:
+    stop
+}
+
+fn @viaModifier() [selector=0xb93fa0d6, abi_params=[], abi_returns=[]] {
+  bb0:
+    v0 = abi_encode []
+    v1 = not 31
+    v2 = and 323, v1
+    v3 = alloc raw, exact, uninitialized, infallible, v2
+    data_copy CreationModifier_initcode_2, v3, 292
+    v4 = slice_ptr v0
+    v5 = add v3, 292
+    mcopy v5, v4, 0 !metadata(memory=heap)
+    v6 = create 0, v3, 292
+    jumpi v6, bb2, bb1
+  bb1:
+    revert_returndata
+  bb2:
+    stop
+}
+
+fn @viaBase() [selector=0x0f982f84, abi_params=[], abi_returns=[]] {
+  bb0:
+    v0 = abi_encode []
+    v1 = not 31
+    v2 = and 323, v1
+    v3 = alloc raw, exact, uninitialized, infallible, v2
+    data_copy CreationModifier_initcode_2, v3, 292
+    v4 = slice_ptr v0
+    v5 = add v3, 292
+    mcopy v5, v4, 0 !metadata(memory=heap)
+    v6 = create 0, v3, 292
+    jumpi v6, bb2, bb1
+  bb1:
+    revert_returndata
+  bb2:
+    stop
+}

--- a/tests/ui/codegen/lowering/run-call/this_call_creation_code_guard.mir.stdout
+++ b/tests/ui/codegen/lowering/run-call/this_call_creation_code_guard.mir.stdout
@@ -382,12 +382,18 @@ fn @helper() {
     v2 = abi_encode [], selector 0x5fb1149200000000000000000000000000000000000000000000000000000000
     v3 = slice_ptr v2
     v4 = slice_len v2
-    v5 = call v1, v0, 0, v3, v4, 0, 0
-    jumpi v5, bb2, bb1
-  bb1:
-    revert_returndata
+    v5 = extcodesize v0
+    v6 = iszero v5
+    jumpi v6, bb1, bb2
   bb2:
+    v7 = call v1, v0, 0, v3, v4, 0, 0
+    jumpi v7, bb4, bb3
+  bb3:
+    revert_returndata
+  bb4:
     stop
+  bb1:
+    revert 0, 0
 }
 
 fn @viaHelper() -> u256 [selector=0x9c6f4ff5, abi_params=[], abi_returns=[word]] {

--- a/tests/ui/codegen/lowering/run-call/this_call_creation_code_guard.mir.stdout
+++ b/tests/ui/codegen/lowering/run-call/this_call_creation_code_guard.mir.stdout
@@ -232,6 +232,141 @@ fn @setIt() [selector=0x5fb11492, abi_params=[], abi_returns=[]] {
     revert 0, 36
 }
 
+// === ROOT/tests/ui/codegen/lowering/run-call/this_call_creation_code_guard.sol:CreationInitializer ===
+@module CreationInitializer
+fn @seen() -> u256 [selector=0xd99aa8e2, view, abi_params=[], abi_returns=[word]] {
+  bb0:
+    v0 = sload 0 !metadata(storage=slot(0))
+    ret v0
+}
+
+fn @x() -> u256 [selector=0x0c55699c, view, abi_params=[], abi_returns=[word]] {
+  bb0:
+    v0 = sload 1 !metadata(storage=slot(1))
+    ret v0
+}
+
+fn @init() -> u256 {
+  bb0:
+    v0 = address
+    v1 = gas
+    v2 = abi_encode [], selector 0x5fb1149200000000000000000000000000000000000000000000000000000000
+    v3 = slice_ptr v2
+    v4 = slice_len v2
+    v5 = extcodesize v0
+    v6 = iszero v5
+    jumpi v6, bb1, bb2
+  bb2:
+    v7 = call v1, v0, 0, v3, v4, 0, 0
+    jumpi v7, bb4, bb3
+  bb3:
+    revert_returndata
+  bb4:
+    ret 3
+  bb1:
+    revert 0, 0
+}
+
+fn @setIt() [selector=0x5fb11492, abi_params=[], abi_returns=[]] {
+  bb0:
+    v0 = sload 0 !metadata(storage=slot(0))
+    v1 = add v0, 1
+    v2 = lt v1, v0
+    jumpi v2, bb1, bb2
+  bb2:
+    sstore 0, v1 !metadata(storage=slot(0))
+    stop
+  bb1:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 17 !metadata(memory=scratch)
+    revert 0, 36
+}
+
+fn @constructor() [constructor] {
+  bb0:
+    v0 = internal_call @init, 1
+    sstore 1, v0 !metadata(storage=slot(1))
+    stop
+}
+
+// === ROOT/tests/ui/codegen/lowering/run-call/this_call_creation_code_guard.sol:CreationTry ===
+@module CreationTry
+fn @seen() -> u256 [selector=0xd99aa8e2, view, abi_params=[], abi_returns=[word]] {
+  bb0:
+    v0 = sload 0 !metadata(storage=slot(0))
+    ret v0
+}
+
+fn @constructor() [constructor] {
+  bb0:
+    v0 = address
+    v1 = gas
+    v2 = abi_encode [], selector 0x5fb1149200000000000000000000000000000000000000000000000000000000
+    v3 = slice_ptr v2
+    v4 = slice_len v2
+    v5 = extcodesize v0
+    v6 = iszero v5
+    jumpi v6, bb1, bb2
+  bb2:
+    v7 = call v1, v0, 0, v3, v4, 0, 0
+    jumpi v7, bb3, bb4
+  bb4:
+    v8 = returndatasize
+    v9 = add v8, 63
+    v10 = lt v9, v8
+    jumpi v10, bb6, bb7
+  bb7:
+    v11 = not 31
+    v12 = and v9, v11
+    v13 = alloc memorybytes, exact, uninitialized, infallible, v12
+    set_memory_object_len memorybytes, v13, v8
+    v14 = make_returndata_slice 0, v8
+    memory_object_copy_from_slice memorybytes, v13, v14
+    v15 = memory_object_data memorybytes, v13
+    v16 = memory_object_len memorybytes, v13
+    v17 = make_memory_slice v15, v16
+    v18 = memory_slice_load_word memory, v17, 0
+    v19 = lt v16, 4
+    v20 = iszero v19
+    v21 = shr 224, v18
+    v22 = eq v21, 0x8c379a0
+    v23 = and v20, v22
+    v24 = lt v16, 36
+    v25 = iszero v24
+    v26 = eq v21, 0x4e487b71
+    v27 = and v25, v26
+    jumpi 1, bb8, bb9
+  bb9:
+    revert v15, v16
+  bb8:
+    jump bb5
+  bb6:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 65 !metadata(memory=scratch)
+    revert 0, 36
+  bb3:
+    jump bb5
+  bb5:
+    stop
+  bb1:
+    revert 0, 0
+}
+
+fn @setIt() [selector=0x5fb11492, abi_params=[], abi_returns=[]] {
+  bb0:
+    v0 = sload 0 !metadata(storage=slot(0))
+    v1 = add v0, 1
+    v2 = lt v1, v0
+    jumpi v2, bb1, bb2
+  bb2:
+    sstore 0, v1 !metadata(storage=slot(0))
+    stop
+  bb1:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 17 !metadata(memory=scratch)
+    revert 0, 36
+}
+
 // === ROOT/tests/ui/codegen/lowering/run-call/this_call_creation_code_guard.sol:Runtime ===
 @module Runtime
 fn @seen() -> u256 [selector=0xd99aa8e2, view, abi_params=[], abi_returns=[word]] {
@@ -277,12 +412,78 @@ fn @setIt() [selector=0x5fb11492, abi_params=[], abi_returns=[]] {
     revert 0, 36
 }
 
+// === ROOT/tests/ui/codegen/lowering/run-call/this_call_creation_code_guard.sol:SharedHelper ===
+@module SharedHelper
+fn @seen() -> u256 [selector=0xd99aa8e2, view, abi_params=[], abi_returns=[word]] {
+  bb0:
+    v0 = sload 0 !metadata(storage=slot(0))
+    ret v0
+}
+
+fn @constructor(arg0: bool) [constructor, abi_params=[bool]] {
+  bb0:
+    jumpi arg0, bb1, bb2
+  bb2:
+    jump bb3
+  bb1:
+    internal_call @helper, 0
+    jump bb3
+  bb3:
+    stop
+}
+
+fn @helper() {
+  bb0:
+    v0 = address
+    v1 = gas
+    v2 = abi_encode [], selector 0x5fb1149200000000000000000000000000000000000000000000000000000000
+    v3 = slice_ptr v2
+    v4 = slice_len v2
+    v5 = extcodesize v0
+    v6 = iszero v5
+    jumpi v6, bb1, bb2
+  bb2:
+    v7 = call v1, v0, 0, v3, v4, 0, 0
+    jumpi v7, bb4, bb3
+  bb3:
+    revert_returndata
+  bb4:
+    stop
+  bb1:
+    revert 0, 0
+}
+
+fn @viaHelper() -> u256 [selector=0x9c6f4ff5, abi_params=[], abi_returns=[word]] {
+  bb0:
+    internal_call @helper, 0
+    v0 = sload 0 !metadata(storage=slot(0))
+    ret v0
+}
+
+fn @setIt() [selector=0x5fb11492, abi_params=[], abi_returns=[]] {
+  bb0:
+    v0 = sload 0 !metadata(storage=slot(0))
+    v1 = add v0, 1
+    v2 = lt v1, v0
+    jumpi v2, bb1, bb2
+  bb2:
+    sstore 0, v1 !metadata(storage=slot(0))
+    stop
+  bb1:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 17 !metadata(memory=scratch)
+    revert 0, 36
+}
+
 // === ROOT/tests/ui/codegen/lowering/run-call/this_call_creation_code_guard.sol:Deployer ===
 @module Deployer
 data:
   CreationHelper_initcode_0: hex"60c06040526097565b5a8060a051606001528060a051606001526040518060a051608001528060a05160800152602081016040527f5fb114920000000000000000000000000000000000000000000000000000000081526004810150308060a051604001523b1515606e575f5ffd5b8160a051606001528060a051608001525f5f6004835f3087f19150506095573d5f5f3e3d5ffd5b565b3460ca5760405160a05181602001528060a05260a00160405260b66008565b60a05160405260a0516020015160a05260ce565b5f5ffd5b608d8060d85f395ff3346028575f3560e01c80635fb11492146020578063d99aa8e2146024576028565b603e565b602c565b5f5ffd5b5f546080526020608001608090036080f35b5f54600181018060805280608052818110915050156083577f4e487b71000000000000000000000000000000000000000000000000000000005f52601160045260245ffd5b608051806080525f55"
   CreationDirect_initcode_1: hex"610120604052346081575a8060e0528060e05260405180610100528061010052602081016040527f5fb114920000000000000000000000000000000000000000000000000000000081526004810150308060c0523b1515605d575f5ffd5b8160e05280610100525f5f6004835f3087f1915050607d573d5f5f3e3d5ffd5b6085565b5f5ffd5b608d80608f5f395ff3346028575f3560e01c80635fb11492146020578063d99aa8e2146024576028565b603e565b602c565b5f5ffd5b5f546080526020608001608090036080f35b5f54600181018060805280608052818110915050156083577f4e487b71000000000000000000000000000000000000000000000000000000005f52601160045260245ffd5b608051806080525f55"
   CreationModifier_initcode_2: hex"610120604052346089575a8060e0528060e05260405180610100528061010052602081016040527f5fb114920000000000000000000000000000000000000000000000000000000081526004810150308060c0523b15156065576061565b608d565b5f5ffd5b8160e05280610100525f5f6004835f3087f19150506085573d5f5f3e3d5ffd5b605d565b5f5ffd5b608d8060975f395ff3346028575f3560e01c80635fb11492146020578063d99aa8e2146024576028565b603e565b602c565b5f5ffd5b5f546080526020608001608090036080f35b5f54600181018060805280608052818110915050156083577f4e487b71000000000000000000000000000000000000000000000000000000005f52601160045260245ffd5b608051806080525f55"
+  CreationInitializer_initcode_3: hex"60e060405260a0565b5a8060a051608001528060a051608001526040518060a05160a001528060a05160a00152602081016040527f5fb114920000000000000000000000000000000000000000000000000000000081526004810150308060a051606001523b1515606e575f5ffd5b8160a051608001528060a05160a001525f5f6004835f3087f19150506095573d5f5f3e3d5ffd5b600360a05160400152565b3460e95760405160a05181602001528060a05260c00160405260bf6008565b60a051604001518060c05260a05160405260a0516020015160a0528060c0528060c05260015560ed565b5f5ffd5b60ae8060f75f395ff3346036575f3560e01c80630c55699c14602a5780635fb1149214602e578063d99aa8e2146032576036565b604c565b605f565b603a565b5f5ffd5b5f546080526020608001608090036080f35b6001546080526020608001608090036080f35b5f546001810180608052806080528181109150501560a4577f4e487b71000000000000000000000000000000000000000000000000000000005f52601160045260245ffd5b608051806080525f55"
+  CreationTry_initcode_4: hex"6101c06040523461016b575a8060e0528060e05260405180610180528061018052602081016040527f5fb114920000000000000000000000000000000000000000000000000000000081526004810150308060c0523b1515605e575f5ffd5b8160e05280610180525f5f6004835f3087f191505015607b5760a4565b3d80610100528061010052603f81018061012052806101205281806101005281101560d65760a9565b61016f565b7f4e487b71000000000000000000000000000000000000000000000000000000005f52604160045260245ffd5b601f1981169050604051806101a05281810191508160405290508180610100528152602081018280610100525f823e509050602081018061014052806101405281806101a0525180610160529150816101605280610140525160048210158160e01c91506308c379a08214811650506024821015634e487b71821491501650506001156101615760a4565b6101605161014051fd5b5f5ffd5b608d8061017a5f395ff3346028575f3560e01c80635fb11492146020578063d99aa8e2146024576028565b603e565b602c565b5f5ffd5b5f546080526020608001608090036080f35b5f54600181018060805280608052818110915050156083577f4e487b71000000000000000000000000000000000000000000000000000000005f52601160045260245ffd5b608051806080525f55"
+  SharedHelper_initcode_5: hex"61028338038061028360e03960e001601f017fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe01660405260c9565b5a8060a051606001528060a051606001526040518060a051608001528060a05160800152602081016040527f5fb114920000000000000000000000000000000000000000000000000000000081526004810150308060a051604001523b151560a0575f5ffd5b8160a051606001528060a051608001525f5f6004835f3087f191505060c7573d5f5f3e3d5ffd5b565b346101445760e08060c0528060c05260e06102833803016020820111156101325761012e565b60e051156101285760405160a05181602001528060a05260a001604052610113603a565b60a05160405260a0516020015160a052610129565b5b610148565b5f5ffd5b8060c05251600290101561012e5760ef565b5f5ffd5b61012f806101545f395ff3346036575f3560e01c80635fb1149214602a5780639c6f4ff514602e578063d99aa8e2146032576036565b606a565b604c565b603a565b5f5ffd5b5f546080526020608001608090036080f35b610100604052605860ba565b5f546080526020608001608090036080f35b5f546001810180608052806080528181109150501560af577f4e487b71000000000000000000000000000000000000000000000000000000005f52601160045260245ffd5b608051806080525f55005b5a8060c0528060c0526040518060e0528060e052602081016040527f5fb114920000000000000000000000000000000000000000000000000000000081526004810150308060a0523b151561010d575f5ffd5b8160c0528060e0525f5f6004835f3087f191505061012d573d5f5f3e3d5ffd5b56"
 
 fn @viaHelper() [selector=0x9c6f4ff5, abi_params=[], abi_returns=[]] {
   bb0:
@@ -350,6 +551,62 @@ fn @viaBase() [selector=0x0f982f84, abi_params=[], abi_returns=[]] {
     mcopy v5, v4, 0 !metadata(memory=heap)
     v6 = create 0, v3, 292
     jumpi v6, bb2, bb1
+  bb1:
+    revert_returndata
+  bb2:
+    stop
+}
+
+fn @viaInitializer() [selector=0x7c61d018, abi_params=[], abi_returns=[]] {
+  bb0:
+    v0 = abi_encode []
+    v1 = not 31
+    v2 = and 452, v1
+    v3 = alloc raw, exact, uninitialized, infallible, v2
+    data_copy CreationInitializer_initcode_3, v3, 421
+    v4 = slice_ptr v0
+    v5 = add v3, 421
+    mcopy v5, v4, 0 !metadata(memory=heap)
+    v6 = create 0, v3, 421
+    jumpi v6, bb2, bb1
+  bb1:
+    revert_returndata
+  bb2:
+    stop
+}
+
+fn @viaTry() [selector=0x9369e272, abi_params=[], abi_returns=[]] {
+  bb0:
+    v0 = abi_encode []
+    v1 = not 31
+    v2 = and 550, v1
+    v3 = alloc raw, exact, uninitialized, infallible, v2
+    data_copy CreationTry_initcode_4, v3, 519
+    v4 = slice_ptr v0
+    v5 = add v3, 519
+    mcopy v5, v4, 0 !metadata(memory=heap)
+    v6 = create 0, v3, 519
+    jumpi v6, bb2, bb1
+  bb1:
+    revert_returndata
+  bb2:
+    stop
+}
+
+fn @viaShared() [selector=0x86375232, abi_params=[], abi_returns=[]] {
+  bb0:
+    v0 = eq 1, 0
+    v1 = iszero v0
+    v2 = abi_encode [word<bool>], args v1
+    v3 = not 31
+    v4 = and 706, v3
+    v5 = alloc raw, exact, uninitialized, infallible, v4
+    data_copy SharedHelper_initcode_5, v5, 643
+    v6 = slice_ptr v2
+    v7 = add v5, 643
+    mcopy v7, v6, 32 !metadata(memory=heap)
+    v8 = create 0, v5, 675
+    jumpi v8, bb2, bb1
   bb1:
     revert_returndata
   bb2:

--- a/tests/ui/codegen/lowering/run-call/this_call_creation_code_guard.mir.stdout
+++ b/tests/ui/codegen/lowering/run-call/this_call_creation_code_guard.mir.stdout
@@ -8,7 +8,7 @@ fn @seen() -> u256 [selector=0xd99aa8e2, view, abi_params=[], abi_returns=[word]
 
 fn @constructor() [constructor] {
   bb0:
-    internal_call @helper, 0
+    icall @helper, 0
     stop
 }
 
@@ -284,7 +284,7 @@ fn @setIt() [selector=0x5fb11492, abi_params=[], abi_returns=[]] {
 
 fn @constructor() [constructor] {
   bb0:
-    v0 = internal_call @init, 1
+    v0 = icall @init, 1
     sstore 1, v0 !metadata(storage=slot(1))
     stop
 }
@@ -398,7 +398,7 @@ fn @helper() {
 
 fn @viaHelper() -> u256 [selector=0x9c6f4ff5, abi_params=[], abi_returns=[word]] {
   bb0:
-    internal_call @helper, 0
+    icall @helper, 0
     v0 = sload 0 !metadata(storage=slot(0))
     ret v0
 }
@@ -432,7 +432,7 @@ fn @constructor(arg0: bool) [constructor, abi_params=[bool]] {
   bb2:
     jump bb3
   bb1:
-    internal_call @helper, 0
+    icall @helper, 0
     jump bb3
   bb3:
     stop
@@ -461,7 +461,7 @@ fn @helper() {
 
 fn @viaHelper() -> u256 [selector=0x9c6f4ff5, abi_params=[], abi_returns=[word]] {
   bb0:
-    internal_call @helper, 0
+    icall @helper, 0
     v0 = sload 0 !metadata(storage=slot(0))
     ret v0
 }

--- a/tests/ui/codegen/lowering/run-call/this_call_creation_code_guard.sol
+++ b/tests/ui/codegen/lowering/run-call/this_call_creation_code_guard.sol
@@ -4,11 +4,17 @@
 //@ run-call-fail: Deployer::direct => 0x
 //@ run-call-fail: Deployer::viaModifier => 0x
 //@ run-call-fail: Deployer::viaBase => 0x
+//@ run-call-fail: Deployer::viaInitializer => 0x
+//@ run-call-fail: Deployer::viaTry => 0x
+//@ run-call-fail: Deployer::viaShared => 0x
 //@ run-call: Runtime::viaHelper => 1
+//@ run-call: SharedHelper::viaHelper; constructor=[false] => 1
 
 // A `this.f()` call in creation code has to keep the `extcodesize` guard: the contract's code is
 // only stored once the constructor returns, so the call would otherwise silently do nothing.
 // Every function copied into the creation object keeps the guard, not just the constructor.
+// A function the runtime object shares with the creation object has one body, so it keeps the
+// guard in both copies; the runtime call still succeeds because the code exists by then.
 
 // CHECK-LABEL: @module CreationHelper
 // CHECK-LABEL: fn @helper
@@ -85,6 +91,43 @@ contract CreationDerived is CreationBase {
     constructor() CreationBase() {}
 }
 
+// A state variable initializer runs in creation code as well, so its callees keep the guard.
+// CHECK-LABEL: @module CreationInitializer
+// CHECK-LABEL: fn @init
+// CHECK: extcodesize
+// CHECK: call
+contract CreationInitializer {
+    uint256 public seen;
+    uint256 public x = init();
+
+    function init() internal returns (uint256) {
+        this.setIt();
+        return 3;
+    }
+
+    function setIt() external {
+        seen = seen + 1;
+    }
+}
+
+// The `try` form of the same call keeps the guard too. The guard reverts before the call, so the
+// `catch` clause does not run and the deployment fails.
+// CHECK-LABEL: @module CreationTry
+// CHECK-LABEL: fn @constructor
+// CHECK: extcodesize
+// CHECK: call
+contract CreationTry {
+    uint256 public seen;
+
+    constructor() {
+        try this.setIt() {} catch {}
+    }
+
+    function setIt() external {
+        seen = seen + 1;
+    }
+}
+
 // The same helper in runtime code needs no guard: the running code is the contract's own.
 // CHECK-LABEL: @module Runtime
 // CHECK-LABEL: fn @helper
@@ -93,6 +136,35 @@ contract CreationDerived is CreationBase {
 // CHECK-LABEL: fn @viaHelper
 contract Runtime {
     uint256 public seen;
+
+    function helper() internal {
+        this.setIt();
+    }
+
+    function viaHelper() external returns (uint256) {
+        helper();
+        return seen;
+    }
+
+    function setIt() external {
+        seen = seen + 1;
+    }
+}
+
+// One helper reached from both objects: its single body keeps the guard, which the constructor
+// only reaches when its argument asks for it and the runtime call passes.
+// CHECK-LABEL: @module SharedHelper
+// CHECK-LABEL: fn @helper
+// CHECK: extcodesize
+// CHECK: call
+contract SharedHelper {
+    uint256 public seen;
+
+    constructor(bool run) {
+        if (run) {
+            helper();
+        }
+    }
 
     function helper() internal {
         this.setIt();
@@ -124,5 +196,17 @@ contract Deployer {
 
     function viaBase() external {
         new CreationDerived();
+    }
+
+    function viaInitializer() external {
+        new CreationInitializer();
+    }
+
+    function viaTry() external {
+        new CreationTry();
+    }
+
+    function viaShared() external {
+        new SharedHelper(true);
     }
 }

--- a/tests/ui/codegen/lowering/run-call/this_call_creation_code_guard.sol
+++ b/tests/ui/codegen/lowering/run-call/this_call_creation_code_guard.sol
@@ -1,0 +1,128 @@
+//@ codegen-matrix: standard
+//@[mir] filecheck:
+//@ run-call-fail: Deployer::viaHelper => 0x
+//@ run-call-fail: Deployer::direct => 0x
+//@ run-call-fail: Deployer::viaModifier => 0x
+//@ run-call-fail: Deployer::viaBase => 0x
+//@ run-call: Runtime::viaHelper => 1
+
+// A `this.f()` call in creation code has to keep the `extcodesize` guard: the contract's code is
+// only stored once the constructor returns, so the call would otherwise silently do nothing.
+// Every function copied into the creation object keeps the guard, not just the constructor.
+
+// CHECK-LABEL: @module CreationHelper
+// CHECK-LABEL: fn @helper
+// CHECK: extcodesize
+// CHECK: call
+contract CreationHelper {
+    uint256 public seen;
+
+    constructor() {
+        helper();
+    }
+
+    function helper() internal {
+        this.setIt();
+    }
+
+    function setIt() external {
+        seen = seen + 1;
+    }
+}
+
+// CHECK-LABEL: @module CreationDirect
+// CHECK-LABEL: fn @constructor
+// CHECK: extcodesize
+// CHECK: call
+contract CreationDirect {
+    uint256 public seen;
+
+    constructor() {
+        this.setIt();
+    }
+
+    function setIt() external {
+        seen = seen + 1;
+    }
+}
+
+// CHECK-LABEL: @module CreationModifier
+// CHECK-LABEL: fn @constructor
+// CHECK: extcodesize
+// CHECK: call
+contract CreationModifier {
+    uint256 public seen;
+
+    modifier m() {
+        this.setIt();
+        _;
+    }
+
+    constructor() m() {}
+
+    function setIt() external {
+        seen = seen + 1;
+    }
+}
+
+contract CreationBase {
+    uint256 public seen;
+
+    constructor() {
+        this.setIt();
+    }
+
+    function setIt() external {
+        seen = seen + 1;
+    }
+}
+
+// CHECK-LABEL: @module CreationDerived
+// CHECK-LABEL: fn @constructor
+// CHECK: extcodesize
+// CHECK: call
+contract CreationDerived is CreationBase {
+    constructor() CreationBase() {}
+}
+
+// The same helper in runtime code needs no guard: the running code is the contract's own.
+// CHECK-LABEL: @module Runtime
+// CHECK-LABEL: fn @helper
+// CHECK-NOT: extcodesize
+// CHECK: call
+// CHECK-LABEL: fn @viaHelper
+contract Runtime {
+    uint256 public seen;
+
+    function helper() internal {
+        this.setIt();
+    }
+
+    function viaHelper() external returns (uint256) {
+        helper();
+        return seen;
+    }
+
+    function setIt() external {
+        seen = seen + 1;
+    }
+}
+
+// A failing deployment is only observable from a call, so each case is deployed by this contract.
+contract Deployer {
+    function viaHelper() external {
+        new CreationHelper();
+    }
+
+    function direct() external {
+        new CreationDirect();
+    }
+
+    function viaModifier() external {
+        new CreationModifier();
+    }
+
+    function viaBase() external {
+        new CreationDerived();
+    }
+}

--- a/tests/ui/codegen/lowering/run-call/this_call_creation_code_guard.sol
+++ b/tests/ui/codegen/lowering/run-call/this_call_creation_code_guard.sol
@@ -10,11 +10,11 @@
 //@ run-call: Runtime::viaHelper => 1
 //@ run-call: SharedHelper::viaHelper; constructor=[false] => 1
 
-// A `this.f()` call in creation code has to keep the `extcodesize` guard: the contract's code is
-// only stored once the constructor returns, so the call would otherwise silently do nothing.
-// Every function copied into the creation object keeps the guard, not just the constructor.
-// A function the runtime object shares with the creation object has one body, so it keeps the
-// guard in both copies; the runtime call still succeeds because the code exists by then.
+// A `this.f()` call keeps the `extcodesize` guard wherever solc emits one, so creation code is
+// guarded too: the contract's code is only stored once the constructor returns, and the call
+// would otherwise silently do nothing. A function the runtime object shares with the creation
+// object has one body, so it keeps the guard in both copies; the runtime call still succeeds
+// because the code exists by then.
 
 // CHECK-LABEL: @module CreationHelper
 // CHECK-LABEL: fn @helper
@@ -128,10 +128,12 @@ contract CreationTry {
     }
 }
 
-// The same helper in runtime code needs no guard: the running code is the contract's own.
+// The same helper in runtime code is guarded as well: the running code is the contract's own only
+// until a `DELEGATECALL` frame separates it from `address(this)`, which is what
+// `this_call_delegated_guard.sol` covers. The call passes here because the code exists.
 // CHECK-LABEL: @module Runtime
 // CHECK-LABEL: fn @helper
-// CHECK-NOT: extcodesize
+// CHECK: extcodesize
 // CHECK: call
 // CHECK-LABEL: fn @viaHelper
 contract Runtime {
@@ -152,7 +154,7 @@ contract Runtime {
 }
 
 // One helper reached from both objects: its single body keeps the guard, which the constructor
-// only reaches when its argument asks for it and the runtime call passes.
+// only reaches when its argument asks for it, and the runtime call passes.
 // CHECK-LABEL: @module SharedHelper
 // CHECK-LABEL: fn @helper
 // CHECK: extcodesize

--- a/tests/ui/codegen/lowering/run-call/this_call_delegated_guard.mir.stdout
+++ b/tests/ui/codegen/lowering/run-call/this_call_delegated_guard.mir.stdout
@@ -1,0 +1,174 @@
+// === ROOT/tests/ui/codegen/lowering/run-call/this_call_delegated_guard.sol:Impl ===
+@module Impl
+fn @initialized() -> u256 [selector=0x158ef93e, view, abi_params=[], abi_returns=[word]] {
+  bb0:
+    v0 = sload 0 !metadata(storage=slot(0))
+    ret v0
+}
+
+fn @init() [selector=0xe1c7392a, abi_params=[], abi_returns=[]] {
+  bb0:
+    v0 = address
+    v1 = gas
+    v2 = abi_encode [], selector 0x5c36b18600000000000000000000000000000000000000000000000000000000
+    v3 = slice_ptr v2
+    v4 = slice_len v2
+    v5 = extcodesize v0
+    v6 = iszero v5
+    jumpi v6, bb1, bb2
+  bb2:
+    v7 = call v1, v0, 0, v3, v4, 0, 0
+    jumpi v7, bb4, bb3
+  bb3:
+    revert_returndata
+  bb4:
+    sstore 0, 1 !metadata(storage=slot(0))
+    stop
+  bb1:
+    revert 0, 0
+}
+
+fn @ping() [selector=0x5c36b186, abi_params=[], abi_returns=[]] {
+  bb0:
+    stop
+}
+
+// === ROOT/tests/ui/codegen/lowering/run-call/this_call_delegated_guard.sol:Proxy ===
+@module Proxy
+fn @initialized() -> u256 [selector=0x158ef93e, view, abi_params=[], abi_returns=[word]] {
+  bb0:
+    v0 = sload 0 !metadata(storage=slot(0))
+    ret v0
+}
+
+fn @constructor(arg0: address) [constructor, abi_params=[address]] {
+  bb0:
+    v0 = gas
+    v1 = abi_encode [], object, selector 0xe1c7392a00000000000000000000000000000000000000000000000000000000
+    v2 = memory_object_data memorybytes, v1
+    v3 = memory_object_len memorybytes, v1
+    v4 = delegatecall v0, arg0, v2, v3, 0, 0
+    v5 = iszero v4
+    jumpi v5, bb1, bb2
+  bb2:
+    stop
+  bb1:
+    internal_call @revert_error, 0, 11, 0x696e6974206661696c6564000000000000000000000000000000000000000000
+    invalid
+}
+
+fn @revert_error(arg0: u256, arg1: u256) {
+  bb0:
+    mstore 0, 0x8c379a000000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 32 !metadata(memory=scratch)
+    mstore 36, arg0 !metadata(memory=scratch)
+    mstore 68, arg1 !metadata(memory=scratch)
+    revert 0, 100
+}
+
+// === ROOT/tests/ui/codegen/lowering/run-call/this_call_delegated_guard.sol:Deployer ===
+@module Deployer
+data:
+  Impl_initcode_0: hex"34600d5760c98060115f395ff35b5f5ffd346036575f3560e01c8063158ef93e14602a5780635c36b18614602e578063e1c7392a146032576036565b603a565b60c8565b604c565b5f5ffd5b5f546080526020608001608090036080f35b60e06040525a8060a0528060a0526040518060c0528060c052602081016040527f5c36b186000000000000000000000000000000000000000000000000000000008152600481015030806080523b151560a3575f5ffd5b8160a0528060c0525f5f6004835f3087f191505060c2573d5f5f3e3d5ffd5b60015f55005b"
+  Proxy_initcode_1: hex"6101c13803806101c16101403961014001601f017fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe016604052607d565b7f08c379a0000000000000000000000000000000000000000000000000000000005f52602060045260a0516040015160245260a0516060015160445260645ffd5b34610182576101408060c0528060c0526101406101c13803016020820111156101705761016c565b6040518060e0526040810160405260048152602081017fe1c7392a000000000000000000000000000000000000000000000000000000008152600490015060208101818060e052519150806101005281610120525f5f8383610140515af491505015156101675760405160a0518160200152600b81604001527f696e6974206661696c656400000000000000000000000000000000000000000081606001528060a052608001604052610155603c565b60a05160405260a0516020015160a052fe5b610186565b5f5ffd5b8060c0525160a01c151561016c5760a5565b5f5ffd5b6030806101915f395ff334601a575f3560e01c8063158ef93e14601657601a565b601e565b5f5ffd5b5f546080526020608001608090036080f3"
+
+fn @deployProxy() -> u256 [selector=0x44882b95, abi_params=[], abi_returns=[word]] {
+  bb0:
+    v0 = abi_encode []
+    v1 = not 31
+    v2 = and 249, v1
+    v3 = alloc raw, exact, uninitialized, infallible, v2
+    data_copy Impl_initcode_0, v3, 218
+    v4 = slice_ptr v0
+    v5 = add v3, 218
+    mcopy v5, v4, 0 !metadata(memory=heap)
+    v6 = create 0, v3, 218
+    jumpi v6, bb2, bb1
+  bb1:
+    revert_returndata
+  bb2:
+    v7 = and v6, 0xffffffffffffffffffffffffffffffffffffffff
+    v8 = abi_encode [word<u160>], args v7
+    v9 = not 31
+    v10 = and 512, v9
+    v11 = alloc raw, exact, uninitialized, infallible, v10
+    data_copy Proxy_initcode_1, v11, 449
+    v12 = slice_ptr v8
+    v13 = add v11, 449
+    mcopy v13, v12, 32 !metadata(memory=heap)
+    v14 = create 0, v11, 481
+    jumpi v14, bb4, bb3
+  bb3:
+    revert_returndata
+  bb4:
+    v15 = gas
+    v16 = abi_encode [], selector 0x158ef93e00000000000000000000000000000000000000000000000000000000
+    v17 = slice_ptr v16
+    v18 = slice_len v16
+    v19 = staticcall v15, v14, v17, v18, 0, 32
+    jumpi v19, bb6, bb5
+  bb5:
+    revert_returndata
+  bb6:
+    v20 = returndatasize
+    v21 = lt v20, 32
+    jumpi v21, bb7, bb8
+  bb8:
+    v22 = add 0, 0
+    v23 = mload v22
+    v24 = add 0, 0
+    v25 = mload v24
+    ret v25
+  bb7:
+    revert 0, 0
+}
+
+fn @callImplDirectly() -> u256 [selector=0x0bba4d4b, abi_params=[], abi_returns=[word]] {
+  bb0:
+    v0 = abi_encode []
+    v1 = not 31
+    v2 = and 249, v1
+    v3 = alloc raw, exact, uninitialized, infallible, v2
+    data_copy Impl_initcode_0, v3, 218
+    v4 = slice_ptr v0
+    v5 = add v3, 218
+    mcopy v5, v4, 0 !metadata(memory=heap)
+    v6 = create 0, v3, 218
+    jumpi v6, bb2, bb1
+  bb1:
+    revert_returndata
+  bb2:
+    v7 = gas
+    v8 = abi_encode [], selector 0xe1c7392a00000000000000000000000000000000000000000000000000000000
+    v9 = slice_ptr v8
+    v10 = slice_len v8
+    v11 = extcodesize v6
+    v12 = iszero v11
+    jumpi v12, bb3, bb4
+  bb4:
+    v13 = call v7, v6, 0, v9, v10, 0, 0
+    jumpi v13, bb6, bb5
+  bb5:
+    revert_returndata
+  bb6:
+    v14 = gas
+    v15 = abi_encode [], selector 0x158ef93e00000000000000000000000000000000000000000000000000000000
+    v16 = slice_ptr v15
+    v17 = slice_len v15
+    v18 = staticcall v14, v6, v16, v17, 0, 32
+    jumpi v18, bb8, bb7
+  bb7:
+    revert_returndata
+  bb8:
+    v19 = returndatasize
+    v20 = lt v19, 32
+    jumpi v20, bb3, bb9
+  bb9:
+    v21 = add 0, 0
+    v22 = mload v21
+    v23 = add 0, 0
+    v24 = mload v23
+    ret v24
+  bb3:
+    revert 0, 0
+}

--- a/tests/ui/codegen/lowering/run-call/this_call_delegated_guard.mir.stdout
+++ b/tests/ui/codegen/lowering/run-call/this_call_delegated_guard.mir.stdout
@@ -53,7 +53,7 @@ fn @constructor(arg0: address) [constructor, abi_params=[address]] {
   bb2:
     stop
   bb1:
-    internal_call @revert_error, 0, 11, 0x696e6974206661696c6564000000000000000000000000000000000000000000
+    icall @revert_error, 0, 11, 0x696e6974206661696c6564000000000000000000000000000000000000000000
     invalid
 }
 

--- a/tests/ui/codegen/lowering/run-call/this_call_delegated_guard.sol
+++ b/tests/ui/codegen/lowering/run-call/this_call_delegated_guard.sol
@@ -1,0 +1,51 @@
+//@ codegen-matrix: standard
+//@[mir] filecheck:
+//@ run-call-fail: Deployer::deployProxy => Error("init failed")
+//@ run-call: Deployer::callImplDirectly => 1
+
+// A `this.f()` call keeps its `extcodesize` guard wherever solc emits one, which is wherever the
+// call expects no return data or the version has no `RETURNDATASIZE`. The executing code and
+// `address(this)` come apart under `DELEGATECALL`: here the implementation's `init` runs on a
+// proxy that is still in its constructor and has no code, so `this.ping()` reaches a code-less
+// account. Without the guard the `CALL` would succeed without running `ping`, and the
+// initialization would be silently skipped.
+
+// CHECK-LABEL: @module Impl
+// CHECK-LABEL: fn @init
+// CHECK: extcodesize
+// CHECK: call
+contract Impl {
+    uint256 public initialized;
+
+    function init() external {
+        this.ping();
+        initialized = 1;
+    }
+
+    function ping() external {}
+}
+
+contract Proxy {
+    uint256 public initialized;
+
+    constructor(address impl) {
+        (bool ok, ) = impl.delegatecall(abi.encodeWithSelector(Impl.init.selector));
+        require(ok, "init failed");
+    }
+}
+
+// A failing deployment is only observable from a call, so the proxy is deployed by this contract.
+// The same `init` called on the implementation itself finds the code it is running and succeeds.
+contract Deployer {
+    function deployProxy() external returns (uint256) {
+        Impl impl = new Impl();
+        Proxy proxy = new Proxy(address(impl));
+        return proxy.initialized();
+    }
+
+    function callImplDirectly() external returns (uint256) {
+        Impl impl = new Impl();
+        impl.init();
+        return impl.initialized();
+    }
+}

--- a/tests/ui/codegen/lowering/run-call/try_bare_catch_evm_version.homestead.stdout
+++ b/tests/ui/codegen/lowering/run-call/try_bare_catch_evm_version.homestead.stdout
@@ -70,7 +70,7 @@ fn @live() -> u256 [selector=0x957aa58c, abi_params=[], abi_returns=[word]] {
   bb4:
     v12 = gas
     v13 = sub v12, 50
-    v14 = call v13, v6, 0, v8, v9, 0, 32
+    v14 = call v13, v6, 0, v8, v9, v8, 32
     jumpi v14, bb5, bb6
   bb6:
     jumpi 1, bb8, bb9
@@ -79,9 +79,9 @@ fn @live() -> u256 [selector=0x957aa58c, abi_params=[], abi_returns=[word]] {
   bb8:
     jump bb7
   bb5:
-    v15 = add 0, 0
+    v15 = add v8, 0
     v16 = mload v15
-    v17 = add 0, 0
+    v17 = add v8, 0
     v18 = mload v17
     jump bb7
   bb7:
@@ -109,17 +109,16 @@ fn @liveTwo() -> u256 [selector=0xa9b44a2a, abi_params=[], abi_returns=[word]] {
     v7 = abi_encode [], selector 0xa8aa1b3100000000000000000000000000000000000000000000000000000000
     v8 = slice_ptr v7
     v9 = slice_len v7
-    v10 = alloc raw, exact, uninitialized, infallible, 64
-    v11 = add v10, 32
-    mstore v11, 0
-    v12 = extcodesize v6
-    v13 = iszero v12
-    jumpi v13, bb3, bb4
+    v10 = add v8, 32
+    mstore v10, 0
+    v11 = extcodesize v6
+    v12 = iszero v11
+    jumpi v12, bb3, bb4
   bb4:
-    v14 = gas
-    v15 = sub v14, 50
-    v16 = call v15, v6, 0, v8, v9, v10, 64
-    jumpi v16, bb5, bb6
+    v13 = gas
+    v14 = sub v13, 50
+    v15 = call v14, v6, 0, v8, v9, v8, 64
+    jumpi v15, bb5, bb6
   bb6:
     jumpi 1, bb10, bb11
   bb11:
@@ -127,23 +126,23 @@ fn @liveTwo() -> u256 [selector=0xa9b44a2a, abi_params=[], abi_returns=[word]] {
   bb10:
     jump bb7
   bb5:
-    v17 = add v10, 0
-    v18 = mload v17
-    v19 = add v10, 32
-    v20 = mload v19
-    frame_store multi_return, word, 0, v10 !metadata(memory=scratch)
-    v21 = add v10, 0
-    v22 = mload v21
-    v23 = add v10, 32
-    v24 = mload v23
-    v25 = add v22, v24
-    v26 = lt v25, v22
-    jumpi v26, bb8, bb9
+    v16 = add v8, 0
+    v17 = mload v16
+    v18 = add v8, 32
+    v19 = mload v18
+    frame_store multi_return, word, 0, v8 !metadata(memory=scratch)
+    v20 = add v8, 0
+    v21 = mload v20
+    v22 = add v8, 32
+    v23 = mload v22
+    v24 = add v21, v23
+    v25 = lt v24, v21
+    jumpi v25, bb8, bb9
   bb9:
     jump bb7
   bb7:
-    v27 = phi [bb9: v25], [bb10: 7]
-    ret v27
+    v26 = phi [bb9: v24], [bb10: 7]
+    ret v26
   bb8:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
@@ -167,20 +166,22 @@ fn @liveAggregate() -> u256 [selector=0xc64a4ee9, abi_params=[], abi_returns=[wo
   bb1:
     revert_returndata
   bb2:
-    v7 = abi_encode [], selector 0xf5e34bfa00000000000000000000000000000000000000000000000000000000
-    v8 = slice_ptr v7
-    v9 = slice_len v7
-    v10 = alloc raw, exact, uninitialized, infallible, 64
-    v11 = add v10, 32
-    mstore v11, 0
-    v12 = extcodesize v6
-    v13 = iszero v12
-    jumpi v13, bb3, bb4
+    v7 = alloc memorybytes, exact, uninitialized, infallible, 96
+    set_memory_object_len memorybytes, v7, 64
+    v8 = memory_object_data memorybytes, v7
+    v9 = abi_encode [], selector 0xf5e34bfa00000000000000000000000000000000000000000000000000000000
+    v10 = slice_ptr v9
+    v11 = slice_len v9
+    v12 = add v10, 32
+    mstore v12, 0
+    v13 = extcodesize v6
+    v14 = iszero v13
+    jumpi v14, bb3, bb4
   bb4:
-    v14 = gas
-    v15 = sub v14, 50
-    v16 = call v15, v6, 0, v8, v9, v10, 64
-    jumpi v16, bb5, bb6
+    v15 = gas
+    v16 = sub v15, 50
+    v17 = call v16, v6, 0, v10, v11, v10, 64
+    jumpi v17, bb5, bb6
   bb6:
     jumpi 1, bb13, bb14
   bb14:
@@ -188,25 +189,26 @@ fn @liveAggregate() -> u256 [selector=0xc64a4ee9, abi_params=[], abi_returns=[wo
   bb13:
     jump bb7
   bb5:
-    v17 = abi_decode [array<2, u256>], v10
-    v18 = lt 0, 2
-    v19 = iszero v18
-    jumpi v19, bb8, bb9
+    mcopy v8, v10, 64
+    v18 = abi_decode [array<2, u256>], v7
+    v19 = lt 0, 2
+    v20 = iszero v19
+    jumpi v20, bb8, bb9
   bb9:
-    v20 = memory_object_load_element memoryfixedarray<2, 1>, v17, 0
-    v21 = lt 1, 2
-    v22 = iszero v21
-    jumpi v22, bb8, bb10
+    v21 = memory_object_load_element memoryfixedarray<2, 1>, v18, 0
+    v22 = lt 1, 2
+    v23 = iszero v22
+    jumpi v23, bb8, bb10
   bb10:
-    v23 = memory_object_load_element memoryfixedarray<2, 1>, v17, 1
-    v24 = add v20, v23
-    v25 = lt v24, v20
-    jumpi v25, bb11, bb12
+    v24 = memory_object_load_element memoryfixedarray<2, 1>, v18, 1
+    v25 = add v21, v24
+    v26 = lt v25, v21
+    jumpi v26, bb11, bb12
   bb12:
     jump bb7
   bb7:
-    v26 = phi [bb12: v24], [bb13: 7]
-    ret v26
+    v27 = phi [bb12: v25], [bb13: 7]
+    ret v27
   bb11:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
@@ -243,7 +245,7 @@ fn @liveNoReturn() -> u256 [selector=0x0f81fb69, abi_params=[], abi_returns=[wor
   bb4:
     v12 = gas
     v13 = sub v12, 50
-    v14 = call v13, v6, 0, v8, v9, 0, 0
+    v14 = call v13, v6, 0, v8, v9, v8, 0
     jumpi v14, bb5, bb6
   bb6:
     jumpi 1, bb8, bb9
@@ -284,7 +286,7 @@ fn @liveCatch() -> u256 [selector=0x852bf1e6, abi_params=[], abi_returns=[word]]
   bb4:
     v12 = gas
     v13 = sub v12, 0x235a
-    v14 = call v13, v6, 1, v8, v9, 0, 32
+    v14 = call v13, v6, 1, v8, v9, v8, 32
     jumpi v14, bb5, bb6
   bb6:
     jumpi 1, bb8, bb9
@@ -293,9 +295,9 @@ fn @liveCatch() -> u256 [selector=0x852bf1e6, abi_params=[], abi_returns=[word]]
   bb8:
     jump bb7
   bb5:
-    v15 = add 0, 0
+    v15 = add v8, 0
     v16 = mload v15
-    v17 = add 0, 0
+    v17 = add v8, 0
     v18 = mload v17
     jump bb7
   bb7:
@@ -334,7 +336,7 @@ fn @livePointer() -> u256 [selector=0x6347cf88, abi_params=[], abi_returns=[word
   bb4:
     v17 = gas
     v18 = sub v17, 50
-    v19 = call v18, v11, 0, v13, v14, 0, 32
+    v19 = call v18, v11, 0, v13, v14, v13, 32
     jumpi v19, bb5, bb6
   bb6:
     jumpi 1, bb8, bb9
@@ -343,9 +345,9 @@ fn @livePointer() -> u256 [selector=0x6347cf88, abi_params=[], abi_returns=[word
   bb8:
     jump bb7
   bb5:
-    v20 = add 0, 0
+    v20 = add v13, 0
     v21 = mload v20
-    v22 = add 0, 0
+    v22 = add v13, 0
     v23 = mload v22
     jump bb7
   bb7:
@@ -393,7 +395,7 @@ fn @noCode() -> u256 [selector=0x96c56dce, abi_params=[], abi_returns=[word]] {
   bb2:
     v5 = gas
     v6 = sub v5, 50
-    v7 = call v6, 0, 0, v1, v2, 0, 32
+    v7 = call v6, 0, 0, v1, v2, v1, 32
     jumpi v7, bb3, bb4
   bb4:
     jumpi 1, bb6, bb7
@@ -402,9 +404,9 @@ fn @noCode() -> u256 [selector=0x96c56dce, abi_params=[], abi_returns=[word]] {
   bb6:
     jump bb5
   bb3:
-    v8 = add 0, 0
+    v8 = add v1, 0
     v9 = mload v8
-    v10 = add 0, 0
+    v10 = add v1, 0
     v11 = mload v10
     jump bb5
   bb5:
@@ -425,7 +427,7 @@ fn @noCodeNoReturn() -> u256 [selector=0xac1b26c4, abi_params=[], abi_returns=[w
   bb2:
     v5 = gas
     v6 = sub v5, 50
-    v7 = call v6, 0, 0, v1, v2, 0, 0
+    v7 = call v6, 0, 0, v1, v2, v1, 0
     jumpi v7, bb3, bb4
   bb4:
     jumpi 1, bb6, bb7

--- a/tests/ui/codegen/lowering/run-call/try_bare_catch_evm_version.homestead.stdout
+++ b/tests/ui/codegen/lowering/run-call/try_bare_catch_evm_version.homestead.stdout
@@ -61,17 +61,20 @@ fn @live() -> u256 [selector=0x957aa58c, abi_params=[], abi_returns=[word]] {
   bb1:
     revert_returndata
   bb2:
-    v7 = abi_encode [], selector 0x3fa4f24500000000000000000000000000000000000000000000000000000000
-    v8 = slice_ptr v7
-    v9 = slice_len v7
-    v10 = extcodesize v6
-    v11 = iszero v10
-    jumpi v11, bb3, bb4
+    v7 = fmp
+    v8 = add v7, 32
+    mstore v8, 0
+    v9 = abi_encode [], selector 0x3fa4f24500000000000000000000000000000000000000000000000000000000
+    v10 = slice_ptr v9
+    v11 = slice_len v9
+    v12 = extcodesize v6
+    v13 = iszero v12
+    jumpi v13, bb3, bb4
   bb4:
-    v12 = gas
-    v13 = sub v12, 50
-    v14 = call v13, v6, 0, v8, v9, v8, 32
-    jumpi v14, bb5, bb6
+    v14 = gas
+    v15 = sub v14, 50
+    v16 = call v15, v6, 0, v10, v11, v10, 32
+    jumpi v16, bb5, bb6
   bb6:
     jumpi 1, bb8, bb9
   bb9:
@@ -79,14 +82,14 @@ fn @live() -> u256 [selector=0x957aa58c, abi_params=[], abi_returns=[word]] {
   bb8:
     jump bb7
   bb5:
-    v15 = add v8, 0
-    v16 = mload v15
-    v17 = add v8, 0
+    v17 = add v10, 0
     v18 = mload v17
+    v19 = add v10, 0
+    v20 = mload v19
     jump bb7
   bb7:
-    v19 = phi [bb5: v18], [bb8: 7]
-    ret v19
+    v21 = phi [bb5: v20], [bb8: 7]
+    ret v21
   bb3:
     revert 0, 0
 }
@@ -106,19 +109,20 @@ fn @liveTwo() -> u256 [selector=0xa9b44a2a, abi_params=[], abi_returns=[word]] {
   bb1:
     revert_returndata
   bb2:
-    v7 = abi_encode [], selector 0xa8aa1b3100000000000000000000000000000000000000000000000000000000
-    v8 = slice_ptr v7
-    v9 = slice_len v7
-    v10 = add v8, 32
-    mstore v10, 0
-    v11 = extcodesize v6
-    v12 = iszero v11
-    jumpi v12, bb3, bb4
+    v7 = fmp
+    v8 = add v7, 64
+    mstore v8, 0
+    v9 = abi_encode [], selector 0xa8aa1b3100000000000000000000000000000000000000000000000000000000
+    v10 = slice_ptr v9
+    v11 = slice_len v9
+    v12 = extcodesize v6
+    v13 = iszero v12
+    jumpi v13, bb3, bb4
   bb4:
-    v13 = gas
-    v14 = sub v13, 50
-    v15 = call v14, v6, 0, v8, v9, v8, 64
-    jumpi v15, bb5, bb6
+    v14 = gas
+    v15 = sub v14, 50
+    v16 = call v15, v6, 0, v10, v11, v10, 64
+    jumpi v16, bb5, bb6
   bb6:
     jumpi 1, bb10, bb11
   bb11:
@@ -126,23 +130,23 @@ fn @liveTwo() -> u256 [selector=0xa9b44a2a, abi_params=[], abi_returns=[word]] {
   bb10:
     jump bb7
   bb5:
-    v16 = add v8, 0
-    v17 = mload v16
-    v18 = add v8, 32
-    v19 = mload v18
-    frame_store multi_return, word, 0, v8 !metadata(memory=scratch)
-    v20 = add v8, 0
-    v21 = mload v20
-    v22 = add v8, 32
-    v23 = mload v22
-    v24 = add v21, v23
-    v25 = lt v24, v21
-    jumpi v25, bb8, bb9
+    v17 = add v10, 0
+    v18 = mload v17
+    v19 = add v10, 32
+    v20 = mload v19
+    frame_store multi_return, word, 0, v10 !metadata(memory=scratch)
+    v21 = add v10, 0
+    v22 = mload v21
+    v23 = add v10, 32
+    v24 = mload v23
+    v25 = add v22, v24
+    v26 = lt v25, v22
+    jumpi v26, bb8, bb9
   bb9:
     jump bb7
   bb7:
-    v26 = phi [bb9: v24], [bb10: 7]
-    ret v26
+    v27 = phi [bb9: v25], [bb10: 7]
+    ret v27
   bb8:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
@@ -169,19 +173,20 @@ fn @liveAggregate() -> u256 [selector=0xc64a4ee9, abi_params=[], abi_returns=[wo
     v7 = alloc memorybytes, exact, uninitialized, infallible, 96
     set_memory_object_len memorybytes, v7, 64
     v8 = memory_object_data memorybytes, v7
-    v9 = abi_encode [], selector 0xf5e34bfa00000000000000000000000000000000000000000000000000000000
-    v10 = slice_ptr v9
-    v11 = slice_len v9
-    v12 = add v10, 32
-    mstore v12, 0
-    v13 = extcodesize v6
-    v14 = iszero v13
-    jumpi v14, bb3, bb4
+    v9 = fmp
+    v10 = add v9, 64
+    mstore v10, 0
+    v11 = abi_encode [], selector 0xf5e34bfa00000000000000000000000000000000000000000000000000000000
+    v12 = slice_ptr v11
+    v13 = slice_len v11
+    v14 = extcodesize v6
+    v15 = iszero v14
+    jumpi v15, bb3, bb4
   bb4:
-    v15 = gas
-    v16 = sub v15, 50
-    v17 = call v16, v6, 0, v10, v11, v10, 64
-    jumpi v17, bb5, bb6
+    v16 = gas
+    v17 = sub v16, 50
+    v18 = call v17, v6, 0, v12, v13, v12, 64
+    jumpi v18, bb5, bb6
   bb6:
     jumpi 1, bb13, bb14
   bb14:
@@ -189,26 +194,26 @@ fn @liveAggregate() -> u256 [selector=0xc64a4ee9, abi_params=[], abi_returns=[wo
   bb13:
     jump bb7
   bb5:
-    mcopy v8, v10, 64
-    v18 = abi_decode [array<2, u256>], v7
-    v19 = lt 0, 2
-    v20 = iszero v19
-    jumpi v20, bb8, bb9
+    mcopy v8, v12, 64
+    v19 = abi_decode [array<2, u256>], v7
+    v20 = lt 0, 2
+    v21 = iszero v20
+    jumpi v21, bb8, bb9
   bb9:
-    v21 = memory_object_load_element memoryfixedarray<2, 1>, v18, 0
-    v22 = lt 1, 2
-    v23 = iszero v22
-    jumpi v23, bb8, bb10
+    v22 = memory_object_load_element memoryfixedarray<2, 1>, v19, 0
+    v23 = lt 1, 2
+    v24 = iszero v23
+    jumpi v24, bb8, bb10
   bb10:
-    v24 = memory_object_load_element memoryfixedarray<2, 1>, v18, 1
-    v25 = add v21, v24
-    v26 = lt v25, v21
-    jumpi v26, bb11, bb12
+    v25 = memory_object_load_element memoryfixedarray<2, 1>, v19, 1
+    v26 = add v22, v25
+    v27 = lt v26, v22
+    jumpi v27, bb11, bb12
   bb12:
     jump bb7
   bb7:
-    v27 = phi [bb12: v25], [bb13: 7]
-    ret v27
+    v28 = phi [bb12: v26], [bb13: 7]
+    ret v28
   bb11:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
@@ -277,17 +282,20 @@ fn @liveCatch() -> u256 [selector=0x852bf1e6, abi_params=[], abi_returns=[word]]
   bb1:
     revert_returndata
   bb2:
-    v7 = abi_encode [], selector 0xa9cc471800000000000000000000000000000000000000000000000000000000
-    v8 = slice_ptr v7
-    v9 = slice_len v7
-    v10 = extcodesize v6
-    v11 = iszero v10
-    jumpi v11, bb3, bb4
+    v7 = fmp
+    v8 = add v7, 32
+    mstore v8, 0
+    v9 = abi_encode [], selector 0xa9cc471800000000000000000000000000000000000000000000000000000000
+    v10 = slice_ptr v9
+    v11 = slice_len v9
+    v12 = extcodesize v6
+    v13 = iszero v12
+    jumpi v13, bb3, bb4
   bb4:
-    v12 = gas
-    v13 = sub v12, 0x235a
-    v14 = call v13, v6, 1, v8, v9, v8, 32
-    jumpi v14, bb5, bb6
+    v14 = gas
+    v15 = sub v14, 0x235a
+    v16 = call v15, v6, 1, v10, v11, v10, 32
+    jumpi v16, bb5, bb6
   bb6:
     jumpi 1, bb8, bb9
   bb9:
@@ -295,14 +303,14 @@ fn @liveCatch() -> u256 [selector=0x852bf1e6, abi_params=[], abi_returns=[word]]
   bb8:
     jump bb7
   bb5:
-    v15 = add v8, 0
-    v16 = mload v15
-    v17 = add v8, 0
+    v17 = add v10, 0
     v18 = mload v17
+    v19 = add v10, 0
+    v20 = mload v19
     jump bb7
   bb7:
-    v19 = phi [bb5: v18], [bb8: 7]
-    ret v19
+    v21 = phi [bb5: v20], [bb8: 7]
+    ret v21
   bb3:
     revert 0, 0
 }
@@ -327,17 +335,20 @@ fn @livePointer() -> u256 [selector=0x6347cf88, abi_params=[], abi_returns=[word
     v9 = and v8, 0xffffffff
     v10 = shl 224, v9
     v11 = shr 32, v8
-    v12 = abi_encode [], selector v10
-    v13 = slice_ptr v12
-    v14 = slice_len v12
-    v15 = extcodesize v11
-    v16 = iszero v15
-    jumpi v16, bb3, bb4
+    v12 = fmp
+    v13 = add v12, 32
+    mstore v13, 0
+    v14 = abi_encode [], selector v10
+    v15 = slice_ptr v14
+    v16 = slice_len v14
+    v17 = extcodesize v11
+    v18 = iszero v17
+    jumpi v18, bb3, bb4
   bb4:
-    v17 = gas
-    v18 = sub v17, 50
-    v19 = call v18, v11, 0, v13, v14, v13, 32
-    jumpi v19, bb5, bb6
+    v19 = gas
+    v20 = sub v19, 50
+    v21 = call v20, v11, 0, v15, v16, v15, 32
+    jumpi v21, bb5, bb6
   bb6:
     jumpi 1, bb8, bb9
   bb9:
@@ -345,14 +356,14 @@ fn @livePointer() -> u256 [selector=0x6347cf88, abi_params=[], abi_returns=[word
   bb8:
     jump bb7
   bb5:
-    v20 = add v13, 0
-    v21 = mload v20
-    v22 = add v13, 0
+    v22 = add v15, 0
     v23 = mload v22
+    v24 = add v15, 0
+    v25 = mload v24
     jump bb7
   bb7:
-    v24 = phi [bb5: v23], [bb8: 7]
-    ret v24
+    v26 = phi [bb5: v25], [bb8: 7]
+    ret v26
   bb3:
     revert 0, 0
 }
@@ -386,17 +397,20 @@ fn @liveCreation() -> u256 [selector=0xb217934d, abi_params=[], abi_returns=[wor
 
 fn @noCode() -> u256 [selector=0x96c56dce, abi_params=[], abi_returns=[word]] {
   bb0:
-    v0 = abi_encode [], selector 0x3fa4f24500000000000000000000000000000000000000000000000000000000
-    v1 = slice_ptr v0
-    v2 = slice_len v0
-    v3 = extcodesize 0
-    v4 = iszero v3
-    jumpi v4, bb1, bb2
+    v0 = fmp
+    v1 = add v0, 32
+    mstore v1, 0
+    v2 = abi_encode [], selector 0x3fa4f24500000000000000000000000000000000000000000000000000000000
+    v3 = slice_ptr v2
+    v4 = slice_len v2
+    v5 = extcodesize 0
+    v6 = iszero v5
+    jumpi v6, bb1, bb2
   bb2:
-    v5 = gas
-    v6 = sub v5, 50
-    v7 = call v6, 0, 0, v1, v2, v1, 32
-    jumpi v7, bb3, bb4
+    v7 = gas
+    v8 = sub v7, 50
+    v9 = call v8, 0, 0, v3, v4, v3, 32
+    jumpi v9, bb3, bb4
   bb4:
     jumpi 1, bb6, bb7
   bb7:
@@ -404,14 +418,14 @@ fn @noCode() -> u256 [selector=0x96c56dce, abi_params=[], abi_returns=[word]] {
   bb6:
     jump bb5
   bb3:
-    v8 = add v1, 0
-    v9 = mload v8
-    v10 = add v1, 0
+    v10 = add v3, 0
     v11 = mload v10
+    v12 = add v3, 0
+    v13 = mload v12
     jump bb5
   bb5:
-    v12 = phi [bb3: v11], [bb6: 7]
-    ret v12
+    v14 = phi [bb3: v13], [bb6: 7]
+    ret v14
   bb1:
     revert 0, 0
 }

--- a/tests/ui/codegen/lowering/run-call/try_bare_catch_evm_version.homestead.stdout
+++ b/tests/ui/codegen/lowering/run-call/try_bare_catch_evm_version.homestead.stdout
@@ -1,0 +1,443 @@
+// === ROOT/tests/ui/codegen/lowering/run-call/try_bare_catch_evm_version.sol:TryCallee ===
+@module TryCallee
+fn @value() -> u256 [selector=0x3fa4f245, pure, abi_params=[], abi_returns=[word]] {
+  bb0:
+    ret 42
+}
+
+fn @pair() -> (u256, u256) [selector=0xa8aa1b31, pure, abi_params=[], abi_returns=[word, word]] {
+  bb0:
+    ret 1, 2
+}
+
+fn @agg() -> memoryfixedarray [selector=0xf5e34bfa, pure, abi_params=[], abi_returns=[array<2, word>]] {
+  bb0:
+    v0 = alloc memoryfixedarray<2, 1>, exact, uninitialized, infallible, 64
+    memory_zero v0, 64
+    v1 = lt 0, 2
+    v2 = iszero v1
+    jumpi v2, bb1, bb2
+  bb2:
+    memory_object_store_element memoryfixedarray<2, 1>, v0, 0, 11
+    v3 = lt 1, 2
+    v4 = iszero v3
+    jumpi v4, bb1, bb3
+  bb3:
+    memory_object_store_element memoryfixedarray<2, 1>, v0, 1, 22
+    ret v0
+  bb1:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 50 !metadata(memory=scratch)
+    revert 0, 36
+}
+
+fn @noop() [selector=0x5dfc2e4a, abi_params=[], abi_returns=[]] {
+  bb0:
+    stop
+}
+
+fn @fail() [selector=0xa9cc4718, payable, abi_params=[], abi_returns=[word]] {
+  bb0:
+    revert 0, 0
+}
+
+// === ROOT/tests/ui/codegen/lowering/run-call/try_bare_catch_evm_version.sol:TryBareCatch ===
+@module TryBareCatch
+data:
+  TryCallee_initcode_0: hex"346010576101858060166000396000f35b60006000fe6000357c0100000000000000000000000000000000000000000000000000000000900480633fa4f2451460585780635dfc2e4a14605c578063a8aa1b31146061578063a9cc4718146065578063f5e34bfa14606a57606e565b6073565b610174565b608e565b610180565b60b6565b600080fe5b34608957602a6080526020608001608090036080f35b600080fe5b60c06040523460b157600160805260206080016002815260209001608090036080f35b600080fe5b6101206040523461016f576040518060c0528060c05260408101604052604036828060c0523760026000101515610117575b7f4e487b7100000000000000000000000000000000000000000000000000000000600052603260045260246000fe5b8060c052600b815260026001101560e85760208101601681525060005b8060e052600281101561015f576020818060e052028201516020820260800152600181019050610134565b6040608001915050608090036080f35b600080fe5b3461017b57005b600080fe5b600080fe"
+
+fn @live() -> u256 [selector=0x957aa58c, abi_params=[], abi_returns=[word]] {
+  bb0:
+    v0 = abi_encode []
+    v1 = not 31
+    v2 = and 442, v1
+    v3 = alloc raw, exact, uninitialized, infallible, v2
+    data_copy TryCallee_initcode_0, v3, 411
+    v4 = slice_ptr v0
+    v5 = add v3, 411
+    mcopy v5, v4, 0 !metadata(memory=heap)
+    v6 = create 0, v3, 411
+    jumpi v6, bb2, bb1
+  bb1:
+    revert_returndata
+  bb2:
+    v7 = abi_encode [], selector 0x3fa4f24500000000000000000000000000000000000000000000000000000000
+    v8 = slice_ptr v7
+    v9 = slice_len v7
+    v10 = extcodesize v6
+    v11 = iszero v10
+    jumpi v11, bb3, bb4
+  bb4:
+    v12 = gas
+    v13 = sub v12, 50
+    v14 = call v13, v6, 0, v8, v9, 0, 32
+    jumpi v14, bb5, bb6
+  bb6:
+    jumpi 1, bb8, bb9
+  bb9:
+    revert 0, 0
+  bb8:
+    jump bb7
+  bb5:
+    v15 = add 0, 0
+    v16 = mload v15
+    v17 = add 0, 0
+    v18 = mload v17
+    jump bb7
+  bb7:
+    v19 = phi [bb5: v18], [bb8: 7]
+    ret v19
+  bb3:
+    revert 0, 0
+}
+
+fn @liveTwo() -> u256 [selector=0xa9b44a2a, abi_params=[], abi_returns=[word]] {
+  bb0:
+    v0 = abi_encode []
+    v1 = not 31
+    v2 = and 442, v1
+    v3 = alloc raw, exact, uninitialized, infallible, v2
+    data_copy TryCallee_initcode_0, v3, 411
+    v4 = slice_ptr v0
+    v5 = add v3, 411
+    mcopy v5, v4, 0 !metadata(memory=heap)
+    v6 = create 0, v3, 411
+    jumpi v6, bb2, bb1
+  bb1:
+    revert_returndata
+  bb2:
+    v7 = abi_encode [], selector 0xa8aa1b3100000000000000000000000000000000000000000000000000000000
+    v8 = slice_ptr v7
+    v9 = slice_len v7
+    v10 = alloc raw, exact, uninitialized, infallible, 64
+    v11 = add v10, 32
+    mstore v11, 0
+    v12 = extcodesize v6
+    v13 = iszero v12
+    jumpi v13, bb3, bb4
+  bb4:
+    v14 = gas
+    v15 = sub v14, 50
+    v16 = call v15, v6, 0, v8, v9, v10, 64
+    jumpi v16, bb5, bb6
+  bb6:
+    jumpi 1, bb10, bb11
+  bb11:
+    revert 0, 0
+  bb10:
+    jump bb7
+  bb5:
+    v17 = add v10, 0
+    v18 = mload v17
+    v19 = add v10, 32
+    v20 = mload v19
+    frame_store multi_return, word, 0, v10 !metadata(memory=scratch)
+    v21 = add v10, 0
+    v22 = mload v21
+    v23 = add v10, 32
+    v24 = mload v23
+    v25 = add v22, v24
+    v26 = lt v25, v22
+    jumpi v26, bb8, bb9
+  bb9:
+    jump bb7
+  bb7:
+    v27 = phi [bb9: v25], [bb10: 7]
+    ret v27
+  bb8:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 17 !metadata(memory=scratch)
+    revert 0, 36
+  bb3:
+    revert 0, 0
+}
+
+fn @liveAggregate() -> u256 [selector=0xc64a4ee9, abi_params=[], abi_returns=[word]] {
+  bb0:
+    v0 = abi_encode []
+    v1 = not 31
+    v2 = and 442, v1
+    v3 = alloc raw, exact, uninitialized, infallible, v2
+    data_copy TryCallee_initcode_0, v3, 411
+    v4 = slice_ptr v0
+    v5 = add v3, 411
+    mcopy v5, v4, 0 !metadata(memory=heap)
+    v6 = create 0, v3, 411
+    jumpi v6, bb2, bb1
+  bb1:
+    revert_returndata
+  bb2:
+    v7 = abi_encode [], selector 0xf5e34bfa00000000000000000000000000000000000000000000000000000000
+    v8 = slice_ptr v7
+    v9 = slice_len v7
+    v10 = alloc raw, exact, uninitialized, infallible, 64
+    v11 = add v10, 32
+    mstore v11, 0
+    v12 = extcodesize v6
+    v13 = iszero v12
+    jumpi v13, bb3, bb4
+  bb4:
+    v14 = gas
+    v15 = sub v14, 50
+    v16 = call v15, v6, 0, v8, v9, v10, 64
+    jumpi v16, bb5, bb6
+  bb6:
+    jumpi 1, bb13, bb14
+  bb14:
+    revert 0, 0
+  bb13:
+    jump bb7
+  bb5:
+    v17 = abi_decode [array<2, u256>], v10
+    v18 = lt 0, 2
+    v19 = iszero v18
+    jumpi v19, bb8, bb9
+  bb9:
+    v20 = memory_object_load_element memoryfixedarray<2, 1>, v17, 0
+    v21 = lt 1, 2
+    v22 = iszero v21
+    jumpi v22, bb8, bb10
+  bb10:
+    v23 = memory_object_load_element memoryfixedarray<2, 1>, v17, 1
+    v24 = add v20, v23
+    v25 = lt v24, v20
+    jumpi v25, bb11, bb12
+  bb12:
+    jump bb7
+  bb7:
+    v26 = phi [bb12: v24], [bb13: 7]
+    ret v26
+  bb11:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 17 !metadata(memory=scratch)
+    revert 0, 36
+  bb8:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 50 !metadata(memory=scratch)
+    revert 0, 36
+  bb3:
+    revert 0, 0
+}
+
+fn @liveNoReturn() -> u256 [selector=0x0f81fb69, abi_params=[], abi_returns=[word]] {
+  bb0:
+    v0 = abi_encode []
+    v1 = not 31
+    v2 = and 442, v1
+    v3 = alloc raw, exact, uninitialized, infallible, v2
+    data_copy TryCallee_initcode_0, v3, 411
+    v4 = slice_ptr v0
+    v5 = add v3, 411
+    mcopy v5, v4, 0 !metadata(memory=heap)
+    v6 = create 0, v3, 411
+    jumpi v6, bb2, bb1
+  bb1:
+    revert_returndata
+  bb2:
+    v7 = abi_encode [], selector 0x5dfc2e4a00000000000000000000000000000000000000000000000000000000
+    v8 = slice_ptr v7
+    v9 = slice_len v7
+    v10 = extcodesize v6
+    v11 = iszero v10
+    jumpi v11, bb3, bb4
+  bb4:
+    v12 = gas
+    v13 = sub v12, 50
+    v14 = call v13, v6, 0, v8, v9, 0, 0
+    jumpi v14, bb5, bb6
+  bb6:
+    jumpi 1, bb8, bb9
+  bb9:
+    revert 0, 0
+  bb8:
+    jump bb7
+  bb5:
+    jump bb7
+  bb7:
+    v15 = phi [bb5: 1], [bb8: 7]
+    ret v15
+  bb3:
+    revert 0, 0
+}
+
+fn @liveCatch() -> u256 [selector=0x852bf1e6, abi_params=[], abi_returns=[word]] {
+  bb0:
+    v0 = abi_encode []
+    v1 = not 31
+    v2 = and 442, v1
+    v3 = alloc raw, exact, uninitialized, infallible, v2
+    data_copy TryCallee_initcode_0, v3, 411
+    v4 = slice_ptr v0
+    v5 = add v3, 411
+    mcopy v5, v4, 0 !metadata(memory=heap)
+    v6 = create 0, v3, 411
+    jumpi v6, bb2, bb1
+  bb1:
+    revert_returndata
+  bb2:
+    v7 = abi_encode [], selector 0xa9cc471800000000000000000000000000000000000000000000000000000000
+    v8 = slice_ptr v7
+    v9 = slice_len v7
+    v10 = extcodesize v6
+    v11 = iszero v10
+    jumpi v11, bb3, bb4
+  bb4:
+    v12 = gas
+    v13 = sub v12, 0x235a
+    v14 = call v13, v6, 1, v8, v9, 0, 32
+    jumpi v14, bb5, bb6
+  bb6:
+    jumpi 1, bb8, bb9
+  bb9:
+    revert 0, 0
+  bb8:
+    jump bb7
+  bb5:
+    v15 = add 0, 0
+    v16 = mload v15
+    v17 = add 0, 0
+    v18 = mload v17
+    jump bb7
+  bb7:
+    v19 = phi [bb5: v18], [bb8: 7]
+    ret v19
+  bb3:
+    revert 0, 0
+}
+
+fn @livePointer() -> u256 [selector=0x6347cf88, abi_params=[], abi_returns=[word]] {
+  bb0:
+    v0 = abi_encode []
+    v1 = not 31
+    v2 = and 442, v1
+    v3 = alloc raw, exact, uninitialized, infallible, v2
+    data_copy TryCallee_initcode_0, v3, 411
+    v4 = slice_ptr v0
+    v5 = add v3, 411
+    mcopy v5, v4, 0 !metadata(memory=heap)
+    v6 = create 0, v3, 411
+    jumpi v6, bb2, bb1
+  bb1:
+    revert_returndata
+  bb2:
+    v7 = shl 32, v6
+    v8 = or v7, 0x3fa4f245
+    v9 = and v8, 0xffffffff
+    v10 = shl 224, v9
+    v11 = shr 32, v8
+    v12 = abi_encode [], selector v10
+    v13 = slice_ptr v12
+    v14 = slice_len v12
+    v15 = extcodesize v11
+    v16 = iszero v15
+    jumpi v16, bb3, bb4
+  bb4:
+    v17 = gas
+    v18 = sub v17, 50
+    v19 = call v18, v11, 0, v13, v14, 0, 32
+    jumpi v19, bb5, bb6
+  bb6:
+    jumpi 1, bb8, bb9
+  bb9:
+    revert 0, 0
+  bb8:
+    jump bb7
+  bb5:
+    v20 = add 0, 0
+    v21 = mload v20
+    v22 = add 0, 0
+    v23 = mload v22
+    jump bb7
+  bb7:
+    v24 = phi [bb5: v23], [bb8: 7]
+    ret v24
+  bb3:
+    revert 0, 0
+}
+
+fn @liveCreation() -> u256 [selector=0xb217934d, abi_params=[], abi_returns=[word]] {
+  bb0:
+    v0 = abi_encode []
+    v1 = not 31
+    v2 = and 442, v1
+    v3 = alloc raw, exact, uninitialized, infallible, v2
+    data_copy TryCallee_initcode_0, v3, 411
+    v4 = slice_ptr v0
+    v5 = add v3, 411
+    mcopy v5, v4, 0 !metadata(memory=heap)
+    v6 = create 0, v3, 411
+    v7 = eq v6, 0
+    v8 = iszero v7
+    jumpi v8, bb1, bb2
+  bb2:
+    jumpi 1, bb4, bb5
+  bb5:
+    revert 0, 0
+  bb4:
+    jump bb3
+  bb1:
+    jump bb3
+  bb3:
+    v9 = phi [bb1: 1], [bb4: 7]
+    ret v9
+}
+
+fn @noCode() -> u256 [selector=0x96c56dce, abi_params=[], abi_returns=[word]] {
+  bb0:
+    v0 = abi_encode [], selector 0x3fa4f24500000000000000000000000000000000000000000000000000000000
+    v1 = slice_ptr v0
+    v2 = slice_len v0
+    v3 = extcodesize 0
+    v4 = iszero v3
+    jumpi v4, bb1, bb2
+  bb2:
+    v5 = gas
+    v6 = sub v5, 50
+    v7 = call v6, 0, 0, v1, v2, 0, 32
+    jumpi v7, bb3, bb4
+  bb4:
+    jumpi 1, bb6, bb7
+  bb7:
+    revert 0, 0
+  bb6:
+    jump bb5
+  bb3:
+    v8 = add 0, 0
+    v9 = mload v8
+    v10 = add 0, 0
+    v11 = mload v10
+    jump bb5
+  bb5:
+    v12 = phi [bb3: v11], [bb6: 7]
+    ret v12
+  bb1:
+    revert 0, 0
+}
+
+fn @noCodeNoReturn() -> u256 [selector=0xac1b26c4, abi_params=[], abi_returns=[word]] {
+  bb0:
+    v0 = abi_encode [], selector 0x5dfc2e4a00000000000000000000000000000000000000000000000000000000
+    v1 = slice_ptr v0
+    v2 = slice_len v0
+    v3 = extcodesize 0
+    v4 = iszero v3
+    jumpi v4, bb1, bb2
+  bb2:
+    v5 = gas
+    v6 = sub v5, 50
+    v7 = call v6, 0, 0, v1, v2, 0, 0
+    jumpi v7, bb3, bb4
+  bb4:
+    jumpi 1, bb6, bb7
+  bb7:
+    revert 0, 0
+  bb6:
+    jump bb5
+  bb3:
+    jump bb5
+  bb5:
+    v8 = phi [bb3: 1], [bb6: 7]
+    ret v8
+  bb1:
+    revert 0, 0
+}

--- a/tests/ui/codegen/lowering/run-call/try_bare_catch_evm_version.osaka.stdout
+++ b/tests/ui/codegen/lowering/run-call/try_bare_catch_evm_version.osaka.stdout
@@ -1,0 +1,694 @@
+// === ROOT/tests/ui/codegen/lowering/run-call/try_bare_catch_evm_version.sol:TryCallee ===
+@module TryCallee
+fn @value() -> u256 [selector=0x3fa4f245, pure, abi_params=[], abi_returns=[word]] {
+  bb0:
+    ret 42
+}
+
+fn @pair() -> (u256, u256) [selector=0xa8aa1b31, pure, abi_params=[], abi_returns=[word, word]] {
+  bb0:
+    ret 1, 2
+}
+
+fn @agg() -> memoryfixedarray [selector=0xf5e34bfa, pure, abi_params=[], abi_returns=[array<2, word>]] {
+  bb0:
+    v0 = alloc memoryfixedarray<2, 1>, exact, uninitialized, infallible, 64
+    memory_zero v0, 64
+    v1 = lt 0, 2
+    v2 = iszero v1
+    jumpi v2, bb1, bb2
+  bb2:
+    memory_object_store_element memoryfixedarray<2, 1>, v0, 0, 11
+    v3 = lt 1, 2
+    v4 = iszero v3
+    jumpi v4, bb1, bb3
+  bb3:
+    memory_object_store_element memoryfixedarray<2, 1>, v0, 1, 22
+    ret v0
+  bb1:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 50 !metadata(memory=scratch)
+    revert 0, 36
+}
+
+fn @noop() [selector=0x5dfc2e4a, abi_params=[], abi_returns=[]] {
+  bb0:
+    stop
+}
+
+fn @fail() [selector=0xa9cc4718, payable, abi_params=[], abi_returns=[word]] {
+  bb0:
+    revert 0, 0
+}
+
+// === ROOT/tests/ui/codegen/lowering/run-call/try_bare_catch_evm_version.sol:TryBareCatch ===
+@module TryBareCatch
+data:
+  TryCallee_initcode_0: hex"34600e5761015c8060125f395ff35b5f5ffd5f3560e01c80633fa4f24514603a5780635dfc2e4a14603e578063a8aa1b31146043578063a9cc4718146047578063f5e34bfa14604c576050565b6054565b61014d565b606e565b610158565b6095565b5f5ffd5b34606a57602a6080526020608001608090036080f35b5f5ffd5b60c060405234609157600160805260206080016002815260209001608090036080f35b5f5ffd5b61012060405234610149576040518060c0528060c05260408101604052604036828060c0523760025f10151560f2575b7f4e487b71000000000000000000000000000000000000000000000000000000005f52603260045260245ffd5b8060c052600b815260026001101560c5576020810160168152505f5b8060e0526002811015610139576020818060e05202820151602082026080015260018101905061010e565b6040608001915050608090036080f35b5f5ffd5b3461015457005b5f5ffd5b5f5ffd"
+
+fn @live() -> u256 [selector=0x957aa58c, abi_params=[], abi_returns=[word]] {
+  bb0:
+    v0 = abi_encode []
+    v1 = not 31
+    v2 = and 397, v1
+    v3 = alloc raw, exact, uninitialized, infallible, v2
+    data_copy TryCallee_initcode_0, v3, 366
+    v4 = slice_ptr v0
+    v5 = add v3, 366
+    mcopy v5, v4, 0 !metadata(memory=heap)
+    v6 = create 0, v3, 366
+    jumpi v6, bb2, bb1
+  bb1:
+    revert_returndata
+  bb2:
+    v7 = gas
+    v8 = abi_encode [], selector 0x3fa4f24500000000000000000000000000000000000000000000000000000000
+    v9 = slice_ptr v8
+    v10 = slice_len v8
+    v11 = call v7, v6, 0, v9, v10, 0, 0
+    jumpi v11, bb3, bb4
+  bb4:
+    v20 = returndatasize
+    v21 = add v20, 63
+    v22 = lt v21, v20
+    jumpi v22, bb6, bb8
+  bb8:
+    v23 = not 31
+    v24 = and v21, v23
+    v25 = alloc memorybytes, exact, uninitialized, infallible, v24
+    set_memory_object_len memorybytes, v25, v20
+    v26 = make_returndata_slice 0, v20
+    memory_object_copy_from_slice memorybytes, v25, v26
+    v27 = memory_object_data memorybytes, v25
+    v28 = memory_object_len memorybytes, v25
+    v29 = make_memory_slice v27, v28
+    v30 = memory_slice_load_word memory, v29, 0
+    v31 = lt v28, 4
+    v32 = iszero v31
+    v33 = shr 224, v30
+    v34 = eq v33, 0x8c379a0
+    v35 = and v32, v34
+    v36 = lt v28, 36
+    v37 = iszero v36
+    v38 = eq v33, 0x4e487b71
+    v39 = and v37, v38
+    jumpi 1, bb9, bb10
+  bb10:
+    revert v27, v28
+  bb9:
+    jump bb5
+  bb3:
+    v12 = returndatasize
+    v13 = add v12, 63
+    v14 = lt v13, v12
+    jumpi v14, bb6, bb7
+  bb7:
+    v15 = not 31
+    v16 = and v13, v15
+    v17 = alloc memorybytes, exact, uninitialized, infallible, v16
+    set_memory_object_len memorybytes, v17, v12
+    v18 = make_returndata_slice 0, v12
+    memory_object_copy_from_slice memorybytes, v17, v18
+    v19 = abi_decode [u256], v17
+    jump bb5
+  bb5:
+    v40 = phi [bb7: v19], [bb9: 7]
+    ret v40
+  bb6:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 65 !metadata(memory=scratch)
+    revert 0, 36
+}
+
+fn @liveTwo() -> u256 [selector=0xa9b44a2a, abi_params=[], abi_returns=[word]] {
+  bb0:
+    v0 = abi_encode []
+    v1 = not 31
+    v2 = and 397, v1
+    v3 = alloc raw, exact, uninitialized, infallible, v2
+    data_copy TryCallee_initcode_0, v3, 366
+    v4 = slice_ptr v0
+    v5 = add v3, 366
+    mcopy v5, v4, 0 !metadata(memory=heap)
+    v6 = create 0, v3, 366
+    jumpi v6, bb2, bb1
+  bb1:
+    revert_returndata
+  bb2:
+    v7 = gas
+    v8 = abi_encode [], selector 0xa8aa1b3100000000000000000000000000000000000000000000000000000000
+    v9 = slice_ptr v8
+    v10 = slice_len v8
+    v11 = call v7, v6, 0, v9, v10, 0, 0
+    jumpi v11, bb3, bb4
+  bb4:
+    v25 = returndatasize
+    v26 = add v25, 63
+    v27 = lt v26, v25
+    jumpi v27, bb6, bb10
+  bb10:
+    v28 = not 31
+    v29 = and v26, v28
+    v30 = alloc memorybytes, exact, uninitialized, infallible, v29
+    set_memory_object_len memorybytes, v30, v25
+    v31 = make_returndata_slice 0, v25
+    memory_object_copy_from_slice memorybytes, v30, v31
+    v32 = memory_object_data memorybytes, v30
+    v33 = memory_object_len memorybytes, v30
+    v34 = make_memory_slice v32, v33
+    v35 = memory_slice_load_word memory, v34, 0
+    v36 = lt v33, 4
+    v37 = iszero v36
+    v38 = shr 224, v35
+    v39 = eq v38, 0x8c379a0
+    v40 = and v37, v39
+    v41 = lt v33, 36
+    v42 = iszero v41
+    v43 = eq v38, 0x4e487b71
+    v44 = and v42, v43
+    jumpi 1, bb11, bb12
+  bb12:
+    revert v32, v33
+  bb11:
+    jump bb5
+  bb3:
+    v12 = returndatasize
+    v13 = add v12, 63
+    v14 = lt v13, v12
+    jumpi v14, bb6, bb7
+  bb7:
+    v15 = not 31
+    v16 = and v13, v15
+    v17 = alloc memorybytes, exact, uninitialized, infallible, v16
+    set_memory_object_len memorybytes, v17, v12
+    v18 = make_returndata_slice 0, v12
+    memory_object_copy_from_slice memorybytes, v17, v18
+    v19 = abi_decode [u256, u256], v17
+    v20 = frame_load multi_return, word, 0 !metadata(memory=scratch)
+    v21 = add v20, 32
+    v22 = mload v21
+    v23 = add v19, v22
+    v24 = lt v23, v19
+    jumpi v24, bb8, bb9
+  bb9:
+    jump bb5
+  bb5:
+    v45 = phi [bb9: v23], [bb11: 7]
+    ret v45
+  bb8:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 17 !metadata(memory=scratch)
+    revert 0, 36
+  bb6:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 65 !metadata(memory=scratch)
+    revert 0, 36
+}
+
+fn @liveAggregate() -> u256 [selector=0xc64a4ee9, abi_params=[], abi_returns=[word]] {
+  bb0:
+    v0 = abi_encode []
+    v1 = not 31
+    v2 = and 397, v1
+    v3 = alloc raw, exact, uninitialized, infallible, v2
+    data_copy TryCallee_initcode_0, v3, 366
+    v4 = slice_ptr v0
+    v5 = add v3, 366
+    mcopy v5, v4, 0 !metadata(memory=heap)
+    v6 = create 0, v3, 366
+    jumpi v6, bb2, bb1
+  bb1:
+    revert_returndata
+  bb2:
+    v7 = gas
+    v8 = abi_encode [], selector 0xf5e34bfa00000000000000000000000000000000000000000000000000000000
+    v9 = slice_ptr v8
+    v10 = slice_len v8
+    v11 = call v7, v6, 0, v9, v10, 0, 0
+    jumpi v11, bb3, bb4
+  bb4:
+    v28 = returndatasize
+    v29 = add v28, 63
+    v30 = lt v29, v28
+    jumpi v30, bb6, bb13
+  bb13:
+    v31 = not 31
+    v32 = and v29, v31
+    v33 = alloc memorybytes, exact, uninitialized, infallible, v32
+    set_memory_object_len memorybytes, v33, v28
+    v34 = make_returndata_slice 0, v28
+    memory_object_copy_from_slice memorybytes, v33, v34
+    v35 = memory_object_data memorybytes, v33
+    v36 = memory_object_len memorybytes, v33
+    v37 = make_memory_slice v35, v36
+    v38 = memory_slice_load_word memory, v37, 0
+    v39 = lt v36, 4
+    v40 = iszero v39
+    v41 = shr 224, v38
+    v42 = eq v41, 0x8c379a0
+    v43 = and v40, v42
+    v44 = lt v36, 36
+    v45 = iszero v44
+    v46 = eq v41, 0x4e487b71
+    v47 = and v45, v46
+    jumpi 1, bb14, bb15
+  bb15:
+    revert v35, v36
+  bb14:
+    jump bb5
+  bb3:
+    v12 = returndatasize
+    v13 = add v12, 63
+    v14 = lt v13, v12
+    jumpi v14, bb6, bb7
+  bb7:
+    v15 = not 31
+    v16 = and v13, v15
+    v17 = alloc memorybytes, exact, uninitialized, infallible, v16
+    set_memory_object_len memorybytes, v17, v12
+    v18 = make_returndata_slice 0, v12
+    memory_object_copy_from_slice memorybytes, v17, v18
+    v19 = abi_decode [array<2, u256>], v17
+    v20 = lt 0, 2
+    v21 = iszero v20
+    jumpi v21, bb8, bb9
+  bb9:
+    v22 = memory_object_load_element memoryfixedarray<2, 1>, v19, 0
+    v23 = lt 1, 2
+    v24 = iszero v23
+    jumpi v24, bb8, bb10
+  bb10:
+    v25 = memory_object_load_element memoryfixedarray<2, 1>, v19, 1
+    v26 = add v22, v25
+    v27 = lt v26, v22
+    jumpi v27, bb11, bb12
+  bb12:
+    jump bb5
+  bb5:
+    v48 = phi [bb12: v26], [bb14: 7]
+    ret v48
+  bb11:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 17 !metadata(memory=scratch)
+    revert 0, 36
+  bb8:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 50 !metadata(memory=scratch)
+    revert 0, 36
+  bb6:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 65 !metadata(memory=scratch)
+    revert 0, 36
+}
+
+fn @liveNoReturn() -> u256 [selector=0x0f81fb69, abi_params=[], abi_returns=[word]] {
+  bb0:
+    v0 = abi_encode []
+    v1 = not 31
+    v2 = and 397, v1
+    v3 = alloc raw, exact, uninitialized, infallible, v2
+    data_copy TryCallee_initcode_0, v3, 366
+    v4 = slice_ptr v0
+    v5 = add v3, 366
+    mcopy v5, v4, 0 !metadata(memory=heap)
+    v6 = create 0, v3, 366
+    jumpi v6, bb2, bb1
+  bb1:
+    revert_returndata
+  bb2:
+    v7 = gas
+    v8 = abi_encode [], selector 0x5dfc2e4a00000000000000000000000000000000000000000000000000000000
+    v9 = slice_ptr v8
+    v10 = slice_len v8
+    v11 = extcodesize v6
+    v12 = iszero v11
+    jumpi v12, bb3, bb4
+  bb4:
+    v13 = call v7, v6, 0, v9, v10, 0, 0
+    jumpi v13, bb5, bb6
+  bb6:
+    v14 = returndatasize
+    v15 = add v14, 63
+    v16 = lt v15, v14
+    jumpi v16, bb8, bb9
+  bb9:
+    v17 = not 31
+    v18 = and v15, v17
+    v19 = alloc memorybytes, exact, uninitialized, infallible, v18
+    set_memory_object_len memorybytes, v19, v14
+    v20 = make_returndata_slice 0, v14
+    memory_object_copy_from_slice memorybytes, v19, v20
+    v21 = memory_object_data memorybytes, v19
+    v22 = memory_object_len memorybytes, v19
+    v23 = make_memory_slice v21, v22
+    v24 = memory_slice_load_word memory, v23, 0
+    v25 = lt v22, 4
+    v26 = iszero v25
+    v27 = shr 224, v24
+    v28 = eq v27, 0x8c379a0
+    v29 = and v26, v28
+    v30 = lt v22, 36
+    v31 = iszero v30
+    v32 = eq v27, 0x4e487b71
+    v33 = and v31, v32
+    jumpi 1, bb10, bb11
+  bb11:
+    revert v21, v22
+  bb10:
+    jump bb7
+  bb8:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 65 !metadata(memory=scratch)
+    revert 0, 36
+  bb5:
+    jump bb7
+  bb7:
+    v34 = phi [bb5: 1], [bb10: 7]
+    ret v34
+  bb3:
+    revert 0, 0
+}
+
+fn @liveCatch() -> u256 [selector=0x852bf1e6, abi_params=[], abi_returns=[word]] {
+  bb0:
+    v0 = abi_encode []
+    v1 = not 31
+    v2 = and 397, v1
+    v3 = alloc raw, exact, uninitialized, infallible, v2
+    data_copy TryCallee_initcode_0, v3, 366
+    v4 = slice_ptr v0
+    v5 = add v3, 366
+    mcopy v5, v4, 0 !metadata(memory=heap)
+    v6 = create 0, v3, 366
+    jumpi v6, bb2, bb1
+  bb1:
+    revert_returndata
+  bb2:
+    v7 = gas
+    v8 = abi_encode [], selector 0xa9cc471800000000000000000000000000000000000000000000000000000000
+    v9 = slice_ptr v8
+    v10 = slice_len v8
+    v11 = call v7, v6, 1, v9, v10, 0, 0
+    jumpi v11, bb3, bb4
+  bb4:
+    v20 = returndatasize
+    v21 = add v20, 63
+    v22 = lt v21, v20
+    jumpi v22, bb6, bb8
+  bb8:
+    v23 = not 31
+    v24 = and v21, v23
+    v25 = alloc memorybytes, exact, uninitialized, infallible, v24
+    set_memory_object_len memorybytes, v25, v20
+    v26 = make_returndata_slice 0, v20
+    memory_object_copy_from_slice memorybytes, v25, v26
+    v27 = memory_object_data memorybytes, v25
+    v28 = memory_object_len memorybytes, v25
+    v29 = make_memory_slice v27, v28
+    v30 = memory_slice_load_word memory, v29, 0
+    v31 = lt v28, 4
+    v32 = iszero v31
+    v33 = shr 224, v30
+    v34 = eq v33, 0x8c379a0
+    v35 = and v32, v34
+    v36 = lt v28, 36
+    v37 = iszero v36
+    v38 = eq v33, 0x4e487b71
+    v39 = and v37, v38
+    jumpi 1, bb9, bb10
+  bb10:
+    revert v27, v28
+  bb9:
+    jump bb5
+  bb3:
+    v12 = returndatasize
+    v13 = add v12, 63
+    v14 = lt v13, v12
+    jumpi v14, bb6, bb7
+  bb7:
+    v15 = not 31
+    v16 = and v13, v15
+    v17 = alloc memorybytes, exact, uninitialized, infallible, v16
+    set_memory_object_len memorybytes, v17, v12
+    v18 = make_returndata_slice 0, v12
+    memory_object_copy_from_slice memorybytes, v17, v18
+    v19 = abi_decode [u256], v17
+    jump bb5
+  bb5:
+    v40 = phi [bb7: v19], [bb9: 7]
+    ret v40
+  bb6:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 65 !metadata(memory=scratch)
+    revert 0, 36
+}
+
+fn @livePointer() -> u256 [selector=0x6347cf88, abi_params=[], abi_returns=[word]] {
+  bb0:
+    v0 = abi_encode []
+    v1 = not 31
+    v2 = and 397, v1
+    v3 = alloc raw, exact, uninitialized, infallible, v2
+    data_copy TryCallee_initcode_0, v3, 366
+    v4 = slice_ptr v0
+    v5 = add v3, 366
+    mcopy v5, v4, 0 !metadata(memory=heap)
+    v6 = create 0, v3, 366
+    jumpi v6, bb2, bb1
+  bb1:
+    revert_returndata
+  bb2:
+    v7 = shl 32, v6
+    v8 = or v7, 0x3fa4f245
+    v9 = and v8, 0xffffffff
+    v10 = shl 224, v9
+    v11 = shr 32, v8
+    v12 = gas
+    v13 = abi_encode [], selector v10
+    v14 = slice_ptr v13
+    v15 = slice_len v13
+    v16 = call v12, v11, 0, v14, v15, 0, 0
+    jumpi v16, bb3, bb4
+  bb4:
+    v25 = returndatasize
+    v26 = add v25, 63
+    v27 = lt v26, v25
+    jumpi v27, bb6, bb8
+  bb8:
+    v28 = not 31
+    v29 = and v26, v28
+    v30 = alloc memorybytes, exact, uninitialized, infallible, v29
+    set_memory_object_len memorybytes, v30, v25
+    v31 = make_returndata_slice 0, v25
+    memory_object_copy_from_slice memorybytes, v30, v31
+    v32 = memory_object_data memorybytes, v30
+    v33 = memory_object_len memorybytes, v30
+    v34 = make_memory_slice v32, v33
+    v35 = memory_slice_load_word memory, v34, 0
+    v36 = lt v33, 4
+    v37 = iszero v36
+    v38 = shr 224, v35
+    v39 = eq v38, 0x8c379a0
+    v40 = and v37, v39
+    v41 = lt v33, 36
+    v42 = iszero v41
+    v43 = eq v38, 0x4e487b71
+    v44 = and v42, v43
+    jumpi 1, bb9, bb10
+  bb10:
+    revert v32, v33
+  bb9:
+    jump bb5
+  bb3:
+    v17 = returndatasize
+    v18 = add v17, 63
+    v19 = lt v18, v17
+    jumpi v19, bb6, bb7
+  bb7:
+    v20 = not 31
+    v21 = and v18, v20
+    v22 = alloc memorybytes, exact, uninitialized, infallible, v21
+    set_memory_object_len memorybytes, v22, v17
+    v23 = make_returndata_slice 0, v17
+    memory_object_copy_from_slice memorybytes, v22, v23
+    v24 = abi_decode [u256], v22
+    jump bb5
+  bb5:
+    v45 = phi [bb7: v24], [bb9: 7]
+    ret v45
+  bb6:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 65 !metadata(memory=scratch)
+    revert 0, 36
+}
+
+fn @liveCreation() -> u256 [selector=0xb217934d, abi_params=[], abi_returns=[word]] {
+  bb0:
+    v0 = abi_encode []
+    v1 = not 31
+    v2 = and 397, v1
+    v3 = alloc raw, exact, uninitialized, infallible, v2
+    data_copy TryCallee_initcode_0, v3, 366
+    v4 = slice_ptr v0
+    v5 = add v3, 366
+    mcopy v5, v4, 0 !metadata(memory=heap)
+    v6 = create 0, v3, 366
+    v7 = eq v6, 0
+    v8 = iszero v7
+    jumpi v8, bb1, bb2
+  bb2:
+    v9 = returndatasize
+    v10 = add v9, 63
+    v11 = lt v10, v9
+    jumpi v11, bb4, bb5
+  bb5:
+    v12 = not 31
+    v13 = and v10, v12
+    v14 = alloc memorybytes, exact, uninitialized, infallible, v13
+    set_memory_object_len memorybytes, v14, v9
+    v15 = make_returndata_slice 0, v9
+    memory_object_copy_from_slice memorybytes, v14, v15
+    v16 = memory_object_data memorybytes, v14
+    v17 = memory_object_len memorybytes, v14
+    v18 = make_memory_slice v16, v17
+    v19 = memory_slice_load_word memory, v18, 0
+    v20 = lt v17, 4
+    v21 = iszero v20
+    v22 = shr 224, v19
+    v23 = eq v22, 0x8c379a0
+    v24 = and v21, v23
+    v25 = lt v17, 36
+    v26 = iszero v25
+    v27 = eq v22, 0x4e487b71
+    v28 = and v26, v27
+    jumpi 1, bb6, bb7
+  bb7:
+    revert v16, v17
+  bb6:
+    jump bb3
+  bb4:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 65 !metadata(memory=scratch)
+    revert 0, 36
+  bb1:
+    jump bb3
+  bb3:
+    v29 = phi [bb1: 1], [bb6: 7]
+    ret v29
+}
+
+fn @noCode() -> u256 [selector=0x96c56dce, abi_params=[], abi_returns=[word]] {
+  bb0:
+    v0 = gas
+    v1 = abi_encode [], selector 0x3fa4f24500000000000000000000000000000000000000000000000000000000
+    v2 = slice_ptr v1
+    v3 = slice_len v1
+    v4 = call v0, 0, 0, v2, v3, 0, 0
+    jumpi v4, bb1, bb2
+  bb2:
+    v13 = returndatasize
+    v14 = add v13, 63
+    v15 = lt v14, v13
+    jumpi v15, bb4, bb6
+  bb6:
+    v16 = not 31
+    v17 = and v14, v16
+    v18 = alloc memorybytes, exact, uninitialized, infallible, v17
+    set_memory_object_len memorybytes, v18, v13
+    v19 = make_returndata_slice 0, v13
+    memory_object_copy_from_slice memorybytes, v18, v19
+    v20 = memory_object_data memorybytes, v18
+    v21 = memory_object_len memorybytes, v18
+    v22 = make_memory_slice v20, v21
+    v23 = memory_slice_load_word memory, v22, 0
+    v24 = lt v21, 4
+    v25 = iszero v24
+    v26 = shr 224, v23
+    v27 = eq v26, 0x8c379a0
+    v28 = and v25, v27
+    v29 = lt v21, 36
+    v30 = iszero v29
+    v31 = eq v26, 0x4e487b71
+    v32 = and v30, v31
+    jumpi 1, bb7, bb8
+  bb8:
+    revert v20, v21
+  bb7:
+    jump bb3
+  bb1:
+    v5 = returndatasize
+    v6 = add v5, 63
+    v7 = lt v6, v5
+    jumpi v7, bb4, bb5
+  bb5:
+    v8 = not 31
+    v9 = and v6, v8
+    v10 = alloc memorybytes, exact, uninitialized, infallible, v9
+    set_memory_object_len memorybytes, v10, v5
+    v11 = make_returndata_slice 0, v5
+    memory_object_copy_from_slice memorybytes, v10, v11
+    v12 = abi_decode [u256], v10
+    jump bb3
+  bb3:
+    v33 = phi [bb5: v12], [bb7: 7]
+    ret v33
+  bb4:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 65 !metadata(memory=scratch)
+    revert 0, 36
+}
+
+fn @noCodeNoReturn() -> u256 [selector=0xac1b26c4, abi_params=[], abi_returns=[word]] {
+  bb0:
+    v0 = gas
+    v1 = abi_encode [], selector 0x5dfc2e4a00000000000000000000000000000000000000000000000000000000
+    v2 = slice_ptr v1
+    v3 = slice_len v1
+    v4 = extcodesize 0
+    v5 = iszero v4
+    jumpi v5, bb1, bb2
+  bb2:
+    v6 = call v0, 0, 0, v2, v3, 0, 0
+    jumpi v6, bb3, bb4
+  bb4:
+    v7 = returndatasize
+    v8 = add v7, 63
+    v9 = lt v8, v7
+    jumpi v9, bb6, bb7
+  bb7:
+    v10 = not 31
+    v11 = and v8, v10
+    v12 = alloc memorybytes, exact, uninitialized, infallible, v11
+    set_memory_object_len memorybytes, v12, v7
+    v13 = make_returndata_slice 0, v7
+    memory_object_copy_from_slice memorybytes, v12, v13
+    v14 = memory_object_data memorybytes, v12
+    v15 = memory_object_len memorybytes, v12
+    v16 = make_memory_slice v14, v15
+    v17 = memory_slice_load_word memory, v16, 0
+    v18 = lt v15, 4
+    v19 = iszero v18
+    v20 = shr 224, v17
+    v21 = eq v20, 0x8c379a0
+    v22 = and v19, v21
+    v23 = lt v15, 36
+    v24 = iszero v23
+    v25 = eq v20, 0x4e487b71
+    v26 = and v24, v25
+    jumpi 1, bb8, bb9
+  bb9:
+    revert v14, v15
+  bb8:
+    jump bb5
+  bb6:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 65 !metadata(memory=scratch)
+    revert 0, 36
+  bb3:
+    jump bb5
+  bb5:
+    v27 = phi [bb3: 1], [bb8: 7]
+    ret v27
+  bb1:
+    revert 0, 0
+}

--- a/tests/ui/codegen/lowering/run-call/try_bare_catch_evm_version.sol
+++ b/tests/ui/codegen/lowering/run-call/try_bare_catch_evm_version.sol
@@ -47,12 +47,15 @@ contract TryCallee {
 
 contract TryBareCatch {
     // Before Byzantium a bare `catch { }` needs no return data: the call writes its return
-    // values into an output area of its own and the failure path runs the clause as it is.
+    // values into an output area overlaying its input and the failure path runs the clause as it
+    // is.
     // HOMESTEAD-LABEL: fn @live
+    // HOMESTEAD: create
+    // HOMESTEAD: [[INPUT:v[0-9]+]] = slice_ptr
     // HOMESTEAD: extcodesize
     // HOMESTEAD: [[GAS:v[0-9]+]] = gas
     // HOMESTEAD: [[FWD:v[0-9]+]] = sub [[GAS]], 50
-    // HOMESTEAD: [[OK:v[0-9]+]] = call [[FWD]], {{v[0-9]+}}, 0, {{v[0-9]+}}, {{v[0-9]+}}, 0, 32
+    // HOMESTEAD: [[OK:v[0-9]+]] = call [[FWD]], {{v[0-9]+}}, 0, [[INPUT]], {{v[0-9]+}}, [[INPUT]], 32
     // HOMESTEAD: jumpi [[OK]]
     // OSAKA-LABEL: fn @live
     // OSAKA: [[OK:v[0-9]+]] = call {{v[0-9]+}}, {{v[0-9]+}}, 0, {{v[0-9]+}}, {{v[0-9]+}}, 0, 0
@@ -66,15 +69,16 @@ contract TryBareCatch {
         }
     }
 
-    // A multi-word output area gets a buffer of its own before EIP-150, whose last word is
-    // touched before the gas is read.
+    // A multi-word output area reaches a word past the four-byte input, and that word is touched
+    // before the gas is read.
     // HOMESTEAD-LABEL: fn @liveTwo
-    // HOMESTEAD: [[BUFFER:v[0-9]+]] = alloc raw, exact, uninitialized, infallible, 64
-    // HOMESTEAD: [[LAST:v[0-9]+]] = add [[BUFFER]], 32
+    // HOMESTEAD: create
+    // HOMESTEAD: [[INPUT:v[0-9]+]] = slice_ptr
+    // HOMESTEAD: [[LAST:v[0-9]+]] = add [[INPUT]], 32
     // HOMESTEAD: mstore [[LAST]], 0
     // HOMESTEAD: [[GAS:v[0-9]+]] = gas
     // HOMESTEAD: [[FWD:v[0-9]+]] = sub [[GAS]], 50
-    // HOMESTEAD: call [[FWD]], {{v[0-9]+}}, 0, {{v[0-9]+}}, {{v[0-9]+}}, [[BUFFER]], 64
+    // HOMESTEAD: call [[FWD]], {{v[0-9]+}}, 0, [[INPUT]], {{v[0-9]+}}, [[INPUT]], 64
     function liveTwo() external returns (uint256 r) {
         try TryTarget(address(new TryCallee())).pair() returns (uint256 a, uint256 b) {
             r = a + b;

--- a/tests/ui/codegen/lowering/run-call/try_bare_catch_evm_version.sol
+++ b/tests/ui/codegen/lowering/run-call/try_bare_catch_evm_version.sol
@@ -1,0 +1,166 @@
+//@ revisions: homestead homesteadGas homesteadSize byzantium osaka
+//@[homestead] compile-flags: -O none --evm-version homestead -Zdump=mir
+//@[homestead] filecheck: --check-prefix=HOMESTEAD --implicit-check-not=returndatasize --implicit-check-not=make_returndata_slice
+//@[homesteadGas] compile-flags: -O gas --evm-version homestead
+//@[homesteadSize] compile-flags: -O size --evm-version homestead
+//@[byzantium] compile-flags: -O none --evm-version byzantium
+//@[osaka] compile-flags: -O none --evm-version osaka -Zdump=mir
+//@[osaka] filecheck: --check-prefix=OSAKA
+//@ run-call-fail: TryBareCatch::noCode => 0x
+//@ run-call-fail: TryBareCatch::noCodeNoReturn => 0x
+//@ run-call: TryBareCatch::live => 42
+//@ run-call: TryBareCatch::liveTwo => 3
+//@ run-call: TryBareCatch::liveAggregate => 33
+//@ run-call: TryBareCatch::liveNoReturn => 1
+//@ run-call: TryBareCatch::liveCatch => 7
+//@ run-call: TryBareCatch::livePointer => 42
+//@ run-call: TryBareCatch::liveCreation => 1
+
+interface TryTarget {
+    function value() external returns (uint256);
+    function pair() external returns (uint256, uint256);
+    function agg() external returns (uint256[2] memory);
+    function noop() external;
+    function fail() external payable returns (uint256);
+}
+
+contract TryCallee {
+    function value() external pure returns (uint256) {
+        return 42;
+    }
+
+    function pair() external pure returns (uint256, uint256) {
+        return (1, 2);
+    }
+
+    function agg() external pure returns (uint256[2] memory r) {
+        r[0] = 11;
+        r[1] = 22;
+    }
+
+    function noop() external {}
+
+    function fail() external payable returns (uint256) {
+        revert();
+    }
+}
+
+contract TryBareCatch {
+    // Before Byzantium a bare `catch { }` needs no return data: the call writes its return
+    // values into an output area of its own and the failure path runs the clause as it is.
+    // HOMESTEAD-LABEL: fn @live
+    // HOMESTEAD: extcodesize
+    // HOMESTEAD: [[GAS:v[0-9]+]] = gas
+    // HOMESTEAD: [[FWD:v[0-9]+]] = sub [[GAS]], 50
+    // HOMESTEAD: [[OK:v[0-9]+]] = call [[FWD]], {{v[0-9]+}}, 0, {{v[0-9]+}}, {{v[0-9]+}}, 0, 32
+    // HOMESTEAD: jumpi [[OK]]
+    // OSAKA-LABEL: fn @live
+    // OSAKA: [[OK:v[0-9]+]] = call {{v[0-9]+}}, {{v[0-9]+}}, 0, {{v[0-9]+}}, {{v[0-9]+}}, 0, 0
+    // OSAKA: jumpi [[OK]]
+    // OSAKA: returndatasize
+    function live() external returns (uint256 r) {
+        try TryTarget(address(new TryCallee())).value() returns (uint256 v) {
+            r = v;
+        } catch {
+            r = 7;
+        }
+    }
+
+    // A multi-word output area gets a buffer of its own before EIP-150, whose last word is
+    // touched before the gas is read.
+    // HOMESTEAD-LABEL: fn @liveTwo
+    // HOMESTEAD: [[BUFFER:v[0-9]+]] = alloc raw, exact, uninitialized, infallible, 64
+    // HOMESTEAD: [[LAST:v[0-9]+]] = add [[BUFFER]], 32
+    // HOMESTEAD: mstore [[LAST]], 0
+    // HOMESTEAD: [[GAS:v[0-9]+]] = gas
+    // HOMESTEAD: [[FWD:v[0-9]+]] = sub [[GAS]], 50
+    // HOMESTEAD: call [[FWD]], {{v[0-9]+}}, 0, {{v[0-9]+}}, {{v[0-9]+}}, [[BUFFER]], 64
+    function liveTwo() external returns (uint256 r) {
+        try TryTarget(address(new TryCallee())).pair() returns (uint256 a, uint256 b) {
+            r = a + b;
+        } catch {
+            r = 7;
+        }
+    }
+
+    function liveAggregate() external returns (uint256 r) {
+        try TryTarget(address(new TryCallee())).agg() returns (uint256[2] memory v) {
+            r = v[0] + v[1];
+        } catch {
+            r = 7;
+        }
+    }
+
+    // A call without return values keeps its `extcodesize` guard at every version.
+    // HOMESTEAD-LABEL: fn @liveNoReturn
+    // HOMESTEAD: extcodesize
+    // HOMESTEAD: call
+    // OSAKA-LABEL: fn @liveNoReturn
+    // OSAKA: extcodesize
+    // OSAKA: call
+    function liveNoReturn() external returns (uint256 r) {
+        try TryTarget(address(new TryCallee())).noop() {
+            r = 1;
+        } catch {
+            r = 7;
+        }
+    }
+
+    // A call that cannot be made at all fails without running the callee, which is the one
+    // pre-Byzantium failure that leaves the caller enough gas to run the catch clause: every
+    // exception there consumes all the gas the call was forwarded.
+    // HOMESTEAD-LABEL: fn @liveCatch
+    // HOMESTEAD: [[GAS:v[0-9]+]] = gas
+    // HOMESTEAD: [[FWD:v[0-9]+]] = sub [[GAS]], 0x235a
+    // HOMESTEAD: [[OK:v[0-9]+]] = call [[FWD]], {{v[0-9]+}}, 1,
+    // HOMESTEAD: jumpi [[OK]]
+    function liveCatch() external returns (uint256 r) {
+        try TryTarget(address(new TryCallee())).fail{value: 1}() returns (uint256 v) {
+            r = v;
+        } catch {
+            r = 7;
+        }
+    }
+
+    function livePointer() external returns (uint256 r) {
+        TryTarget target = TryTarget(address(new TryCallee()));
+        function() external returns (uint256) f = target.value;
+        try f() returns (uint256 v) {
+            r = v;
+        } catch {
+            r = 7;
+        }
+    }
+
+    function liveCreation() external returns (uint256 r) {
+        try new TryCallee() {
+            r = 1;
+        } catch {
+            r = 7;
+        }
+    }
+
+    // A code-less callee reverts the whole function instead of running the catch clause: the
+    // `extcodesize` guard is what a pre-Byzantium call has in place of a return-data check.
+    // HOMESTEAD-LABEL: fn @noCode
+    // HOMESTEAD: extcodesize
+    function noCode() external returns (uint256 r) {
+        try TryTarget(address(0)).value() returns (uint256 v) {
+            r = v;
+        } catch {
+            r = 7;
+        }
+    }
+
+    // HOMESTEAD-LABEL: fn @noCodeNoReturn
+    // HOMESTEAD: extcodesize
+    // OSAKA-LABEL: fn @noCodeNoReturn
+    // OSAKA: extcodesize
+    function noCodeNoReturn() external returns (uint256 r) {
+        try TryTarget(address(0)).noop() {
+            r = 1;
+        } catch {
+            r = 7;
+        }
+    }
+}

--- a/tests/ui/codegen/lowering/run-call/try_bare_catch_evm_version.sol
+++ b/tests/ui/codegen/lowering/run-call/try_bare_catch_evm_version.sol
@@ -69,13 +69,14 @@ contract TryBareCatch {
         }
     }
 
-    // A multi-word output area reaches a word past the four-byte input, and that word is touched
-    // before the gas is read.
+    // The word above a multi-word output area is touched before the arguments are encoded and
+    // the gas is read.
     // HOMESTEAD-LABEL: fn @liveTwo
     // HOMESTEAD: create
+    // HOMESTEAD: [[AREA:v[0-9]+]] = fmp
+    // HOMESTEAD: [[ABOVE:v[0-9]+]] = add [[AREA]], 64
+    // HOMESTEAD: mstore [[ABOVE]], 0
     // HOMESTEAD: [[INPUT:v[0-9]+]] = slice_ptr
-    // HOMESTEAD: [[LAST:v[0-9]+]] = add [[INPUT]], 32
-    // HOMESTEAD: mstore [[LAST]], 0
     // HOMESTEAD: [[GAS:v[0-9]+]] = gas
     // HOMESTEAD: [[FWD:v[0-9]+]] = sub [[GAS]], 50
     // HOMESTEAD: call [[FWD]], {{v[0-9]+}}, 0, [[INPUT]], {{v[0-9]+}}, [[INPUT]], 64

--- a/tests/ui/codegen/lowering/try_catch_clause_evm_version.byzantium.stdout
+++ b/tests/ui/codegen/lowering/try_catch_clause_evm_version.byzantium.stdout
@@ -93,7 +93,7 @@ fn @typed(arg0: address) -> u256 [selector=0x18d9eb38, abi_params=[address], abi
   bb8:
     jump bb9
   bb7:
-    v28 = internal_call @try_decode_error_message, 1, v20, v21
+    v28 = icall @try_decode_error_message, 1, v20, v21
     jump bb9
   bb9:
     v29 = phi [bb7: v28], [bb8: 0]

--- a/tests/ui/codegen/lowering/try_catch_clause_evm_version.byzantium.stdout
+++ b/tests/ui/codegen/lowering/try_catch_clause_evm_version.byzantium.stdout
@@ -1,0 +1,184 @@
+// === ROOT/tests/ui/codegen/lowering/try_catch_clause_evm_version.sol:TryCatchClauses ===
+@module TryCatchClauses
+fn @bare(arg0: address) -> u256 [selector=0x590eaf9b, abi_params=[address], abi_returns=[word]] {
+  bb0:
+    v0 = gas
+    v1 = abi_encode [], selector 0x3fa4f24500000000000000000000000000000000000000000000000000000000
+    v2 = slice_ptr v1
+    v3 = slice_len v1
+    v4 = call v0, arg0, 0, v2, v3, 0, 0
+    jumpi v4, bb1, bb2
+  bb2:
+    v13 = returndatasize
+    v14 = add v13, 63
+    v15 = lt v14, v13
+    jumpi v15, bb4, bb6
+  bb6:
+    v16 = not 31
+    v17 = and v14, v16
+    v18 = alloc memorybytes, exact, uninitialized, infallible, v17
+    set_memory_object_len memorybytes, v18, v13
+    v19 = make_returndata_slice 0, v13
+    memory_object_copy_from_slice memorybytes, v18, v19
+    v20 = memory_object_data memorybytes, v18
+    v21 = memory_object_len memorybytes, v18
+    v22 = make_memory_slice v20, v21
+    v23 = memory_slice_load_word memory, v22, 0
+    v24 = lt v21, 4
+    v25 = iszero v24
+    v26 = shr 224, v23
+    v27 = eq v26, 0x8c379a0
+    v28 = and v25, v27
+    v29 = lt v21, 36
+    v30 = iszero v29
+    v31 = eq v26, 0x4e487b71
+    v32 = and v30, v31
+    jumpi 1, bb7, bb8
+  bb8:
+    revert v20, v21
+  bb7:
+    jump bb3
+  bb1:
+    v5 = returndatasize
+    v6 = add v5, 63
+    v7 = lt v6, v5
+    jumpi v7, bb4, bb5
+  bb5:
+    v8 = not 31
+    v9 = and v6, v8
+    v10 = alloc memorybytes, exact, uninitialized, infallible, v9
+    set_memory_object_len memorybytes, v10, v5
+    v11 = make_returndata_slice 0, v5
+    memory_object_copy_from_slice memorybytes, v10, v11
+    v12 = abi_decode [u256], v10
+    jump bb3
+  bb3:
+    v33 = phi [bb5: v12], [bb7: 7]
+    ret v33
+  bb4:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 65 !metadata(memory=scratch)
+    revert 0, 36
+}
+
+fn @typed(arg0: address) -> u256 [selector=0x18d9eb38, abi_params=[address], abi_returns=[word]] {
+  bb0:
+    v0 = gas
+    v1 = abi_encode [], selector 0x3fa4f24500000000000000000000000000000000000000000000000000000000
+    v2 = slice_ptr v1
+    v3 = slice_len v1
+    v4 = call v0, arg0, 0, v2, v3, 0, 0
+    jumpi v4, bb1, bb2
+  bb2:
+    v13 = returndatasize
+    v14 = add v13, 63
+    v15 = lt v14, v13
+    jumpi v15, bb4, bb6
+  bb6:
+    v16 = not 31
+    v17 = and v14, v16
+    v18 = alloc memorybytes, exact, uninitialized, infallible, v17
+    set_memory_object_len memorybytes, v18, v13
+    v19 = make_returndata_slice 0, v13
+    memory_object_copy_from_slice memorybytes, v18, v19
+    v20 = memory_object_data memorybytes, v18
+    v21 = memory_object_len memorybytes, v18
+    v22 = make_memory_slice v20, v21
+    v23 = memory_slice_load_word memory, v22, 0
+    v24 = lt v21, 4
+    v25 = iszero v24
+    v26 = shr 224, v23
+    v27 = eq v26, 0x8c379a0
+    jumpi v27, bb7, bb8
+  bb8:
+    jump bb9
+  bb7:
+    v28 = internal_call @try_decode_error_message, 1, v20, v21
+    jump bb9
+  bb9:
+    v29 = phi [bb7: v28], [bb8: 0]
+    v30 = lt v21, 36
+    v31 = iszero v30
+    v32 = eq v26, 0x4e487b71
+    v33 = and v31, v32
+    jumpi v29, bb10, bb11
+  bb11:
+    jumpi v33, bb13, bb14
+  bb14:
+    jumpi 1, bb15, bb16
+  bb16:
+    revert v20, v21
+  bb15:
+    jump bb3
+  bb13:
+    v46 = memory_object_data memorybytes, v18
+    v47 = add v46, 4
+    v48 = make_memory_slice v47, 32
+    v49 = memory_slice_load_word memory, v48, 0
+    jump bb3
+  bb10:
+    v34 = memory_object_data memorybytes, v18
+    v35 = memory_object_len memorybytes, v18
+    v36 = add v34, 4
+    v37 = sub v35, 4
+    v38 = make_memory_slice v36, v37
+    v39 = slice_len v38
+    v40 = add v39, 63
+    v41 = lt v40, v39
+    jumpi v41, bb4, bb12
+  bb12:
+    v42 = not 31
+    v43 = and v40, v42
+    v44 = alloc memorybytes, exact, uninitialized, infallible, v43
+    set_memory_object_len memorybytes, v44, v39
+    memory_object_copy_from_slice memorybytes, v44, v38
+    v45 = abi_decode [bytes], v44
+    jump bb3
+  bb1:
+    v5 = returndatasize
+    v6 = add v5, 63
+    v7 = lt v6, v5
+    jumpi v7, bb4, bb5
+  bb5:
+    v8 = not 31
+    v9 = and v6, v8
+    v10 = alloc memorybytes, exact, uninitialized, infallible, v9
+    set_memory_object_len memorybytes, v10, v5
+    v11 = make_returndata_slice 0, v5
+    memory_object_copy_from_slice memorybytes, v10, v11
+    v12 = abi_decode [u256], v10
+    jump bb3
+  bb3:
+    v50 = phi [bb5: v12], [bb12: 1], [bb13: 2], [bb15: 3]
+    ret v50
+  bb4:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 65 !metadata(memory=scratch)
+    revert 0, 36
+}
+
+fn @try_decode_error_message(arg0: memptr, arg1: u256) -> bool {
+  bb0:
+    v0 = lt arg1, 68
+    v1 = iszero v0
+    jumpi v1, bb1, bb3
+  bb1:
+    v2 = add arg0, 4
+    v3 = mload v2
+    v4 = gt v3, 0xffffffffffffffff
+    v5 = add v3, 36
+    v6 = gt v5, arg1
+    v7 = or v4, v6
+    jumpi v7, bb3, bb2
+  bb2:
+    v8 = add v2, v3
+    v9 = mload v8
+    v10 = gt v9, 0xffffffffffffffff
+    v11 = sub arg1, v5
+    v12 = gt v9, v11
+    v13 = or v10, v12
+    v14 = iszero v13
+    ret v14
+  bb3:
+    ret 0
+}

--- a/tests/ui/codegen/lowering/try_catch_clause_evm_version.homestead.stderr
+++ b/tests/ui/codegen/lowering/try_catch_clause_evm_version.homestead.stderr
@@ -1,43 +1,38 @@
-error: builtin `staticcall` requires Byzantium-compatible EVM
-   ╭▸ ROOT/tests/ui/typeck/evm_version/byzantium.sol:LL:CC
-   │
-LL │         addr.staticcall("");
-   │         ━━━━━━━━━━━━━━━
-   │
-   ╰ help: compile with `--evm-version byzantium` or newer
-
 error[1812]: typed catch clause requires Byzantium-compatible EVM
-   ╭▸ ROOT/tests/ui/typeck/evm_version/byzantium.sol:LL:CC
+   ╭▸ ROOT/tests/ui/codegen/lowering/try_catch_clause_evm_version.sol:LL:CC
    │
 LL │           } catch Error(string memory) {
    │ ┏━━━━━━━━━━━┛
 LL │ ┃
+LL │ ┃             r = 1;
 LL │ ┃         } catch Panic(uint256) {
    │ ┗━━━━━━━━━┛
    │
    ╰ help: compile with `--evm-version byzantium` or newer
 
 error[1812]: typed catch clause requires Byzantium-compatible EVM
-   ╭▸ ROOT/tests/ui/typeck/evm_version/byzantium.sol:LL:CC
+   ╭▸ ROOT/tests/ui/codegen/lowering/try_catch_clause_evm_version.sol:LL:CC
    │
 LL │           } catch Panic(uint256) {
    │ ┏━━━━━━━━━━━┛
 LL │ ┃
+LL │ ┃             r = 2;
 LL │ ┃         } catch (bytes memory) {
    │ ┗━━━━━━━━━┛
    │
    ╰ help: compile with `--evm-version byzantium` or newer
 
 error[9908]: typed catch clause requires Byzantium-compatible EVM
-   ╭▸ ROOT/tests/ui/typeck/evm_version/byzantium.sol:LL:CC
+   ╭▸ ROOT/tests/ui/codegen/lowering/try_catch_clause_evm_version.sol:LL:CC
    │
 LL │           } catch (bytes memory) {
    │ ┏━━━━━━━━━━━┛
 LL │ ┃
-LL │ ┃         } catch {
+LL │ ┃             r = 3;
+LL │ ┃         }
    │ ┗━━━━━━━━━┛
    │
    ╰ help: compile with `--evm-version byzantium` or newer
 
-error: aborting due to 4 previous errors
+error: aborting due to 3 previous errors
 

--- a/tests/ui/codegen/lowering/try_catch_clause_evm_version.sol
+++ b/tests/ui/codegen/lowering/try_catch_clause_evm_version.sol
@@ -1,0 +1,41 @@
+//@ revisions: homestead byzantium
+//@[homestead] compile-flags: -O none --evm-version homestead -Zdump=mir
+//@[byzantium] compile-flags: -O none --evm-version byzantium -Zdump=mir
+//@[byzantium] filecheck:
+
+interface ClauseTarget {
+    function value() external returns (uint256);
+}
+
+contract TryCatchClauses {
+    // A bare `catch { }` binds nothing and compiles at every version: the return values come
+    // out of the call's own output area, and the clause runs with no return data at all.
+    // CHECK-LABEL: fn @bare
+    // CHECK: call
+    // CHECK: returndatasize
+    function bare(ClauseTarget target) external returns (uint256 r) {
+        try target.value() returns (uint256 v) {
+            r = v;
+        } catch {
+            r = 7;
+        }
+    }
+
+    // Every clause that matches or binds the return data needs it to exist. The type checker
+    // reports that on its own, once per clause, as solc does; codegen adds nothing.
+    // CHECK-LABEL: fn @typed
+    function typed(ClauseTarget target) external returns (uint256 r) {
+        try target.value() returns (uint256 v) {
+            r = v;
+        } catch Error(string memory) {
+            //~[homestead]^ ERROR: typed catch clause requires Byzantium-compatible EVM
+            r = 1;
+        } catch Panic(uint256) {
+            //~[homestead]^ ERROR: typed catch clause requires Byzantium-compatible EVM
+            r = 2;
+        } catch (bytes memory) {
+            //~[homestead]^ ERROR: typed catch clause requires Byzantium-compatible EVM
+            r = 3;
+        }
+    }
+}

--- a/tests/ui/codegen/lowering/try_library_call_evm_version.byzantium.stdout
+++ b/tests/ui/codegen/lowering/try_library_call_evm_version.byzantium.stdout
@@ -1,0 +1,149 @@
+// === ROOT/tests/ui/codegen/lowering/try_library_call_evm_version.sol:TryLib ===
+@module TryLib
+fn @double(arg0: u256) -> u256 [selector=0xeee97206, pure, abi_params=[u256], abi_returns=[word]] {
+  bb0:
+    v0 = mul 2, arg0
+    v1 = iszero arg0
+    v2 = div v0, arg0
+    v3 = eq v2, 2
+    v4 = or v1, v3
+    v5 = iszero v4
+    jumpi v5, bb1, bb2
+  bb2:
+    ret v0
+  bb1:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 17 !metadata(memory=scratch)
+    revert 0, 36
+}
+
+fn @noop(arg0: u256) [selector=0x67190395, pure, abi_params=[u256], abi_returns=[]] {
+  bb0:
+    stop
+}
+
+// === ROOT/tests/ui/codegen/lowering/try_library_call_evm_version.sol:TryLibraryCall ===
+@module TryLibraryCall
+fn @seen() -> u256 [selector=0xd99aa8e2, view, abi_params=[], abi_returns=[word]] {
+  bb0:
+    v0 = sload 0 !metadata(storage=slot(0))
+    ret v0
+}
+
+fn @libCall(arg0: u256) -> u256 [selector=0x34ea0c3e, abi_params=[u256], abi_returns=[word]] {
+  bb0:
+    v0 = gas
+    v1 = abi_encode [word], selector 0xeee9720600000000000000000000000000000000000000000000000000000000, args arg0
+    v2 = slice_ptr v1
+    v3 = slice_len v1
+    v4 = delegatecall v0, 0xf6e85b2cc7f6a7ce364e7443aa232891136029fe, v2, v3, 0, 0
+    jumpi v4, bb1, bb2
+  bb2:
+    v13 = returndatasize
+    v14 = add v13, 63
+    v15 = lt v14, v13
+    jumpi v15, bb4, bb6
+  bb6:
+    v16 = not 31
+    v17 = and v14, v16
+    v18 = alloc memorybytes, exact, uninitialized, infallible, v17
+    set_memory_object_len memorybytes, v18, v13
+    v19 = make_returndata_slice 0, v13
+    memory_object_copy_from_slice memorybytes, v18, v19
+    v20 = memory_object_data memorybytes, v18
+    v21 = memory_object_len memorybytes, v18
+    v22 = make_memory_slice v20, v21
+    v23 = memory_slice_load_word memory, v22, 0
+    v24 = lt v21, 4
+    v25 = iszero v24
+    v26 = shr 224, v23
+    v27 = eq v26, 0x8c379a0
+    v28 = and v25, v27
+    v29 = lt v21, 36
+    v30 = iszero v29
+    v31 = eq v26, 0x4e487b71
+    v32 = and v30, v31
+    jumpi 1, bb7, bb8
+  bb8:
+    revert v20, v21
+  bb7:
+    jump bb3
+  bb1:
+    v5 = returndatasize
+    v6 = add v5, 63
+    v7 = lt v6, v5
+    jumpi v7, bb4, bb5
+  bb5:
+    v8 = not 31
+    v9 = and v6, v8
+    v10 = alloc memorybytes, exact, uninitialized, infallible, v9
+    set_memory_object_len memorybytes, v10, v5
+    v11 = make_returndata_slice 0, v5
+    memory_object_copy_from_slice memorybytes, v10, v11
+    v12 = abi_decode [u256], v10
+    sstore 0, v12 !metadata(storage=slot(0))
+    jump bb3
+  bb3:
+    v33 = phi [bb5: v12], [bb7: 7]
+    ret v33
+  bb4:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 65 !metadata(memory=scratch)
+    revert 0, 36
+}
+
+fn @libNoReturn(arg0: u256) -> u256 [selector=0x364676bf, abi_params=[u256], abi_returns=[word]] {
+  bb0:
+    v0 = gas
+    v1 = abi_encode [word], selector 0x6719039500000000000000000000000000000000000000000000000000000000, args arg0
+    v2 = slice_ptr v1
+    v3 = slice_len v1
+    v4 = extcodesize 0xf6e85b2cc7f6a7ce364e7443aa232891136029fe
+    v5 = iszero v4
+    jumpi v5, bb1, bb2
+  bb2:
+    v6 = delegatecall v0, 0xf6e85b2cc7f6a7ce364e7443aa232891136029fe, v2, v3, 0, 0
+    jumpi v6, bb3, bb4
+  bb4:
+    v7 = returndatasize
+    v8 = add v7, 63
+    v9 = lt v8, v7
+    jumpi v9, bb6, bb7
+  bb7:
+    v10 = not 31
+    v11 = and v8, v10
+    v12 = alloc memorybytes, exact, uninitialized, infallible, v11
+    set_memory_object_len memorybytes, v12, v7
+    v13 = make_returndata_slice 0, v7
+    memory_object_copy_from_slice memorybytes, v12, v13
+    v14 = memory_object_data memorybytes, v12
+    v15 = memory_object_len memorybytes, v12
+    v16 = make_memory_slice v14, v15
+    v17 = memory_slice_load_word memory, v16, 0
+    v18 = lt v15, 4
+    v19 = iszero v18
+    v20 = shr 224, v17
+    v21 = eq v20, 0x8c379a0
+    v22 = and v19, v21
+    v23 = lt v15, 36
+    v24 = iszero v23
+    v25 = eq v20, 0x4e487b71
+    v26 = and v24, v25
+    jumpi 1, bb8, bb9
+  bb9:
+    revert v14, v15
+  bb8:
+    jump bb5
+  bb6:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 65 !metadata(memory=scratch)
+    revert 0, 36
+  bb3:
+    sstore 0, 1 !metadata(storage=slot(0))
+    jump bb5
+  bb5:
+    v27 = phi [bb3: 1], [bb8: 7]
+    ret v27
+  bb1:
+    revert 0, 0
+}

--- a/tests/ui/codegen/lowering/try_library_call_evm_version.byzantium.stdout
+++ b/tests/ui/codegen/lowering/try_library_call_evm_version.byzantium.stdout
@@ -36,7 +36,7 @@ fn @libCall(arg0: u256) -> u256 [selector=0x34ea0c3e, abi_params=[u256], abi_ret
     v1 = abi_encode [word], selector 0xeee9720600000000000000000000000000000000000000000000000000000000, args arg0
     v2 = slice_ptr v1
     v3 = slice_len v1
-    v4 = delegatecall v0, 0xf6e85b2cc7f6a7ce364e7443aa232891136029fe, v2, v3, 0, 0
+    v4 = delegatecall v0, 0xc0eda96c2648cd3a6a6e9ddfea8fc5f701ed980d, v2, v3, 0, 0
     jumpi v4, bb1, bb2
   bb2:
     v13 = returndatasize
@@ -98,11 +98,11 @@ fn @libNoReturn(arg0: u256) -> u256 [selector=0x364676bf, abi_params=[u256], abi
     v1 = abi_encode [word], selector 0x6719039500000000000000000000000000000000000000000000000000000000, args arg0
     v2 = slice_ptr v1
     v3 = slice_len v1
-    v4 = extcodesize 0xf6e85b2cc7f6a7ce364e7443aa232891136029fe
+    v4 = extcodesize 0xc0eda96c2648cd3a6a6e9ddfea8fc5f701ed980d
     v5 = iszero v4
     jumpi v5, bb1, bb2
   bb2:
-    v6 = delegatecall v0, 0xf6e85b2cc7f6a7ce364e7443aa232891136029fe, v2, v3, 0, 0
+    v6 = delegatecall v0, 0xc0eda96c2648cd3a6a6e9ddfea8fc5f701ed980d, v2, v3, 0, 0
     jumpi v6, bb3, bb4
   bb4:
     v7 = returndatasize

--- a/tests/ui/codegen/lowering/try_library_call_evm_version.homestead.stdout
+++ b/tests/ui/codegen/lowering/try_library_call_evm_version.homestead.stdout
@@ -35,13 +35,13 @@ fn @libCall(arg0: u256) -> u256 [selector=0x34ea0c3e, abi_params=[u256], abi_ret
     v0 = abi_encode [word], selector 0xeee9720600000000000000000000000000000000000000000000000000000000, args arg0
     v1 = slice_ptr v0
     v2 = slice_len v0
-    v3 = extcodesize 0xf6e85b2cc7f6a7ce364e7443aa232891136029fe
+    v3 = extcodesize 0xc0eda96c2648cd3a6a6e9ddfea8fc5f701ed980d
     v4 = iszero v3
     jumpi v4, bb1, bb2
   bb2:
     v5 = gas
     v6 = sub v5, 50
-    v7 = delegatecall v6, 0xf6e85b2cc7f6a7ce364e7443aa232891136029fe, v1, v2, 0, 32
+    v7 = delegatecall v6, 0xc0eda96c2648cd3a6a6e9ddfea8fc5f701ed980d, v1, v2, 0, 32
     jumpi v7, bb3, bb4
   bb4:
     jumpi 1, bb6, bb7
@@ -68,13 +68,13 @@ fn @libNoReturn(arg0: u256) -> u256 [selector=0x364676bf, abi_params=[u256], abi
     v0 = abi_encode [word], selector 0x6719039500000000000000000000000000000000000000000000000000000000, args arg0
     v1 = slice_ptr v0
     v2 = slice_len v0
-    v3 = extcodesize 0xf6e85b2cc7f6a7ce364e7443aa232891136029fe
+    v3 = extcodesize 0xc0eda96c2648cd3a6a6e9ddfea8fc5f701ed980d
     v4 = iszero v3
     jumpi v4, bb1, bb2
   bb2:
     v5 = gas
     v6 = sub v5, 50
-    v7 = delegatecall v6, 0xf6e85b2cc7f6a7ce364e7443aa232891136029fe, v1, v2, 0, 0
+    v7 = delegatecall v6, 0xc0eda96c2648cd3a6a6e9ddfea8fc5f701ed980d, v1, v2, 0, 0
     jumpi v7, bb3, bb4
   bb4:
     jumpi 1, bb6, bb7

--- a/tests/ui/codegen/lowering/try_library_call_evm_version.homestead.stdout
+++ b/tests/ui/codegen/lowering/try_library_call_evm_version.homestead.stdout
@@ -1,0 +1,93 @@
+// === ROOT/tests/ui/codegen/lowering/try_library_call_evm_version.sol:TryLib ===
+@module TryLib
+fn @double(arg0: u256) -> u256 [selector=0xeee97206, pure, abi_params=[u256], abi_returns=[word]] {
+  bb0:
+    v0 = mul 2, arg0
+    v1 = iszero arg0
+    v2 = div v0, arg0
+    v3 = eq v2, 2
+    v4 = or v1, v3
+    v5 = iszero v4
+    jumpi v5, bb1, bb2
+  bb2:
+    ret v0
+  bb1:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 17 !metadata(memory=scratch)
+    revert 0, 36
+}
+
+fn @noop(arg0: u256) [selector=0x67190395, pure, abi_params=[u256], abi_returns=[]] {
+  bb0:
+    stop
+}
+
+// === ROOT/tests/ui/codegen/lowering/try_library_call_evm_version.sol:TryLibraryCall ===
+@module TryLibraryCall
+fn @seen() -> u256 [selector=0xd99aa8e2, view, abi_params=[], abi_returns=[word]] {
+  bb0:
+    v0 = sload 0 !metadata(storage=slot(0))
+    ret v0
+}
+
+fn @libCall(arg0: u256) -> u256 [selector=0x34ea0c3e, abi_params=[u256], abi_returns=[word]] {
+  bb0:
+    v0 = abi_encode [word], selector 0xeee9720600000000000000000000000000000000000000000000000000000000, args arg0
+    v1 = slice_ptr v0
+    v2 = slice_len v0
+    v3 = extcodesize 0xf6e85b2cc7f6a7ce364e7443aa232891136029fe
+    v4 = iszero v3
+    jumpi v4, bb1, bb2
+  bb2:
+    v5 = gas
+    v6 = sub v5, 50
+    v7 = delegatecall v6, 0xf6e85b2cc7f6a7ce364e7443aa232891136029fe, v1, v2, 0, 32
+    jumpi v7, bb3, bb4
+  bb4:
+    jumpi 1, bb6, bb7
+  bb7:
+    revert 0, 0
+  bb6:
+    jump bb5
+  bb3:
+    v8 = add 0, 0
+    v9 = mload v8
+    v10 = add 0, 0
+    v11 = mload v10
+    sstore 0, v11 !metadata(storage=slot(0))
+    jump bb5
+  bb5:
+    v12 = phi [bb3: v11], [bb6: 7]
+    ret v12
+  bb1:
+    revert 0, 0
+}
+
+fn @libNoReturn(arg0: u256) -> u256 [selector=0x364676bf, abi_params=[u256], abi_returns=[word]] {
+  bb0:
+    v0 = abi_encode [word], selector 0x6719039500000000000000000000000000000000000000000000000000000000, args arg0
+    v1 = slice_ptr v0
+    v2 = slice_len v0
+    v3 = extcodesize 0xf6e85b2cc7f6a7ce364e7443aa232891136029fe
+    v4 = iszero v3
+    jumpi v4, bb1, bb2
+  bb2:
+    v5 = gas
+    v6 = sub v5, 50
+    v7 = delegatecall v6, 0xf6e85b2cc7f6a7ce364e7443aa232891136029fe, v1, v2, 0, 0
+    jumpi v7, bb3, bb4
+  bb4:
+    jumpi 1, bb6, bb7
+  bb7:
+    revert 0, 0
+  bb6:
+    jump bb5
+  bb3:
+    sstore 0, 1 !metadata(storage=slot(0))
+    jump bb5
+  bb5:
+    v8 = phi [bb3: 1], [bb6: 7]
+    ret v8
+  bb1:
+    revert 0, 0
+}

--- a/tests/ui/codegen/lowering/try_library_call_evm_version.homestead.stdout
+++ b/tests/ui/codegen/lowering/try_library_call_evm_version.homestead.stdout
@@ -41,7 +41,7 @@ fn @libCall(arg0: u256) -> u256 [selector=0x34ea0c3e, abi_params=[u256], abi_ret
   bb2:
     v5 = gas
     v6 = sub v5, 50
-    v7 = delegatecall v6, 0xc0eda96c2648cd3a6a6e9ddfea8fc5f701ed980d, v1, v2, 0, 32
+    v7 = delegatecall v6, 0xc0eda96c2648cd3a6a6e9ddfea8fc5f701ed980d, v1, v2, v1, 32
     jumpi v7, bb3, bb4
   bb4:
     jumpi 1, bb6, bb7
@@ -50,9 +50,9 @@ fn @libCall(arg0: u256) -> u256 [selector=0x34ea0c3e, abi_params=[u256], abi_ret
   bb6:
     jump bb5
   bb3:
-    v8 = add 0, 0
+    v8 = add v1, 0
     v9 = mload v8
-    v10 = add 0, 0
+    v10 = add v1, 0
     v11 = mload v10
     sstore 0, v11 !metadata(storage=slot(0))
     jump bb5
@@ -74,7 +74,7 @@ fn @libNoReturn(arg0: u256) -> u256 [selector=0x364676bf, abi_params=[u256], abi
   bb2:
     v5 = gas
     v6 = sub v5, 50
-    v7 = delegatecall v6, 0xc0eda96c2648cd3a6a6e9ddfea8fc5f701ed980d, v1, v2, 0, 0
+    v7 = delegatecall v6, 0xc0eda96c2648cd3a6a6e9ddfea8fc5f701ed980d, v1, v2, v1, 0
     jumpi v7, bb3, bb4
   bb4:
     jumpi 1, bb6, bb7

--- a/tests/ui/codegen/lowering/try_library_call_evm_version.homestead.stdout
+++ b/tests/ui/codegen/lowering/try_library_call_evm_version.homestead.stdout
@@ -32,17 +32,20 @@ fn @seen() -> u256 [selector=0xd99aa8e2, view, abi_params=[], abi_returns=[word]
 
 fn @libCall(arg0: u256) -> u256 [selector=0x34ea0c3e, abi_params=[u256], abi_returns=[word]] {
   bb0:
-    v0 = abi_encode [word], selector 0xeee9720600000000000000000000000000000000000000000000000000000000, args arg0
-    v1 = slice_ptr v0
-    v2 = slice_len v0
-    v3 = extcodesize 0xc0eda96c2648cd3a6a6e9ddfea8fc5f701ed980d
-    v4 = iszero v3
-    jumpi v4, bb1, bb2
+    v0 = fmp
+    v1 = add v0, 32
+    mstore v1, 0
+    v2 = abi_encode [word], selector 0xeee9720600000000000000000000000000000000000000000000000000000000, args arg0
+    v3 = slice_ptr v2
+    v4 = slice_len v2
+    v5 = extcodesize 0xc0eda96c2648cd3a6a6e9ddfea8fc5f701ed980d
+    v6 = iszero v5
+    jumpi v6, bb1, bb2
   bb2:
-    v5 = gas
-    v6 = sub v5, 50
-    v7 = delegatecall v6, 0xc0eda96c2648cd3a6a6e9ddfea8fc5f701ed980d, v1, v2, v1, 32
-    jumpi v7, bb3, bb4
+    v7 = gas
+    v8 = sub v7, 50
+    v9 = delegatecall v8, 0xc0eda96c2648cd3a6a6e9ddfea8fc5f701ed980d, v3, v4, v3, 32
+    jumpi v9, bb3, bb4
   bb4:
     jumpi 1, bb6, bb7
   bb7:
@@ -50,15 +53,15 @@ fn @libCall(arg0: u256) -> u256 [selector=0x34ea0c3e, abi_params=[u256], abi_ret
   bb6:
     jump bb5
   bb3:
-    v8 = add v1, 0
-    v9 = mload v8
-    v10 = add v1, 0
+    v10 = add v3, 0
     v11 = mload v10
-    sstore 0, v11 !metadata(storage=slot(0))
+    v12 = add v3, 0
+    v13 = mload v12
+    sstore 0, v13 !metadata(storage=slot(0))
     jump bb5
   bb5:
-    v12 = phi [bb3: v11], [bb6: 7]
-    ret v12
+    v14 = phi [bb3: v13], [bb6: 7]
+    ret v14
   bb1:
     revert 0, 0
 }

--- a/tests/ui/codegen/lowering/try_library_call_evm_version.sol
+++ b/tests/ui/codegen/lowering/try_library_call_evm_version.sol
@@ -1,0 +1,49 @@
+//@ revisions: homestead byzantium
+//@[homestead] compile-flags: -O none --evm-version homestead -Zdump=mir
+//@[homestead] filecheck: --check-prefix=HOMESTEAD --implicit-check-not=returndatasize
+//@[byzantium] compile-flags: -O none --evm-version byzantium -Zdump=mir
+//@[byzantium] filecheck: --check-prefix=BYZANTIUM
+
+library TryLib {
+    function double(uint256 x) external pure returns (uint256) {
+        return 2 * x;
+    }
+
+    function noop(uint256) external pure {}
+}
+
+contract TryLibraryCall {
+    uint256 public seen;
+
+    // solc compiles a `try` around an external library call before Byzantium as well: the
+    // delegatecall's static output size carries the return values, with no return data
+    // involved. A library call outside a `try` still needs Byzantium here.
+    // HOMESTEAD-LABEL: fn @libCall
+    // HOMESTEAD: extcodesize
+    // HOMESTEAD: [[GAS:v[0-9]+]] = gas
+    // HOMESTEAD: [[FWD:v[0-9]+]] = sub [[GAS]], 50
+    // HOMESTEAD: delegatecall [[FWD]], {{.*}}, 0, 32
+    // BYZANTIUM-LABEL: fn @libCall
+    // BYZANTIUM: delegatecall {{.*}}, 0, 0
+    // BYZANTIUM: returndatasize
+    function libCall(uint256 x) external returns (uint256 r) {
+        try TryLib.double(x) returns (uint256 v) {
+            seen = v;
+            r = v;
+        } catch {
+            r = 7;
+        }
+    }
+
+    // HOMESTEAD-LABEL: fn @libNoReturn
+    // HOMESTEAD: extcodesize
+    // HOMESTEAD: delegatecall {{.*}}, 0, 0
+    function libNoReturn(uint256 x) external returns (uint256 r) {
+        try TryLib.noop(x) {
+            seen = 1;
+            r = 1;
+        } catch {
+            r = 7;
+        }
+    }
+}

--- a/tests/ui/codegen/lowering/try_library_call_evm_version.sol
+++ b/tests/ui/codegen/lowering/try_library_call_evm_version.sol
@@ -16,13 +16,14 @@ contract TryLibraryCall {
     uint256 public seen;
 
     // solc compiles a `try` around an external library call before Byzantium as well: the
-    // delegatecall's static output size carries the return values, with no return data
-    // involved. A library call outside a `try` still needs Byzantium here.
+    // delegatecall's static output size carries the return values out of the area overlaying its
+    // input, with no return data involved.
     // HOMESTEAD-LABEL: fn @libCall
+    // HOMESTEAD: [[IN:v[0-9]+]] = slice_ptr
     // HOMESTEAD: extcodesize
     // HOMESTEAD: [[GAS:v[0-9]+]] = gas
     // HOMESTEAD: [[FWD:v[0-9]+]] = sub [[GAS]], 50
-    // HOMESTEAD: delegatecall [[FWD]], {{.*}}, 0, 32
+    // HOMESTEAD: delegatecall [[FWD]], {{.*}}, [[IN]], {{.*}}, [[IN]], 32
     // BYZANTIUM-LABEL: fn @libCall
     // BYZANTIUM: delegatecall {{.*}}, 0, 0
     // BYZANTIUM: returndatasize
@@ -36,8 +37,9 @@ contract TryLibraryCall {
     }
 
     // HOMESTEAD-LABEL: fn @libNoReturn
+    // HOMESTEAD: [[IN:v[0-9]+]] = slice_ptr
     // HOMESTEAD: extcodesize
-    // HOMESTEAD: delegatecall {{.*}}, 0, 0
+    // HOMESTEAD: delegatecall {{.*}}, [[IN]], 0
     function libNoReturn(uint256 x) external returns (uint256 r) {
         try TryLib.noop(x) {
             seen = 1;

--- a/tests/ui/typeck/evm_version/inaccessible_dynamic_return.byzantium.stderr
+++ b/tests/ui/typeck/evm_version/inaccessible_dynamic_return.byzantium.stderr
@@ -1,0 +1,9 @@
+warning[2018]: function state mutability can be restricted to pure
+   ╭▸ ROOT/tests/ui/typeck/evm_version/inaccessible_dynamic_return.sol:LL:CC
+   │
+LL │ ┏     function dyn() external returns (bytes memory) {
+LL │ ┃
+LL │ ┃         return "x";
+LL │ ┃     }
+   ╰╴┗━━━━━┛
+

--- a/tests/ui/typeck/evm_version/inaccessible_dynamic_return.homestead.stderr
+++ b/tests/ui/typeck/evm_version/inaccessible_dynamic_return.homestead.stderr
@@ -1,4 +1,4 @@
-error[6509]: cannot use the dynamically encoded return value of an external call
+error[9553]: cannot use the dynamically encoded return value of an external call
    ╭▸ ROOT/tests/ui/typeck/evm_version/inaccessible_dynamic_return.sol:LL:CC
    │
 LL │         (keccak256(I(a).dyn()), uint256(1));
@@ -7,7 +7,7 @@ LL │         (keccak256(I(a).dyn()), uint256(1));
    ├ note: the call returns `bytes memory`, whose size is unknowable without `RETURNDATASIZE`
    ╰ help: discard the value, or compile with `--evm-version byzantium` or newer
 
-error[6509]: cannot use the dynamically encoded return value of an external call
+error[7407]: cannot use the dynamically encoded return value of an external call
    ╭▸ ROOT/tests/ui/typeck/evm_version/inaccessible_dynamic_return.sol:LL:CC
    │
 LL │         (b, ) = (I(a).dyn(), uint256(1));
@@ -16,7 +16,7 @@ LL │         (b, ) = (I(a).dyn(), uint256(1));
    ├ note: the call returns `bytes memory`, whose size is unknowable without `RETURNDATASIZE`
    ╰ help: discard the value, or compile with `--evm-version byzantium` or newer
 
-error[6509]: cannot use the dynamically encoded return value of an external call
+error[9574]: cannot use the dynamically encoded return value of an external call
    ╭▸ ROOT/tests/ui/typeck/evm_version/inaccessible_dynamic_return.sol:LL:CC
    │
 LL │         bytes memory b = I(a).dyn();
@@ -25,7 +25,7 @@ LL │         bytes memory b = I(a).dyn();
    ├ note: the call returns `bytes memory`, whose size is unknowable without `RETURNDATASIZE`
    ╰ help: discard the value, or compile with `--evm-version byzantium` or newer
 
-error[6509]: cannot use the dynamically encoded return value of an external call
+error[9574]: cannot use the dynamically encoded return value of an external call
    ╭▸ ROOT/tests/ui/typeck/evm_version/inaccessible_dynamic_return.sol:LL:CC
    │
 LL │         uint256[] memory c = I(a).dynArray();
@@ -34,7 +34,7 @@ LL │         uint256[] memory c = I(a).dynArray();
    ├ note: the call returns `uint256[] memory`, whose size is unknowable without `RETURNDATASIZE`
    ╰ help: discard the value, or compile with `--evm-version byzantium` or newer
 
-error[6509]: cannot use the dynamically encoded return value of an external call
+error[9574]: cannot use the dynamically encoded return value of an external call
    ╭▸ ROOT/tests/ui/typeck/evm_version/inaccessible_dynamic_return.sol:LL:CC
    │
 LL │         S memory s = I(a).dynStruct();
@@ -43,7 +43,7 @@ LL │         S memory s = I(a).dynStruct();
    ├ note: the call returns `struct S memory`, whose size is unknowable without `RETURNDATASIZE`
    ╰ help: discard the value, or compile with `--evm-version byzantium` or newer
 
-error[6509]: cannot use the dynamically encoded return value of an external call
+error[9574]: cannot use the dynamically encoded return value of an external call
    ╭▸ ROOT/tests/ui/typeck/evm_version/inaccessible_dynamic_return.sol:LL:CC
    │
 LL │         bytes[2] memory f = I(a).dynFixed();
@@ -52,7 +52,7 @@ LL │         bytes[2] memory f = I(a).dynFixed();
    ├ note: the call returns `bytes[2] memory`, whose size is unknowable without `RETURNDATASIZE`
    ╰ help: discard the value, or compile with `--evm-version byzantium` or newer
 
-error[6509]: cannot use the dynamically encoded return value of an external call
+error[6359]: cannot use the dynamically encoded return value of an external call
    ╭▸ ROOT/tests/ui/typeck/evm_version/inaccessible_dynamic_return.sol:LL:CC
    │
 LL │         return I(a).dyn();
@@ -61,7 +61,7 @@ LL │         return I(a).dyn();
    ├ note: the call returns `bytes memory`, whose size is unknowable without `RETURNDATASIZE`
    ╰ help: discard the value, or compile with `--evm-version byzantium` or newer
 
-error[6509]: cannot use the dynamically encoded return value of an external call
+error[9553]: cannot use the dynamically encoded return value of an external call
    ╭▸ ROOT/tests/ui/typeck/evm_version/inaccessible_dynamic_return.sol:LL:CC
    │
 LL │         return keccak256(I(a).dyn());
@@ -70,7 +70,7 @@ LL │         return keccak256(I(a).dyn());
    ├ note: the call returns `bytes memory`, whose size is unknowable without `RETURNDATASIZE`
    ╰ help: discard the value, or compile with `--evm-version byzantium` or newer
 
-error[6509]: cannot use the dynamically encoded return value of an external call
+error[7407]: cannot use the dynamically encoded return value of an external call
    ╭▸ ROOT/tests/ui/typeck/evm_version/inaccessible_dynamic_return.sol:LL:CC
    │
 LL │         I(a).dyn().length;
@@ -97,7 +97,7 @@ LL │         try I(a).mixed() returns (uint256 v, bytes memory b) {
    ├ note: the call returns `bytes memory`, whose size is unknowable without `RETURNDATASIZE`
    ╰ help: discard the value, or compile with `--evm-version byzantium` or newer
 
-error[6509]: cannot use the dynamically encoded return value of an external call
+error[9574]: cannot use the dynamically encoded return value of an external call
    ╭▸ ROOT/tests/ui/typeck/evm_version/inaccessible_dynamic_return.sol:LL:CC
    │
 LL │         bytes memory b = p();
@@ -106,7 +106,7 @@ LL │         bytes memory b = p();
    ├ note: the call returns `bytes memory`, whose size is unknowable without `RETURNDATASIZE`
    ╰ help: discard the value, or compile with `--evm-version byzantium` or newer
 
-error[6509]: cannot use the dynamically encoded return value of an external call
+error[9574]: cannot use the dynamically encoded return value of an external call
    ╭▸ ROOT/tests/ui/typeck/evm_version/inaccessible_dynamic_return.sol:LL:CC
    │
 LL │         bytes memory b = L.dyn();

--- a/tests/ui/typeck/evm_version/inaccessible_dynamic_return.homestead.stderr
+++ b/tests/ui/typeck/evm_version/inaccessible_dynamic_return.homestead.stderr
@@ -1,6 +1,24 @@
 error[6509]: cannot use the dynamically encoded return value of an external call
    ╭▸ ROOT/tests/ui/typeck/evm_version/inaccessible_dynamic_return.sol:LL:CC
    │
+LL │         (keccak256(I(a).dyn()), uint256(1));
+   │                    ━━━━━━━━━━
+   │
+   ├ note: the call returns `bytes memory`, whose size is unknowable without `RETURNDATASIZE`
+   ╰ help: discard the value, or compile with `--evm-version byzantium` or newer
+
+error[6509]: cannot use the dynamically encoded return value of an external call
+   ╭▸ ROOT/tests/ui/typeck/evm_version/inaccessible_dynamic_return.sol:LL:CC
+   │
+LL │         (b, ) = (I(a).dyn(), uint256(1));
+   │                  ━━━━━━━━━━
+   │
+   ├ note: the call returns `bytes memory`, whose size is unknowable without `RETURNDATASIZE`
+   ╰ help: discard the value, or compile with `--evm-version byzantium` or newer
+
+error[6509]: cannot use the dynamically encoded return value of an external call
+   ╭▸ ROOT/tests/ui/typeck/evm_version/inaccessible_dynamic_return.sol:LL:CC
+   │
 LL │         bytes memory b = I(a).dyn();
    │                          ━━━━━━━━━━
    │
@@ -97,5 +115,5 @@ LL │         bytes memory b = L.dyn();
    ├ note: the call returns `bytes memory`, whose size is unknowable without `RETURNDATASIZE`
    ╰ help: discard the value, or compile with `--evm-version byzantium` or newer
 
-error: aborting due to 11 previous errors
+error: aborting due to 13 previous errors
 

--- a/tests/ui/typeck/evm_version/inaccessible_dynamic_return.homestead.stderr
+++ b/tests/ui/typeck/evm_version/inaccessible_dynamic_return.homestead.stderr
@@ -1,0 +1,101 @@
+error[6509]: cannot use the dynamically encoded return value of an external call
+   ╭▸ ROOT/tests/ui/typeck/evm_version/inaccessible_dynamic_return.sol:LL:CC
+   │
+LL │         bytes memory b = I(a).dyn();
+   │                          ━━━━━━━━━━
+   │
+   ├ note: the call returns `bytes memory`, whose size is unknowable without `RETURNDATASIZE`
+   ╰ help: discard the value, or compile with `--evm-version byzantium` or newer
+
+error[6509]: cannot use the dynamically encoded return value of an external call
+   ╭▸ ROOT/tests/ui/typeck/evm_version/inaccessible_dynamic_return.sol:LL:CC
+   │
+LL │         uint256[] memory c = I(a).dynArray();
+   │                              ━━━━━━━━━━━━━━━
+   │
+   ├ note: the call returns `uint256[] memory`, whose size is unknowable without `RETURNDATASIZE`
+   ╰ help: discard the value, or compile with `--evm-version byzantium` or newer
+
+error[6509]: cannot use the dynamically encoded return value of an external call
+   ╭▸ ROOT/tests/ui/typeck/evm_version/inaccessible_dynamic_return.sol:LL:CC
+   │
+LL │         S memory s = I(a).dynStruct();
+   │                      ━━━━━━━━━━━━━━━━
+   │
+   ├ note: the call returns `struct S memory`, whose size is unknowable without `RETURNDATASIZE`
+   ╰ help: discard the value, or compile with `--evm-version byzantium` or newer
+
+error[6509]: cannot use the dynamically encoded return value of an external call
+   ╭▸ ROOT/tests/ui/typeck/evm_version/inaccessible_dynamic_return.sol:LL:CC
+   │
+LL │         bytes[2] memory f = I(a).dynFixed();
+   │                             ━━━━━━━━━━━━━━━
+   │
+   ├ note: the call returns `bytes[2] memory`, whose size is unknowable without `RETURNDATASIZE`
+   ╰ help: discard the value, or compile with `--evm-version byzantium` or newer
+
+error[6509]: cannot use the dynamically encoded return value of an external call
+   ╭▸ ROOT/tests/ui/typeck/evm_version/inaccessible_dynamic_return.sol:LL:CC
+   │
+LL │         return I(a).dyn();
+   │                ━━━━━━━━━━
+   │
+   ├ note: the call returns `bytes memory`, whose size is unknowable without `RETURNDATASIZE`
+   ╰ help: discard the value, or compile with `--evm-version byzantium` or newer
+
+error[6509]: cannot use the dynamically encoded return value of an external call
+   ╭▸ ROOT/tests/ui/typeck/evm_version/inaccessible_dynamic_return.sol:LL:CC
+   │
+LL │         return keccak256(I(a).dyn());
+   │                          ━━━━━━━━━━
+   │
+   ├ note: the call returns `bytes memory`, whose size is unknowable without `RETURNDATASIZE`
+   ╰ help: discard the value, or compile with `--evm-version byzantium` or newer
+
+error[6509]: cannot use the dynamically encoded return value of an external call
+   ╭▸ ROOT/tests/ui/typeck/evm_version/inaccessible_dynamic_return.sol:LL:CC
+   │
+LL │         I(a).dyn().length;
+   │         ━━━━━━━━━━
+   │
+   ├ note: the call returns `bytes memory`, whose size is unknowable without `RETURNDATASIZE`
+   ╰ help: discard the value, or compile with `--evm-version byzantium` or newer
+
+error[6509]: cannot use the dynamically encoded return value of an external call
+   ╭▸ ROOT/tests/ui/typeck/evm_version/inaccessible_dynamic_return.sol:LL:CC
+   │
+LL │         try I(a).dyn() returns (bytes memory b) {
+   │             ━━━━━━━━━━
+   │
+   ├ note: the call returns `bytes memory`, whose size is unknowable without `RETURNDATASIZE`
+   ╰ help: discard the value, or compile with `--evm-version byzantium` or newer
+
+error[6509]: cannot use the dynamically encoded return value of an external call
+   ╭▸ ROOT/tests/ui/typeck/evm_version/inaccessible_dynamic_return.sol:LL:CC
+   │
+LL │         try I(a).mixed() returns (uint256 v, bytes memory b) {
+   │             ━━━━━━━━━━━━
+   │
+   ├ note: the call returns `bytes memory`, whose size is unknowable without `RETURNDATASIZE`
+   ╰ help: discard the value, or compile with `--evm-version byzantium` or newer
+
+error[6509]: cannot use the dynamically encoded return value of an external call
+   ╭▸ ROOT/tests/ui/typeck/evm_version/inaccessible_dynamic_return.sol:LL:CC
+   │
+LL │         bytes memory b = p();
+   │                          ━━━
+   │
+   ├ note: the call returns `bytes memory`, whose size is unknowable without `RETURNDATASIZE`
+   ╰ help: discard the value, or compile with `--evm-version byzantium` or newer
+
+error[6509]: cannot use the dynamically encoded return value of an external call
+   ╭▸ ROOT/tests/ui/typeck/evm_version/inaccessible_dynamic_return.sol:LL:CC
+   │
+LL │         bytes memory b = L.dyn();
+   │                          ━━━━━━━
+   │
+   ├ note: the call returns `bytes memory`, whose size is unknowable without `RETURNDATASIZE`
+   ╰ help: discard the value, or compile with `--evm-version byzantium` or newer
+
+error: aborting due to 11 previous errors
+

--- a/tests/ui/typeck/evm_version/inaccessible_dynamic_return.sol
+++ b/tests/ui/typeck/evm_version/inaccessible_dynamic_return.sol
@@ -1,0 +1,105 @@
+//@ revisions: homestead byzantium
+//@[homestead] compile-flags: --evm-version homestead
+//@[byzantium] compile-flags: --evm-version byzantium
+
+// Before Byzantium there is no `RETURNDATASIZE`, so the size of a dynamically encoded return
+// value is unknowable: the call is legal as long as the value is discarded, and any use of it is
+// rejected. From Byzantium on every use compiles.
+
+struct S {
+    uint256 a;
+    bytes b;
+}
+
+interface I {
+    function dyn() external returns (bytes memory);
+    function dynStruct() external returns (S memory);
+    function dynFixed() external returns (bytes[2] memory);
+    function dynArray() external returns (uint256[] memory);
+    function mixed() external returns (uint256, bytes memory);
+}
+
+library L {
+    function dyn() external returns (bytes memory) {
+        //~[byzantium]^ WARN: function state mutability can be restricted to pure
+        return "x";
+    }
+}
+
+contract C {
+    function discarded(address a) external {
+        I(a).dyn();
+        I(a).dynArray();
+        I(a).dynStruct();
+        I(a).dynFixed();
+        try I(a).dyn() {} catch {}
+        L.dyn();
+        (uint256 v, ) = I(a).mixed();
+        v;
+        function() external returns (bytes memory) pointer = I(a).dyn;
+        pointer();
+    }
+
+    function assigned(address a) external {
+        bytes memory b = I(a).dyn();
+        //~[homestead]^ ERROR: cannot use the dynamically encoded return value of an external call
+        b;
+        uint256[] memory c = I(a).dynArray();
+        //~[homestead]^ ERROR: cannot use the dynamically encoded return value of an external call
+        c;
+    }
+
+    // A struct with a dynamic member and a fixed array of dynamic elements are dynamically
+    // encoded too, through their component types.
+    function aggregates(address a) external returns (uint256) {
+        S memory s = I(a).dynStruct();
+        //~[homestead]^ ERROR: cannot use the dynamically encoded return value of an external call
+        bytes[2] memory f = I(a).dynFixed();
+        //~[homestead]^ ERROR: cannot use the dynamically encoded return value of an external call
+        f;
+        return s.a;
+    }
+
+    function returned(address a) external returns (bytes memory) {
+        return I(a).dyn();
+        //~[homestead]^ ERROR: cannot use the dynamically encoded return value of an external call
+    }
+
+    function argument(address a) external returns (bytes32) {
+        return keccak256(I(a).dyn());
+        //~[homestead]^ ERROR: cannot use the dynamically encoded return value of an external call
+    }
+
+    function member(address a) external {
+        I(a).dyn().length;
+        //~[homestead]^ ERROR: cannot use the dynamically encoded return value of an external call
+    }
+
+    function bound(address a) external {
+        try I(a).dyn() returns (bytes memory b) {
+            //~[homestead]^ ERROR: cannot use the dynamically encoded return value of an external call
+            b;
+        } catch {}
+    }
+
+    function boundMixed(address a) external {
+        try I(a).mixed() returns (uint256 v, bytes memory b) {
+            //~[homestead]^ ERROR: cannot use the dynamically encoded return value of an external call
+            v;
+            b;
+        } catch {}
+    }
+
+    function pointer(address a) external {
+        function() external returns (bytes memory) p = I(a).dyn;
+        bytes memory b = p();
+        //~[homestead]^ ERROR: cannot use the dynamically encoded return value of an external call
+        b;
+    }
+
+    function library_() external {
+        bytes memory b = L.dyn();
+        //~[homestead]^ ERROR: cannot use the dynamically encoded return value of an external call
+        b;
+    }
+}

--- a/tests/ui/typeck/evm_version/inaccessible_dynamic_return.sol
+++ b/tests/ui/typeck/evm_version/inaccessible_dynamic_return.sol
@@ -40,6 +40,29 @@ contract C {
         pointer();
     }
 
+    // A tuple expression statement discards every component, however deeply the tuples nest,
+    // and a tuple assignment discards the components it drops.
+    function discardedTuple(address a) external {
+        (I(a).dyn(), I(a).dynArray());
+        ((I(a).dyn(), I(a).dynStruct()), I(a).dyn());
+        uint256 v;
+        (v, ) = (v, I(a).dyn());
+        (v, ) = I(a).mixed();
+        for (uint256 i = 0; i < 1; I(a).dyn()) {
+            i++;
+        }
+    }
+
+    // A component that is used stays a use, whichever tuple it sits in.
+    function usedInTuple(address a) external {
+        (keccak256(I(a).dyn()), uint256(1));
+        //~[homestead]^ ERROR: cannot use the dynamically encoded return value of an external call
+        bytes memory b;
+        (b, ) = (I(a).dyn(), uint256(1));
+        //~[homestead]^ ERROR: cannot use the dynamically encoded return value of an external call
+        b;
+    }
+
     function assigned(address a) external {
         bytes memory b = I(a).dyn();
         //~[homestead]^ ERROR: cannot use the dynamically encoded return value of an external call

--- a/tests/ui/typeck/evm_version/returned_dynamic_array_without_returndata.homestead.stderr
+++ b/tests/ui/typeck/evm_version/returned_dynamic_array_without_returndata.homestead.stderr
@@ -1,4 +1,4 @@
-error[6509]: cannot use the dynamically encoded return value of an external call
+error[9574]: cannot use the dynamically encoded return value of an external call
    ╭▸ ROOT/tests/ui/typeck/evm_version/returned_dynamic_array_without_returndata.sol:LL:CC
    │
 LL │         uint[][] memory x = this.get();

--- a/tests/ui/typeck/evm_version/returned_dynamic_array_without_returndata.homestead.stderr
+++ b/tests/ui/typeck/evm_version/returned_dynamic_array_without_returndata.homestead.stderr
@@ -1,0 +1,11 @@
+error[6509]: cannot use the dynamically encoded return value of an external call
+   ╭▸ ROOT/tests/ui/typeck/evm_version/returned_dynamic_array_without_returndata.sol:LL:CC
+   │
+LL │         uint[][] memory x = this.get();
+   │                             ━━━━━━━━━━
+   │
+   ├ note: the call returns `uint256[][] memory`, whose size is unknowable without `RETURNDATASIZE`
+   ╰ help: discard the value, or compile with `--evm-version byzantium` or newer
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/typeck/evm_version/returned_dynamic_array_without_returndata.sol
+++ b/tests/ui/typeck/evm_version/returned_dynamic_array_without_returndata.sol
@@ -1,0 +1,16 @@
+//@ revisions: homestead byzantium
+//@[homestead] compile-flags: --evm-version homestead
+//@[byzantium] compile-flags: --evm-version byzantium
+// ported-from: test/libsolidity/syntaxTests/abiEncoder/v2_accessing_returned_dynamic_array_without_returndata_support.sol
+// ported-from: test/libsolidity/syntaxTests/abiEncoder/v2_accessing_returned_dynamic_array_with_returndata_support.sol
+
+pragma abicoder v2;
+
+contract C {
+    function get() public view returns (uint[][] memory) {}
+
+    function test() public view returns (bool) {
+        uint[][] memory x = this.get();
+        //~[homestead]^ ERROR: cannot use the dynamically encoded return value of an external call
+    }
+}

--- a/tests/ui/typeck/try_catch_clause_name.sol
+++ b/tests/ui/typeck/try_catch_clause_name.sol
@@ -1,0 +1,13 @@
+// ported-from: test/libsolidity/syntaxTests/tryCatch/invalid_error_name.sol
+// The upstream test writes the clauses with an empty parameter list, which our parser rejects.
+
+contract C {
+    function f() public returns (uint256, uint256) {
+        try this.f() {
+        } catch Error2(string memory) {
+            //~^ ERROR: invalid catch clause name
+        } catch abc(uint256) {
+            //~^ ERROR: invalid catch clause name
+        }
+    }
+}

--- a/tests/ui/typeck/try_catch_clause_name.stderr
+++ b/tests/ui/typeck/try_catch_clause_name.stderr
@@ -1,0 +1,24 @@
+error[3542]: invalid catch clause name
+   ╭▸ ROOT/tests/ui/typeck/try_catch_clause_name.sol:LL:CC
+   │
+LL │           } catch Error2(string memory) {
+   │ ┏━━━━━━━━━━━┛
+LL │ ┃
+LL │ ┃         } catch abc(uint256) {
+   │ ┗━━━━━━━━━┛
+   │
+   ╰ help: expected `catch (...)`, `catch Error(...)`, or `catch Panic(...)`
+
+error[3542]: invalid catch clause name
+   ╭▸ ROOT/tests/ui/typeck/try_catch_clause_name.sol:LL:CC
+   │
+LL │           } catch abc(uint256) {
+   │ ┏━━━━━━━━━━━┛
+LL │ ┃
+LL │ ┃         }
+   │ ┗━━━━━━━━━┛
+   │
+   ╰ help: expected `catch (...)`, `catch Error(...)`, or `catch Panic(...)`
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
Part of the split of the solc-vs-solar differential audit branch (#1360). Based on #1368 in the stack; the pre-byzantium library tests embed the in-place `bytes` lowering from #1366, and #1369 builds on this PR.

A set of fixes for external calls on the pre-byzantium EVM targets and one for every target. Before byzantium there is no `RETURNDATASIZE`, so solc guards every call with `extcodesize` and reads static returns from an output area; we emitted the guard only for calls without return values and always decoded return data, which made a code-less callee return zeros, rejected bare `catch` blocks, rejected library calls with return values, and rejected calls whose dynamic return value is unused. At homestead we forwarded `gas()`, which a pre-EIP-150 `CALL` rejects, so every call failed; the call gas is now solc's `sub(gas(), reserve)`, evaluated next to the call and kept adjacent to it through an EVM IR `keep_with_next` constraint that tail merging and outlining respect and the verifier enforces. `this.f()` in a helper reached from the constructor skipped the guard at every version, so a deployment solc rejects went through with the call dropped; the bypass now follows the creation call graph. The type checker gains solc's codes for catch clause names and inaccessible dynamic values, and unlinked library placeholders in UI test dumps no longer depend on the checkout path. TangerineWhistle and later bytecode is unchanged except where the finding itself applies, verified over the UI codegen corpus at several versions.
