### PR TITLE
fix(codegen): return library storage pointers as slots

### DIFF
--- a/crates/codegen/src/lower/function/abi_calls.rs
+++ b/crates/codegen/src/lower/function/abi_calls.rs
@@ -4,7 +4,7 @@ use super::*;
 
 impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
     pub(super) fn is_storage_parameter(ty: Ty<'gcx>) -> bool {
-        ty.is_ref_at(DataLocation::Storage) || matches!(ty.peel_refs().kind, TyKind::Mapping(..))
+        ty.encodes_as_slot()
     }
 
     pub(super) fn needs_calldata_materialization(&self, value: ValueId, ty: &AbiType) -> bool {

--- a/crates/codegen/src/lower/function/abi_values.rs
+++ b/crates/codegen/src/lower/function/abi_values.rs
@@ -300,23 +300,23 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
         // data, layout = lower_decode_layout(data, types)
         // first = abi_decode(layout, data)
         // values = [first] | load_multi_return_values(first, ...)
-        let memory_types = types
+        let decoded_types = types
             .iter()
             .copied()
-            .map(|ty| ty.with_loc_if_ref(self.cx.gcx, DataLocation::Memory))
+            .map(|ty| types::TypeLowerer::return_encoding_ty(self.cx.gcx, ty))
             .collect::<Vec<_>>();
-        let (data, layout) = self.lower_abi_decode_layout(data, &memory_types, span)?;
+        let (data, layout) = self.lower_abi_decode_layout(data, &decoded_types, span)?;
         let layout = self.cx.module.intern_abi_param_layout(layout);
         let first = self.builder.abi_decode(layout, data);
-        if memory_types.len() == 1 {
+        if decoded_types.len() == 1 {
             return Some(vec![first]);
         }
         let base = self.multi_return_buffer_base();
         Some(self.load_multi_return_values(
             first,
             base,
-            memory_types.len(),
-            memory_types.iter().skip(1).copied().map(Some),
+            decoded_types.len(),
+            decoded_types.iter().skip(1).copied().map(Some),
         ))
     }
 

--- a/crates/codegen/src/lower/function/values.rs
+++ b/crates/codegen/src/lower/function/values.rs
@@ -151,8 +151,71 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
                 })
                 .collect();
         }
+        if self.returns.len() > 1 {
+            let returns = self.returns.clone();
+            let source_types = self.multi_value_types(expr);
+            let values = self.lower_values(expr)?;
+            let Some(source_types) = source_types
+                .filter(|types| types.len() == values.len() && values.len() == returns.len())
+            else {
+                return Some(values);
+            };
+            return values
+                .into_iter()
+                .zip(source_types)
+                .zip(returns)
+                .map(|((value, source_ty), id)| {
+                    let target_ty = self.cx.gcx.type_of_item(id.into());
+                    self.convert_return_component(value, source_ty, target_ty, expr.span)
+                })
+                .collect();
+        }
 
         self.lower_values(expr)
+    }
+
+    /// The component types of an expression that produces several values, such as a call to a
+    /// function with several returns.
+    fn multi_value_types(&self, expr: &hir::Expr<'_>) -> Option<Vec<Ty<'gcx>>> {
+        let TyKind::Tuple(types) = self.cx.gcx.type_of_expr(expr.peel_parens().id)?.kind else {
+            return None;
+        };
+        Some(types.to_vec())
+    }
+
+    /// Converts one already-lowered component of a multi-value return source to the type the
+    /// enclosing function declares for it.
+    fn convert_return_component(
+        &mut self,
+        value: ValueId,
+        source_ty: Ty<'gcx>,
+        target_ty: Ty<'gcx>,
+        span: Span,
+    ) -> Option<ValueId> {
+        // A storage reference is its slot in both the source and the declared return, so the
+        // value already has the right shape.
+        if target_ty.is_ref_at(DataLocation::Storage) {
+            return Some(value);
+        }
+        // A component the callee returned as a storage reference arrives as the slot word, which
+        // is not a memory pointer; copy the object out of storage instead of returning the slot.
+        // object = load_storage_object(target_ty, slot)
+        if source_ty.is_ref_at(DataLocation::Storage)
+            && self.types.memory_layout(target_ty).is_some()
+        {
+            return self.load_storage_object(target_ty, value, span);
+        }
+        let value = if target_ty.is_ref_at(DataLocation::Memory) {
+            self.materialize_memory_argument(target_ty, value, span)?
+        } else {
+            value
+        };
+        // value = coerce(value, source_ty, target_ty)
+        Some(if source_ty == target_ty {
+            value
+        } else {
+            self.coerce_value(value, source_ty, target_ty)
+        })
     }
 
     pub(super) fn lower_tuple_assignment<'hir>(

--- a/crates/codegen/src/lower/function/values.rs
+++ b/crates/codegen/src/lower/function/values.rs
@@ -158,7 +158,10 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
             let Some(source_types) = source_types
                 .filter(|types| types.len() == values.len() && values.len() == returns.len())
             else {
-                return Some(values);
+                // Without one source type per lowered value per declared return there is no way
+                // to tell which value needs which conversion, and a storage reference among them
+                // would travel on as a raw slot word.
+                return self.cx.report_unsupported(expr.span, "return value arity");
             };
             return values
                 .into_iter()
@@ -200,9 +203,12 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
         // A component the callee returned as a storage reference arrives as the slot word, which
         // is not a memory pointer; copy the object out of storage instead of returning the slot.
         // object = load_storage_object(target_ty, slot)
-        if source_ty.is_ref_at(DataLocation::Storage)
-            && self.types.memory_layout(target_ty).is_some()
-        {
+        if source_ty.is_ref_at(DataLocation::Storage) {
+            // A target without a memory layout has nowhere to hold the copy, so there is no
+            // conversion to emit and the slot word must not be handed on as a memory pointer.
+            if self.types.memory_layout(target_ty).is_none() {
+                return self.cx.report_unsupported(span, "storage reference return");
+            }
             return self.load_storage_object(target_ty, value, span);
         }
         let value = if target_ty.is_ref_at(DataLocation::Memory) {

--- a/crates/codegen/src/lower/function/values.rs
+++ b/crates/codegen/src/lower/function/values.rs
@@ -84,7 +84,7 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
                     let return_types = return_types
                         .iter()
                         .skip(1)
-                        .map(|ty| Some(ty.with_loc_if_ref(gcx, DataLocation::Memory)));
+                        .map(|&ty| Some(types::TypeLowerer::return_encoding_ty(gcx, ty)));
                     return Some(self.load_multi_return_values(first, base, returns, return_types));
                 }
                 return Some(self.load_internal_return_values(first, &return_types));

--- a/crates/codegen/src/lower/types.rs
+++ b/crates/codegen/src/lower/types.rs
@@ -86,24 +86,36 @@ impl<'gcx> TypeLowerer<'gcx> {
         self.abi_type_inner(ty, ty.loc().unwrap_or(DataLocation::Memory))
     }
 
-    /// Builds the ABI shape of a return value, which is always encoded from
-    /// memory even when its source HIR type names calldata.
+    /// Returns the type a return value is encoded from and decoded into.
+    ///
+    /// A reference return is encoded from memory even when its source HIR type names calldata,
+    /// except for a storage reference, which keeps its location and travels as its slot word.
+    pub(super) fn return_encoding_ty(gcx: Gcx<'gcx>, ty: Ty<'gcx>) -> Ty<'gcx> {
+        if ty.encodes_as_slot() {
+            return ty;
+        }
+        ty.with_loc_if_ref(gcx, DataLocation::Memory)
+    }
+
+    /// Builds the ABI shape of a return value.
+    ///
+    /// A storage reference is one word holding its slot number.
     pub(super) fn abi_return_type(&mut self, ty: Ty<'gcx>) -> Option<AbiType> {
+        if ty.encodes_as_slot() {
+            return Some(AbiType::Word(None));
+        }
         self.abi_type(ty.with_loc_if_ref(self.gcx, DataLocation::Memory))
     }
 
     /// Builds the ABI return shape while retaining scalar MIR types for the ABI phase.
     pub(super) fn abi_return_param_type(&mut self, ty: Ty<'gcx>) -> Option<AbiParamType> {
-        self.abi_param_type(ty.with_loc_if_ref(self.gcx, DataLocation::Memory))
+        self.abi_param_type(Self::return_encoding_ty(self.gcx, ty))
     }
 
     /// Builds both ABI shapes for a return value in one recursive walk.
     pub(super) fn abi_return_shapes(&mut self, ty: Ty<'gcx>) -> Option<(AbiType, AbiParamType)> {
         self.seen_structs.clear();
-        self.abi_return_shapes_inner(
-            ty.with_loc_if_ref(self.gcx, DataLocation::Memory),
-            DataLocation::Memory,
-        )
+        self.abi_return_shapes_inner(Self::return_encoding_ty(self.gcx, ty), DataLocation::Memory)
     }
 
     /// Returns the semantic object layout for a memory-backed aggregate.
@@ -144,8 +156,7 @@ impl<'gcx> TypeLowerer<'gcx> {
         ty: Ty<'gcx>,
         location: DataLocation,
     ) -> Option<AbiParamType> {
-        if ty.is_ref_at(DataLocation::Storage) || matches!(ty.peel_refs().kind, TyKind::Mapping(..))
-        {
+        if ty.encodes_as_slot() {
             return Some(AbiParamType::Scalar(MirType::StoragePtr));
         }
         Some(match ty.peel_refs().kind {
@@ -211,12 +222,10 @@ impl<'gcx> TypeLowerer<'gcx> {
         ty: Ty<'gcx>,
         location: DataLocation,
     ) -> Option<(AbiType, AbiParamType)> {
-        let param_ty = ty.with_loc_if_ref(self.gcx, location);
-        if param_ty.is_ref_at(DataLocation::Storage)
-            || matches!(param_ty.peel_refs().kind, TyKind::Mapping(..))
-        {
+        if ty.encodes_as_slot() {
             return Some((AbiType::Word(None), AbiParamType::Scalar(MirType::StoragePtr)));
         }
+        let param_ty = ty.with_loc_if_ref(self.gcx, location);
 
         Some(match ty.peel_refs().kind {
             TyKind::Elementary(ElementaryType::String | ElementaryType::Bytes) => {

--- a/crates/sema/src/ty/ty.rs
+++ b/crates/sema/src/ty/ty.rs
@@ -542,6 +542,16 @@ impl<'gcx> Ty<'gcx> {
         )
     }
 
+    /// Returns `true` if the type crosses an ABI boundary as its storage slot number, as solc's
+    /// `ArrayType::encodingType`, `StructType::encodingType` and `MappingType::encodingType`.
+    ///
+    /// Such a value is a single static word in both directions, so it is neither dynamically
+    /// encoded nor encoded from memory.
+    pub fn encodes_as_slot(self) -> bool {
+        self.is_ref_at(DataLocation::Storage)
+            || matches!(self.peel_refs().kind, TyKind::Mapping(..))
+    }
+
     /// Returns `true` if the type's ABI encoding carries a tail, as solc's
     /// `Type::isDynamicallyEncoded`.
     ///

--- a/crates/sema/src/typeck/checker/mod.rs
+++ b/crates/sema/src/typeck/checker/mod.rs
@@ -1292,8 +1292,9 @@ impl<'gcx> TypeChecker<'gcx> {
             return Ok(());
         }
         for (index, ty) in f.returns.iter().enumerate() {
-            // A storage reference is decoded as its slot number
-            // (`ReferenceType::decodingType`), so it stays accessible at every version.
+            // A storage reference is decoded as its slot number (`ArrayType::decodingType`,
+            // and `Type::decodingType` through `encodingType` for structs and mappings), so it
+            // stays accessible at every version.
             if ty.encodes_as_slot()
                 || !ty.is_dynamically_encoded(self.gcx)
                 || matches!(discarded, Some(Discarded::Components(components)) if components.contains(index))

--- a/crates/sema/src/typeck/checker/mod.rs
+++ b/crates/sema/src/typeck/checker/mod.rs
@@ -99,6 +99,17 @@ enum ValuePosition {
     TryReturns,
 }
 
+/// How a variable reaches the variable checks, which decides who owns its initializer.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum VarSource {
+    /// The variable is checked on its own and carries its initializer, if it has one.
+    Standalone,
+    /// The variable is one target of a declaration statement whose initializer the caller has
+    /// already checked. A destructuring target has no initializer of its own, because the
+    /// initializer belongs to the statement rather than to any one target.
+    DeclStatement,
+}
+
 /// The components of an expression's value that a statement discards.
 enum Discarded {
     /// The whole value, as in an expression statement or a `try` without a `returns` clause.
@@ -2505,11 +2516,11 @@ impl<'gcx> TypeChecker<'gcx> {
 
     #[must_use]
     fn check_var(&mut self, id: hir::VariableId) -> Ty<'gcx> {
-        self.check_var_(id, true)
+        self.check_var_(id, VarSource::Standalone)
     }
 
     #[must_use]
-    fn check_var_(&mut self, id: hir::VariableId, expect: bool) -> Ty<'gcx> {
+    fn check_var_(&mut self, id: hir::VariableId, source: VarSource) -> Ty<'gcx> {
         let var = self.gcx.hir.variable(id);
         let _ = self.visit_ty(&var.ty);
         let ty = self.gcx.type_of_item(id.into());
@@ -2527,7 +2538,7 @@ impl<'gcx> TypeChecker<'gcx> {
                     var.span,
                     "types in storage containing (nested) mappings cannot be assigned to",
                 );
-            } else if expect {
+            } else if source == VarSource::Standalone {
                 let _ = if var.is_state_variable() {
                     self.with_construction_context(|this| {
                         let init_ty = this.check_expr_with_noexpect(init, Some(ty));
@@ -2572,9 +2583,12 @@ impl<'gcx> TypeChecker<'gcx> {
             );
         }
 
-        // Uninitialized local mapping variables are invalid (error 4182).
+        // Uninitialized local mapping variables are invalid (error 4182). A destructuring
+        // target's initializer belongs to the declaration statement, so only a standalone
+        // declaration without one is uninitialized.
         if var.kind == hir::VarKind::Statement
             && var.initializer.is_none()
+            && source == VarSource::Standalone
             && matches!(ty.peel_refs().kind, TyKind::Mapping(..))
         {
             self.dcx()
@@ -2681,7 +2695,7 @@ impl<'gcx> TypeChecker<'gcx> {
         };
         for ((&var, &ty), &expr) in decls.iter().zip(value_types).zip(exprs) {
             let (Some(var), Some(expr)) = (var, expr) else { continue };
-            let var_ty = self.check_var_(var, false);
+            let var_ty = self.check_var_(var, VarSource::DeclStatement);
             let _ = self.check_expected(expr, ty, var_ty);
         }
         // TODO: checks from https://github.com/ethereum/solidity/blob/9d7cc42bc1c12bb43e9dccf8c6c36833fdfcbbca/libsolidity/analysis/TypeChecker.cpp#L1219

--- a/crates/sema/src/typeck/checker/mod.rs
+++ b/crates/sema/src/typeck/checker/mod.rs
@@ -1292,7 +1292,10 @@ impl<'gcx> TypeChecker<'gcx> {
             return Ok(());
         }
         for (index, ty) in f.returns.iter().enumerate() {
-            if !ty.is_dynamically_encoded(self.gcx)
+            // A storage reference is decoded as its slot number
+            // (`ReferenceType::decodingType`), so it stays accessible at every version.
+            if ty.encodes_as_slot()
+                || !ty.is_dynamically_encoded(self.gcx)
                 || matches!(discarded, Some(Discarded::Components(components)) if components.contains(index))
             {
                 continue;

--- a/tests/foundry/library-storage-pointers/foundry.toml
+++ b/tests/foundry/library-storage-pointers/foundry.toml
@@ -1,0 +1,4 @@
+[profile.default]
+src = "src"
+out = "out"
+libs = ["lib"]

--- a/tests/foundry/library-storage-pointers/foundry.toml
+++ b/tests/foundry/library-storage-pointers/foundry.toml
@@ -2,3 +2,4 @@
 src = "src"
 out = "out"
 libs = ["lib"]
+optimizer = false

--- a/tests/foundry/library-storage-pointers/src/StoragePointerLib.sol
+++ b/tests/foundry/library-storage-pointers/src/StoragePointerLib.sol
@@ -9,6 +9,11 @@ library StoragePointerLib {
         uint256 b;
     }
 
+    struct Nested {
+        uint256[] arr;
+        mapping(uint256 => uint256[]) byKey;
+    }
+
     function arrRef(uint256[] storage a) external pure returns (uint256[] storage) {
         return a;
     }
@@ -28,6 +33,19 @@ library StoragePointerLib {
     function firstOf(uint256[] storage a) external view returns (uint256) {
         return a[0];
     }
+
+    // A pointer to a nested object is one slot word too.
+    function memberArr(Nested storage n) external view returns (uint256[] storage) {
+        return n.arr;
+    }
+
+    function valueArr(Nested storage n, uint256 key) external view returns (uint256[] storage) {
+        return n.byKey[key];
+    }
+
+    function element(uint256[][] storage aa, uint256 i) external view returns (uint256[] storage) {
+        return aa[i];
+    }
 }
 
 contract StoragePointers {
@@ -36,6 +54,8 @@ contract StoragePointers {
     uint256[] internal nums;
     bytes internal bs;
     StoragePointerLib.Plain internal plain;
+    StoragePointerLib.Nested internal nested;
+    uint256[][] internal grid;
     uint256 internal guard;
 
     constructor() {
@@ -44,6 +64,11 @@ contract StoragePointers {
         bs = hex"aabbcc";
         plain.a = 11;
         plain.b = 12;
+        nested.arr.push(4);
+        nested.byKey[1].push(6);
+        grid.push();
+        grid[0].push(1);
+        grid[0].push(2);
         guard = 77;
     }
 
@@ -98,5 +123,28 @@ contract StoragePointers {
     function attachedPush(uint256 v) external returns (uint256, uint256) {
         nums.arrRef().push(v);
         return (nums.length, guard);
+    }
+
+    function memberArrLen() external view returns (uint256) {
+        return StoragePointerLib.memberArr(nested).length;
+    }
+
+    function memberWrite(uint256 i, uint256 v) external returns (uint256, uint256) {
+        StoragePointerLib.memberArr(nested)[i] = v;
+        return (nested.arr[i], guard);
+    }
+
+    function valuePush(uint256 key, uint256 v) external returns (uint256, uint256) {
+        StoragePointerLib.valueArr(nested, key).push(v);
+        return (nested.byKey[key].length, guard);
+    }
+
+    function valueFirst(uint256 key) external view returns (uint256) {
+        return StoragePointerLib.valueArr(nested, key)[0];
+    }
+
+    function gridPop() external returns (uint256, uint256) {
+        StoragePointerLib.element(grid, 0).pop();
+        return (grid[0].length, guard);
     }
 }

--- a/tests/foundry/library-storage-pointers/src/StoragePointerLib.sol
+++ b/tests/foundry/library-storage-pointers/src/StoragePointerLib.sol
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+// A storage reference crosses an external library call boundary as its slot number, in both
+// directions. The expected values below are solc's.
+library StoragePointerLib {
+    struct Plain {
+        uint256 a;
+        uint256 b;
+    }
+
+    function arrRef(uint256[] storage a) external pure returns (uint256[] storage) {
+        return a;
+    }
+
+    function bytesRef(bytes storage b) external pure returns (bytes storage) {
+        return b;
+    }
+
+    function plainRef(Plain storage p) external pure returns (Plain storage) {
+        return p;
+    }
+
+    function pairRef(uint256[] storage a) external view returns (uint256, uint256[] storage) {
+        return (a.length, a);
+    }
+
+    function firstOf(uint256[] storage a) external view returns (uint256) {
+        return a[0];
+    }
+}
+
+contract StoragePointers {
+    using StoragePointerLib for uint256[];
+
+    uint256[] internal nums;
+    bytes internal bs;
+    StoragePointerLib.Plain internal plain;
+    uint256 internal guard;
+
+    constructor() {
+        nums.push(5);
+        nums.push(9);
+        bs = hex"aabbcc";
+        plain.a = 11;
+        plain.b = 12;
+        guard = 77;
+    }
+
+    function len() external view returns (uint256) {
+        return StoragePointerLib.arrRef(nums).length;
+    }
+
+    function sum() external view returns (uint256 s) {
+        uint256[] storage r = StoragePointerLib.arrRef(nums);
+        for (uint256 i; i < r.length; i++) {
+            s += r[i];
+        }
+    }
+
+    function pushThrough(uint256 v) external returns (uint256, uint256) {
+        StoragePointerLib.arrRef(nums).push(v);
+        return (nums.length, guard);
+    }
+
+    function bytesLen() external view returns (uint256) {
+        return StoragePointerLib.bytesRef(bs).length;
+    }
+
+    function bytesPushThrough(uint256 v) external returns (uint256, uint256) {
+        StoragePointerLib.bytesRef(bs).push(bytes1(uint8(v)));
+        return (bs.length, guard);
+    }
+
+    function members() external view returns (uint256, uint256) {
+        StoragePointerLib.Plain storage p = StoragePointerLib.plainRef(plain);
+        return (p.a, p.b);
+    }
+
+    function writeMember(uint256 v) external returns (uint256, uint256) {
+        StoragePointerLib.plainRef(plain).b = v;
+        return (plain.b, guard);
+    }
+
+    function pair() external view returns (uint256, uint256) {
+        (uint256 n, uint256[] storage r) = StoragePointerLib.pairRef(nums);
+        return (n, r.length);
+    }
+
+    function chained() external view returns (uint256) {
+        return StoragePointerLib.firstOf(StoragePointerLib.arrRef(nums));
+    }
+
+    function attachedLen() external view returns (uint256) {
+        return nums.arrRef().length;
+    }
+
+    function attachedPush(uint256 v) external returns (uint256, uint256) {
+        nums.arrRef().push(v);
+        return (nums.length, guard);
+    }
+}

--- a/tests/foundry/library-storage-pointers/test/StoragePointerLib.t.sol
+++ b/tests/foundry/library-storage-pointers/test/StoragePointerLib.t.sol
@@ -63,6 +63,29 @@ contract StoragePointersTest {
         assert(c.attachedLen() == 2);
     }
 
+    function test_memberArrLen() public view {
+        assert(c.memberArrLen() == 1);
+    }
+
+    function test_memberWrite() public {
+        (uint256 v, uint256 guard) = c.memberWrite(0, 9);
+        assert(v == 9);
+        assert(guard == 77);
+    }
+
+    function test_valuePush() public {
+        (uint256 length, uint256 guard) = c.valuePush(1, 8);
+        assert(length == 2);
+        assert(guard == 77);
+        assert(c.valueFirst(1) == 6);
+    }
+
+    function test_gridPop() public {
+        (uint256 length, uint256 guard) = c.gridPop();
+        assert(length == 1);
+        assert(guard == 77);
+    }
+
     function test_attachedPush() public {
         (uint256 length, uint256 guard) = c.attachedPush(7);
         assert(length == 3);

--- a/tests/foundry/library-storage-pointers/test/StoragePointerLib.t.sol
+++ b/tests/foundry/library-storage-pointers/test/StoragePointerLib.t.sol
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "../src/StoragePointerLib.sol";
+
+contract StoragePointersTest {
+    StoragePointers internal c;
+
+    function setUp() public {
+        c = new StoragePointers();
+    }
+
+    function test_len() public view {
+        assert(c.len() == 2);
+    }
+
+    function test_sum() public view {
+        assert(c.sum() == 14);
+    }
+
+    function test_pushThrough() public {
+        (uint256 length, uint256 guard) = c.pushThrough(3);
+        assert(length == 3);
+        assert(guard == 77);
+        assert(c.len() == 3);
+        assert(c.sum() == 17);
+    }
+
+    function test_bytesLen() public view {
+        assert(c.bytesLen() == 3);
+    }
+
+    function test_bytesPushThrough() public {
+        (uint256 length, uint256 guard) = c.bytesPushThrough(0xdd);
+        assert(length == 4);
+        assert(guard == 77);
+        assert(c.bytesLen() == 4);
+    }
+
+    function test_members() public view {
+        (uint256 a, uint256 b) = c.members();
+        assert(a == 11);
+        assert(b == 12);
+    }
+
+    function test_writeMember() public {
+        (uint256 b, uint256 guard) = c.writeMember(99);
+        assert(b == 99);
+        assert(guard == 77);
+    }
+
+    function test_pair() public view {
+        (uint256 n, uint256 length) = c.pair();
+        assert(n == 2);
+        assert(length == 2);
+    }
+
+    function test_chained() public view {
+        assert(c.chained() == 5);
+    }
+
+    function test_attachedLen() public view {
+        assert(c.attachedLen() == 2);
+    }
+
+    function test_attachedPush() public {
+        (uint256 length, uint256 guard) = c.attachedPush(7);
+        assert(length == 3);
+        assert(guard == 77);
+        assert(c.attachedLen() == 3);
+    }
+}

--- a/tests/ui/abi/library_storage_params.sol
+++ b/tests/ui/abi/library_storage_params.sol
@@ -54,6 +54,30 @@ library L {
         return a;
     }
 
+    // A mapping is storage-only, so returning one is omitted as well. The ABI printer never
+    // sees the mapping type.
+    function mappingReturn(Set storage s)
+        external
+        view
+        returns (mapping(uint256 => uint256) storage)
+    {
+        return s.idx;
+    }
+
+    // A struct holding a mapping is storage-only in both directions.
+    function setReturn(Set storage s) external pure returns (Set storage) {
+        return s;
+    }
+
+    // A bare mapping parameter with a mapping return is the same case without a struct.
+    function mapOf(mapping(uint256 => uint256) storage m)
+        external
+        pure
+        returns (mapping(uint256 => uint256) storage)
+    {
+        return m;
+    }
+
     function ext(uint256 x) external pure returns (uint256) {
         return x;
     }

--- a/tests/ui/abi/library_storage_params.stdout
+++ b/tests/ui/abi/library_storage_params.stdout
@@ -51,12 +51,15 @@
       "hashes": {
         "arrParam(uint256[] storage)": "75803ad4",
         "ext(uint256)": "0be5edb6",
+        "mapOf(mapping(uint256 => uint256) storage)": "72e37e63",
         "mappingParam(mapping(uint256 => uint256) storage)": "8aa88f55",
+        "mappingReturn(L.Set storage)": "3449bda1",
         "memStruct(L.Plain)": "e6d09e6b",
         "nestedParam(L.Nested storage)": "5971f431",
         "plainStruct(L.Plain storage)": "2d886fae",
         "pubParam(L.Set storage)": "35d8e2b3",
         "setArrParam(L.Set[] storage)": "d1723c79",
+        "setReturn(L.Set storage)": "40190381",
         "storageReturn(uint256[] storage)": "c37e2c8e",
         "withMapping(L.Set storage)": "6bd4ab76"
       }

--- a/tests/ui/codegen/lowering/library_storage_pointer_return.homestead.stdout
+++ b/tests/ui/codegen/lowering/library_storage_pointer_return.homestead.stdout
@@ -1,0 +1,175 @@
+// === ROOT/tests/ui/codegen/lowering/library_storage_pointer_return.sol:Lib ===
+@module Lib
+fn @arrRef(arg0: storageptr) -> storageptr [selector=0x1fbd3e50, pure, abi_params=[storageptr], abi_returns=[word]] {
+  bb0:
+    ret arg0
+}
+
+fn @bytesRef(arg0: storageptr) -> storageptr [selector=0x4d5b8d56, pure, abi_params=[storageptr], abi_returns=[word]] {
+  bb0:
+    ret arg0
+}
+
+fn @plainRef(arg0: storageptr) -> storageptr [selector=0xd4ba1053, pure, abi_params=[storageptr], abi_returns=[word]] {
+  bb0:
+    ret arg0
+}
+
+fn @pairRef(arg0: storageptr) -> (u256, storageptr) [selector=0x4a3c24da, view, abi_params=[storageptr], abi_returns=[word, word]] {
+  bb0:
+    v0 = sload arg0 !metadata(storage=symbolic(arg0))
+    ret v0, arg0
+}
+
+// === ROOT/tests/ui/codegen/lowering/library_storage_pointer_return.sol:C ===
+@module C
+fn @len() -> u256 [selector=0x56d88e27, view, abi_params=[], abi_returns=[word]] {
+  bb0:
+    v0 = abi_encode [word], selector 0x1fbd3e5000000000000000000000000000000000000000000000000000000000, args 0
+    v1 = slice_ptr v0
+    v2 = slice_len v0
+    v3 = extcodesize 0x1111111111111111111111111111111111111111
+    v4 = iszero v3
+    jumpi v4, bb1, bb2
+  bb2:
+    v5 = gas
+    v6 = sub v5, 50
+    v7 = delegatecall v6, 0x1111111111111111111111111111111111111111, v1, v2, 0, 32
+    jumpi v7, bb4, bb3
+  bb3:
+    revert_returndata
+  bb4:
+    v8 = add 0, 0
+    v9 = mload v8
+    v10 = add 0, 0
+    v11 = mload v10
+    v12 = sload v11 !metadata(storage=symbolic(v11))
+    ret v12
+  bb1:
+    revert 0, 0
+}
+
+fn @bytesLen() -> u256 [selector=0x6a4634a6, view, abi_params=[], abi_returns=[word]] {
+  bb0:
+    v0 = abi_encode [word], selector 0x4d5b8d5600000000000000000000000000000000000000000000000000000000, args 1
+    v1 = slice_ptr v0
+    v2 = slice_len v0
+    v3 = extcodesize 0x1111111111111111111111111111111111111111
+    v4 = iszero v3
+    jumpi v4, bb1, bb2
+  bb2:
+    v5 = gas
+    v6 = sub v5, 50
+    v7 = delegatecall v6, 0x1111111111111111111111111111111111111111, v1, v2, 0, 32
+    jumpi v7, bb4, bb3
+  bb3:
+    revert_returndata
+  bb4:
+    v8 = add 0, 0
+    v9 = mload v8
+    v10 = add 0, 0
+    v11 = mload v10
+    v12 = sload v11 !metadata(storage=symbolic(v11))
+    v13 = and v12, 1
+    v14 = eq v13, 1
+    v15 = shr 1, v12
+    v16 = and v15, 127
+    v17 = select v14, v15, v16
+    v18 = lt v17, 32
+    v19 = eq v14, v18
+    jumpi v19, bb5, bb6
+  bb6:
+    ret v17
+  bb5:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 34 !metadata(memory=scratch)
+    revert 0, 36
+  bb1:
+    revert 0, 0
+}
+
+fn @member() -> u256 [selector=0xe3f6b544, view, abi_params=[], abi_returns=[word]] {
+  bb0:
+    v0 = abi_encode [word], selector 0xd4ba105300000000000000000000000000000000000000000000000000000000, args 2
+    v1 = slice_ptr v0
+    v2 = slice_len v0
+    v3 = extcodesize 0x1111111111111111111111111111111111111111
+    v4 = iszero v3
+    jumpi v4, bb1, bb2
+  bb2:
+    v5 = gas
+    v6 = sub v5, 50
+    v7 = delegatecall v6, 0x1111111111111111111111111111111111111111, v1, v2, 0, 32
+    jumpi v7, bb4, bb3
+  bb3:
+    revert_returndata
+  bb4:
+    v8 = add 0, 0
+    v9 = mload v8
+    v10 = add 0, 0
+    v11 = mload v10
+    v12 = sload v11 !metadata(storage=symbolic(v11))
+    ret v12
+  bb1:
+    revert 0, 0
+}
+
+fn @pair() -> (u256, u256) [selector=0xa8aa1b31, view, abi_params=[], abi_returns=[word, word]] {
+  bb0:
+    v0 = abi_encode [word], selector 0x4a3c24da00000000000000000000000000000000000000000000000000000000, args 0
+    v1 = slice_ptr v0
+    v2 = slice_len v0
+    v3 = alloc raw, exact, uninitialized, infallible, 64
+    v4 = add v3, 32
+    mstore v4, 0
+    v5 = extcodesize 0x1111111111111111111111111111111111111111
+    v6 = iszero v5
+    jumpi v6, bb1, bb2
+  bb2:
+    v7 = gas
+    v8 = sub v7, 50
+    v9 = delegatecall v8, 0x1111111111111111111111111111111111111111, v1, v2, v3, 64
+    jumpi v9, bb4, bb3
+  bb3:
+    revert_returndata
+  bb4:
+    v10 = add v3, 0
+    v11 = mload v10
+    v12 = add v3, 32
+    v13 = mload v12
+    frame_store multi_return, word, 0, v3 !metadata(memory=scratch)
+    v14 = add v3, 0
+    v15 = mload v14
+    v16 = frame_load multi_return, word, 0 !metadata(memory=scratch)
+    v17 = memory_object_load_element memoryfixedarray<2, 1>, v16, 1
+    v18 = sload v17 !metadata(storage=symbolic(v17))
+    ret v15, v18
+  bb1:
+    revert 0, 0
+}
+
+fn @attached() -> u256 [selector=0xd9e6b370, view, abi_params=[], abi_returns=[word]] {
+  bb0:
+    v0 = abi_encode [word], selector 0x1fbd3e5000000000000000000000000000000000000000000000000000000000, args 0
+    v1 = slice_ptr v0
+    v2 = slice_len v0
+    v3 = extcodesize 0x1111111111111111111111111111111111111111
+    v4 = iszero v3
+    jumpi v4, bb1, bb2
+  bb2:
+    v5 = gas
+    v6 = sub v5, 50
+    v7 = delegatecall v6, 0x1111111111111111111111111111111111111111, v1, v2, 0, 32
+    jumpi v7, bb4, bb3
+  bb3:
+    revert_returndata
+  bb4:
+    v8 = add 0, 0
+    v9 = mload v8
+    v10 = add 0, 0
+    v11 = mload v10
+    v12 = sload v11 !metadata(storage=symbolic(v11))
+    ret v12
+  bb1:
+    revert 0, 0
+}

--- a/tests/ui/codegen/lowering/library_storage_pointer_return.homestead.stdout
+++ b/tests/ui/codegen/lowering/library_storage_pointer_return.homestead.stdout
@@ -34,14 +34,14 @@ fn @len() -> u256 [selector=0x56d88e27, view, abi_params=[], abi_returns=[word]]
   bb2:
     v5 = gas
     v6 = sub v5, 50
-    v7 = delegatecall v6, 0x1111111111111111111111111111111111111111, v1, v2, 0, 32
+    v7 = delegatecall v6, 0x1111111111111111111111111111111111111111, v1, v2, v1, 32
     jumpi v7, bb4, bb3
   bb3:
     revert_returndata
   bb4:
-    v8 = add 0, 0
+    v8 = add v1, 0
     v9 = mload v8
-    v10 = add 0, 0
+    v10 = add v1, 0
     v11 = mload v10
     v12 = sload v11 !metadata(storage=symbolic(v11))
     ret v12
@@ -60,14 +60,14 @@ fn @bytesLen() -> u256 [selector=0x6a4634a6, view, abi_params=[], abi_returns=[w
   bb2:
     v5 = gas
     v6 = sub v5, 50
-    v7 = delegatecall v6, 0x1111111111111111111111111111111111111111, v1, v2, 0, 32
+    v7 = delegatecall v6, 0x1111111111111111111111111111111111111111, v1, v2, v1, 32
     jumpi v7, bb4, bb3
   bb3:
     revert_returndata
   bb4:
-    v8 = add 0, 0
+    v8 = add v1, 0
     v9 = mload v8
-    v10 = add 0, 0
+    v10 = add v1, 0
     v11 = mload v10
     v12 = sload v11 !metadata(storage=symbolic(v11))
     v13 = and v12, 1
@@ -99,14 +99,14 @@ fn @member() -> u256 [selector=0xe3f6b544, view, abi_params=[], abi_returns=[wor
   bb2:
     v5 = gas
     v6 = sub v5, 50
-    v7 = delegatecall v6, 0x1111111111111111111111111111111111111111, v1, v2, 0, 32
+    v7 = delegatecall v6, 0x1111111111111111111111111111111111111111, v1, v2, v1, 32
     jumpi v7, bb4, bb3
   bb3:
     revert_returndata
   bb4:
-    v8 = add 0, 0
+    v8 = add v1, 0
     v9 = mload v8
-    v10 = add 0, 0
+    v10 = add v1, 0
     v11 = mload v10
     v12 = sload v11 !metadata(storage=symbolic(v11))
     ret v12
@@ -119,32 +119,29 @@ fn @pair() -> (u256, u256) [selector=0xa8aa1b31, view, abi_params=[], abi_return
     v0 = abi_encode [word], selector 0x4a3c24da00000000000000000000000000000000000000000000000000000000, args 0
     v1 = slice_ptr v0
     v2 = slice_len v0
-    v3 = alloc raw, exact, uninitialized, infallible, 64
-    v4 = add v3, 32
-    mstore v4, 0
-    v5 = extcodesize 0x1111111111111111111111111111111111111111
-    v6 = iszero v5
-    jumpi v6, bb1, bb2
+    v3 = extcodesize 0x1111111111111111111111111111111111111111
+    v4 = iszero v3
+    jumpi v4, bb1, bb2
   bb2:
-    v7 = gas
-    v8 = sub v7, 50
-    v9 = delegatecall v8, 0x1111111111111111111111111111111111111111, v1, v2, v3, 64
-    jumpi v9, bb4, bb3
+    v5 = gas
+    v6 = sub v5, 50
+    v7 = delegatecall v6, 0x1111111111111111111111111111111111111111, v1, v2, v1, 64
+    jumpi v7, bb4, bb3
   bb3:
     revert_returndata
   bb4:
-    v10 = add v3, 0
+    v8 = add v1, 0
+    v9 = mload v8
+    v10 = add v1, 32
     v11 = mload v10
-    v12 = add v3, 32
+    frame_store multi_return, word, 0, v1 !metadata(memory=scratch)
+    v12 = add v1, 0
     v13 = mload v12
-    frame_store multi_return, word, 0, v3 !metadata(memory=scratch)
-    v14 = add v3, 0
-    v15 = mload v14
-    v16 = frame_load multi_return, word, 0 !metadata(memory=scratch)
-    v17 = add v16, 32
-    v18 = mload v17
-    v19 = sload v18 !metadata(storage=symbolic(v18))
-    ret v15, v19
+    v14 = frame_load multi_return, word, 0 !metadata(memory=scratch)
+    v15 = add v14, 32
+    v16 = mload v15
+    v17 = sload v16 !metadata(storage=symbolic(v16))
+    ret v13, v17
   bb1:
     revert 0, 0
 }
@@ -160,14 +157,14 @@ fn @attached() -> u256 [selector=0xd9e6b370, view, abi_params=[], abi_returns=[w
   bb2:
     v5 = gas
     v6 = sub v5, 50
-    v7 = delegatecall v6, 0x1111111111111111111111111111111111111111, v1, v2, 0, 32
+    v7 = delegatecall v6, 0x1111111111111111111111111111111111111111, v1, v2, v1, 32
     jumpi v7, bb4, bb3
   bb3:
     revert_returndata
   bb4:
-    v8 = add 0, 0
+    v8 = add v1, 0
     v9 = mload v8
-    v10 = add 0, 0
+    v10 = add v1, 0
     v11 = mload v10
     v12 = sload v11 !metadata(storage=symbolic(v11))
     ret v12

--- a/tests/ui/codegen/lowering/library_storage_pointer_return.homestead.stdout
+++ b/tests/ui/codegen/lowering/library_storage_pointer_return.homestead.stdout
@@ -141,9 +141,10 @@ fn @pair() -> (u256, u256) [selector=0xa8aa1b31, view, abi_params=[], abi_return
     v14 = add v3, 0
     v15 = mload v14
     v16 = frame_load multi_return, word, 0 !metadata(memory=scratch)
-    v17 = memory_object_load_element memoryfixedarray<2, 1>, v16, 1
-    v18 = sload v17 !metadata(storage=symbolic(v17))
-    ret v15, v18
+    v17 = add v16, 32
+    v18 = mload v17
+    v19 = sload v18 !metadata(storage=symbolic(v18))
+    ret v15, v19
   bb1:
     revert 0, 0
 }

--- a/tests/ui/codegen/lowering/library_storage_pointer_return.homestead.stdout
+++ b/tests/ui/codegen/lowering/library_storage_pointer_return.homestead.stdout
@@ -25,61 +25,67 @@ fn @pairRef(arg0: storageptr) -> (u256, storageptr) [selector=0x4a3c24da, view, 
 @module C
 fn @len() -> u256 [selector=0x56d88e27, view, abi_params=[], abi_returns=[word]] {
   bb0:
-    v0 = abi_encode [word], selector 0x1fbd3e5000000000000000000000000000000000000000000000000000000000, args 0
-    v1 = slice_ptr v0
-    v2 = slice_len v0
-    v3 = extcodesize 0x1111111111111111111111111111111111111111
-    v4 = iszero v3
-    jumpi v4, bb1, bb2
+    v0 = fmp
+    v1 = add v0, 32
+    mstore v1, 0
+    v2 = abi_encode [word], selector 0x1fbd3e5000000000000000000000000000000000000000000000000000000000, args 0
+    v3 = slice_ptr v2
+    v4 = slice_len v2
+    v5 = extcodesize 0x1111111111111111111111111111111111111111
+    v6 = iszero v5
+    jumpi v6, bb1, bb2
   bb2:
-    v5 = gas
-    v6 = sub v5, 50
-    v7 = delegatecall v6, 0x1111111111111111111111111111111111111111, v1, v2, v1, 32
-    jumpi v7, bb4, bb3
+    v7 = gas
+    v8 = sub v7, 50
+    v9 = delegatecall v8, 0x1111111111111111111111111111111111111111, v3, v4, v3, 32
+    jumpi v9, bb4, bb3
   bb3:
     revert_returndata
   bb4:
-    v8 = add v1, 0
-    v9 = mload v8
-    v10 = add v1, 0
+    v10 = add v3, 0
     v11 = mload v10
-    v12 = sload v11 !metadata(storage=symbolic(v11))
-    ret v12
+    v12 = add v3, 0
+    v13 = mload v12
+    v14 = sload v13 !metadata(storage=symbolic(v13))
+    ret v14
   bb1:
     revert 0, 0
 }
 
 fn @bytesLen() -> u256 [selector=0x6a4634a6, view, abi_params=[], abi_returns=[word]] {
   bb0:
-    v0 = abi_encode [word], selector 0x4d5b8d5600000000000000000000000000000000000000000000000000000000, args 1
-    v1 = slice_ptr v0
-    v2 = slice_len v0
-    v3 = extcodesize 0x1111111111111111111111111111111111111111
-    v4 = iszero v3
-    jumpi v4, bb1, bb2
+    v0 = fmp
+    v1 = add v0, 32
+    mstore v1, 0
+    v2 = abi_encode [word], selector 0x4d5b8d5600000000000000000000000000000000000000000000000000000000, args 1
+    v3 = slice_ptr v2
+    v4 = slice_len v2
+    v5 = extcodesize 0x1111111111111111111111111111111111111111
+    v6 = iszero v5
+    jumpi v6, bb1, bb2
   bb2:
-    v5 = gas
-    v6 = sub v5, 50
-    v7 = delegatecall v6, 0x1111111111111111111111111111111111111111, v1, v2, v1, 32
-    jumpi v7, bb4, bb3
+    v7 = gas
+    v8 = sub v7, 50
+    v9 = delegatecall v8, 0x1111111111111111111111111111111111111111, v3, v4, v3, 32
+    jumpi v9, bb4, bb3
   bb3:
     revert_returndata
   bb4:
-    v8 = add v1, 0
-    v9 = mload v8
-    v10 = add v1, 0
+    v10 = add v3, 0
     v11 = mload v10
-    v12 = sload v11 !metadata(storage=symbolic(v11))
-    v13 = and v12, 1
-    v14 = eq v13, 1
-    v15 = shr 1, v12
-    v16 = and v15, 127
-    v17 = select v14, v15, v16
-    v18 = lt v17, 32
-    v19 = eq v14, v18
-    jumpi v19, bb5, bb6
+    v12 = add v3, 0
+    v13 = mload v12
+    v14 = sload v13 !metadata(storage=symbolic(v13))
+    v15 = and v14, 1
+    v16 = eq v15, 1
+    v17 = shr 1, v14
+    v18 = and v17, 127
+    v19 = select v16, v17, v18
+    v20 = lt v19, 32
+    v21 = eq v16, v20
+    jumpi v21, bb5, bb6
   bb6:
-    ret v17
+    ret v19
   bb5:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 34 !metadata(memory=scratch)
@@ -90,84 +96,93 @@ fn @bytesLen() -> u256 [selector=0x6a4634a6, view, abi_params=[], abi_returns=[w
 
 fn @member() -> u256 [selector=0xe3f6b544, view, abi_params=[], abi_returns=[word]] {
   bb0:
-    v0 = abi_encode [word], selector 0xd4ba105300000000000000000000000000000000000000000000000000000000, args 2
-    v1 = slice_ptr v0
-    v2 = slice_len v0
-    v3 = extcodesize 0x1111111111111111111111111111111111111111
-    v4 = iszero v3
-    jumpi v4, bb1, bb2
+    v0 = fmp
+    v1 = add v0, 32
+    mstore v1, 0
+    v2 = abi_encode [word], selector 0xd4ba105300000000000000000000000000000000000000000000000000000000, args 2
+    v3 = slice_ptr v2
+    v4 = slice_len v2
+    v5 = extcodesize 0x1111111111111111111111111111111111111111
+    v6 = iszero v5
+    jumpi v6, bb1, bb2
   bb2:
-    v5 = gas
-    v6 = sub v5, 50
-    v7 = delegatecall v6, 0x1111111111111111111111111111111111111111, v1, v2, v1, 32
-    jumpi v7, bb4, bb3
+    v7 = gas
+    v8 = sub v7, 50
+    v9 = delegatecall v8, 0x1111111111111111111111111111111111111111, v3, v4, v3, 32
+    jumpi v9, bb4, bb3
   bb3:
     revert_returndata
   bb4:
-    v8 = add v1, 0
-    v9 = mload v8
-    v10 = add v1, 0
+    v10 = add v3, 0
     v11 = mload v10
-    v12 = sload v11 !metadata(storage=symbolic(v11))
-    ret v12
+    v12 = add v3, 0
+    v13 = mload v12
+    v14 = sload v13 !metadata(storage=symbolic(v13))
+    ret v14
   bb1:
     revert 0, 0
 }
 
 fn @pair() -> (u256, u256) [selector=0xa8aa1b31, view, abi_params=[], abi_returns=[word, word]] {
   bb0:
-    v0 = abi_encode [word], selector 0x4a3c24da00000000000000000000000000000000000000000000000000000000, args 0
-    v1 = slice_ptr v0
-    v2 = slice_len v0
-    v3 = extcodesize 0x1111111111111111111111111111111111111111
-    v4 = iszero v3
-    jumpi v4, bb1, bb2
+    v0 = fmp
+    v1 = add v0, 64
+    mstore v1, 0
+    v2 = abi_encode [word], selector 0x4a3c24da00000000000000000000000000000000000000000000000000000000, args 0
+    v3 = slice_ptr v2
+    v4 = slice_len v2
+    v5 = extcodesize 0x1111111111111111111111111111111111111111
+    v6 = iszero v5
+    jumpi v6, bb1, bb2
   bb2:
-    v5 = gas
-    v6 = sub v5, 50
-    v7 = delegatecall v6, 0x1111111111111111111111111111111111111111, v1, v2, v1, 64
-    jumpi v7, bb4, bb3
+    v7 = gas
+    v8 = sub v7, 50
+    v9 = delegatecall v8, 0x1111111111111111111111111111111111111111, v3, v4, v3, 64
+    jumpi v9, bb4, bb3
   bb3:
     revert_returndata
   bb4:
-    v8 = add v1, 0
-    v9 = mload v8
-    v10 = add v1, 32
+    v10 = add v3, 0
     v11 = mload v10
-    frame_store multi_return, word, 0, v1 !metadata(memory=scratch)
-    v12 = add v1, 0
+    v12 = add v3, 32
     v13 = mload v12
-    v14 = frame_load multi_return, word, 0 !metadata(memory=scratch)
-    v15 = add v14, 32
-    v16 = mload v15
-    v17 = sload v16 !metadata(storage=symbolic(v16))
-    ret v13, v17
+    frame_store multi_return, word, 0, v3 !metadata(memory=scratch)
+    v14 = add v3, 0
+    v15 = mload v14
+    v16 = frame_load multi_return, word, 0 !metadata(memory=scratch)
+    v17 = add v16, 32
+    v18 = mload v17
+    v19 = sload v18 !metadata(storage=symbolic(v18))
+    ret v15, v19
   bb1:
     revert 0, 0
 }
 
 fn @attached() -> u256 [selector=0xd9e6b370, view, abi_params=[], abi_returns=[word]] {
   bb0:
-    v0 = abi_encode [word], selector 0x1fbd3e5000000000000000000000000000000000000000000000000000000000, args 0
-    v1 = slice_ptr v0
-    v2 = slice_len v0
-    v3 = extcodesize 0x1111111111111111111111111111111111111111
-    v4 = iszero v3
-    jumpi v4, bb1, bb2
+    v0 = fmp
+    v1 = add v0, 32
+    mstore v1, 0
+    v2 = abi_encode [word], selector 0x1fbd3e5000000000000000000000000000000000000000000000000000000000, args 0
+    v3 = slice_ptr v2
+    v4 = slice_len v2
+    v5 = extcodesize 0x1111111111111111111111111111111111111111
+    v6 = iszero v5
+    jumpi v6, bb1, bb2
   bb2:
-    v5 = gas
-    v6 = sub v5, 50
-    v7 = delegatecall v6, 0x1111111111111111111111111111111111111111, v1, v2, v1, 32
-    jumpi v7, bb4, bb3
+    v7 = gas
+    v8 = sub v7, 50
+    v9 = delegatecall v8, 0x1111111111111111111111111111111111111111, v3, v4, v3, 32
+    jumpi v9, bb4, bb3
   bb3:
     revert_returndata
   bb4:
-    v8 = add v1, 0
-    v9 = mload v8
-    v10 = add v1, 0
+    v10 = add v3, 0
     v11 = mload v10
-    v12 = sload v11 !metadata(storage=symbolic(v11))
-    ret v12
+    v12 = add v3, 0
+    v13 = mload v12
+    v14 = sload v13 !metadata(storage=symbolic(v13))
+    ret v14
   bb1:
     revert 0, 0
 }

--- a/tests/ui/codegen/lowering/library_storage_pointer_return.osaka.stdout
+++ b/tests/ui/codegen/lowering/library_storage_pointer_return.osaka.stdout
@@ -1,0 +1,201 @@
+// === ROOT/tests/ui/codegen/lowering/library_storage_pointer_return.sol:Lib ===
+@module Lib
+fn @arrRef(arg0: storageptr) -> storageptr [selector=0x1fbd3e50, pure, abi_params=[storageptr], abi_returns=[word]] {
+  bb0:
+    ret arg0
+}
+
+fn @bytesRef(arg0: storageptr) -> storageptr [selector=0x4d5b8d56, pure, abi_params=[storageptr], abi_returns=[word]] {
+  bb0:
+    ret arg0
+}
+
+fn @plainRef(arg0: storageptr) -> storageptr [selector=0xd4ba1053, pure, abi_params=[storageptr], abi_returns=[word]] {
+  bb0:
+    ret arg0
+}
+
+fn @pairRef(arg0: storageptr) -> (u256, storageptr) [selector=0x4a3c24da, view, abi_params=[storageptr], abi_returns=[word, word]] {
+  bb0:
+    v0 = sload arg0 !metadata(storage=symbolic(arg0))
+    ret v0, arg0
+}
+
+// === ROOT/tests/ui/codegen/lowering/library_storage_pointer_return.sol:C ===
+@module C
+fn @len() -> u256 [selector=0x56d88e27, view, abi_params=[], abi_returns=[word]] {
+  bb0:
+    v0 = abi_encode [word], selector 0x1fbd3e5000000000000000000000000000000000000000000000000000000000, args 0
+    v1 = slice_ptr v0
+    v2 = slice_len v0
+    v3 = gas
+    v4 = delegatecall v3, 0x1111111111111111111111111111111111111111, v1, v2, 0, 0
+    jumpi v4, bb2, bb1
+  bb1:
+    revert_returndata
+  bb2:
+    v5 = returndatasize
+    v6 = add v5, 63
+    v7 = lt v6, v5
+    jumpi v7, bb3, bb4
+  bb4:
+    v8 = not 31
+    v9 = and v6, v8
+    v10 = alloc memorybytes, exact, uninitialized, infallible, v9
+    set_memory_object_len memorybytes, v10, v5
+    v11 = make_returndata_slice 0, v5
+    memory_object_copy_from_slice memorybytes, v10, v11
+    v12 = abi_decode [storageptr], v10
+    v13 = sload v12 !metadata(storage=symbolic(v12))
+    ret v13
+  bb3:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 65 !metadata(memory=scratch)
+    revert 0, 36
+}
+
+fn @bytesLen() -> u256 [selector=0x6a4634a6, view, abi_params=[], abi_returns=[word]] {
+  bb0:
+    v0 = abi_encode [word], selector 0x4d5b8d5600000000000000000000000000000000000000000000000000000000, args 1
+    v1 = slice_ptr v0
+    v2 = slice_len v0
+    v3 = gas
+    v4 = delegatecall v3, 0x1111111111111111111111111111111111111111, v1, v2, 0, 0
+    jumpi v4, bb2, bb1
+  bb1:
+    revert_returndata
+  bb2:
+    v5 = returndatasize
+    v6 = add v5, 63
+    v7 = lt v6, v5
+    jumpi v7, bb3, bb4
+  bb4:
+    v8 = not 31
+    v9 = and v6, v8
+    v10 = alloc memorybytes, exact, uninitialized, infallible, v9
+    set_memory_object_len memorybytes, v10, v5
+    v11 = make_returndata_slice 0, v5
+    memory_object_copy_from_slice memorybytes, v10, v11
+    v12 = abi_decode [storageptr], v10
+    v13 = sload v12 !metadata(storage=symbolic(v12))
+    v14 = and v13, 1
+    v15 = eq v14, 1
+    v16 = shr 1, v13
+    v17 = and v16, 127
+    v18 = select v15, v16, v17
+    v19 = lt v18, 32
+    v20 = eq v15, v19
+    jumpi v20, bb5, bb6
+  bb6:
+    ret v18
+  bb5:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 34 !metadata(memory=scratch)
+    revert 0, 36
+  bb3:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 65 !metadata(memory=scratch)
+    revert 0, 36
+}
+
+fn @member() -> u256 [selector=0xe3f6b544, view, abi_params=[], abi_returns=[word]] {
+  bb0:
+    v0 = abi_encode [word], selector 0xd4ba105300000000000000000000000000000000000000000000000000000000, args 2
+    v1 = slice_ptr v0
+    v2 = slice_len v0
+    v3 = gas
+    v4 = delegatecall v3, 0x1111111111111111111111111111111111111111, v1, v2, 0, 0
+    jumpi v4, bb2, bb1
+  bb1:
+    revert_returndata
+  bb2:
+    v5 = returndatasize
+    v6 = add v5, 63
+    v7 = lt v6, v5
+    jumpi v7, bb3, bb4
+  bb4:
+    v8 = not 31
+    v9 = and v6, v8
+    v10 = alloc memorybytes, exact, uninitialized, infallible, v9
+    set_memory_object_len memorybytes, v10, v5
+    v11 = make_returndata_slice 0, v5
+    memory_object_copy_from_slice memorybytes, v10, v11
+    v12 = abi_decode [storageptr], v10
+    v13 = sload v12 !metadata(storage=symbolic(v12))
+    ret v13
+  bb3:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 65 !metadata(memory=scratch)
+    revert 0, 36
+}
+
+fn @pair() -> (u256, u256) [selector=0xa8aa1b31, view, abi_params=[], abi_returns=[word, word]] {
+  bb0:
+    v0 = abi_encode [word], selector 0x4a3c24da00000000000000000000000000000000000000000000000000000000, args 0
+    v1 = slice_ptr v0
+    v2 = slice_len v0
+    v3 = gas
+    v4 = delegatecall v3, 0x1111111111111111111111111111111111111111, v1, v2, 0, 0
+    jumpi v4, bb2, bb1
+  bb1:
+    revert_returndata
+  bb2:
+    v5 = returndatasize
+    v6 = add v5, 63
+    v7 = lt v6, v5
+    jumpi v7, bb3, bb4
+  bb4:
+    v8 = not 31
+    v9 = and v6, v8
+    v10 = alloc memorybytes, exact, uninitialized, infallible, v9
+    set_memory_object_len memorybytes, v10, v5
+    v11 = make_returndata_slice 0, v5
+    memory_object_copy_from_slice memorybytes, v10, v11
+    v12 = abi_decode [u256, storageptr], v10
+    v13 = frame_load multi_return, word, 0 !metadata(memory=scratch)
+    v14 = add v13, 32
+    v15 = mload v14
+    v16 = alloc memoryfixedarray<2, 1>, exact, uninitialized, infallible, 64
+    v17 = memory_object_data memoryfixedarray, v16
+    frame_store multi_return, word, 0, v17 !metadata(memory=scratch)
+    memory_object_store_element memoryfixedarray<2, 1>, v16, 1, v15
+    v18 = frame_load multi_return, word, 0 !metadata(memory=scratch)
+    v19 = memory_object_load_element memoryfixedarray<2, 1>, v18, 1
+    v20 = sload v19 !metadata(storage=symbolic(v19))
+    ret v12, v20
+  bb3:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 65 !metadata(memory=scratch)
+    revert 0, 36
+}
+
+fn @attached() -> u256 [selector=0xd9e6b370, view, abi_params=[], abi_returns=[word]] {
+  bb0:
+    v0 = abi_encode [word], selector 0x1fbd3e5000000000000000000000000000000000000000000000000000000000, args 0
+    v1 = slice_ptr v0
+    v2 = slice_len v0
+    v3 = gas
+    v4 = delegatecall v3, 0x1111111111111111111111111111111111111111, v1, v2, 0, 0
+    jumpi v4, bb2, bb1
+  bb1:
+    revert_returndata
+  bb2:
+    v5 = returndatasize
+    v6 = add v5, 63
+    v7 = lt v6, v5
+    jumpi v7, bb3, bb4
+  bb4:
+    v8 = not 31
+    v9 = and v6, v8
+    v10 = alloc memorybytes, exact, uninitialized, infallible, v9
+    set_memory_object_len memorybytes, v10, v5
+    v11 = make_returndata_slice 0, v5
+    memory_object_copy_from_slice memorybytes, v10, v11
+    v12 = abi_decode [storageptr], v10
+    v13 = sload v12 !metadata(storage=symbolic(v12))
+    ret v13
+  bb3:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 65 !metadata(memory=scratch)
+    revert 0, 36
+}

--- a/tests/ui/codegen/lowering/library_storage_pointer_return.osaka.stdout
+++ b/tests/ui/codegen/lowering/library_storage_pointer_return.osaka.stdout
@@ -160,9 +160,10 @@ fn @pair() -> (u256, u256) [selector=0xa8aa1b31, view, abi_params=[], abi_return
     frame_store multi_return, word, 0, v17 !metadata(memory=scratch)
     memory_object_store_element memoryfixedarray<2, 1>, v16, 1, v15
     v18 = frame_load multi_return, word, 0 !metadata(memory=scratch)
-    v19 = memory_object_load_element memoryfixedarray<2, 1>, v18, 1
-    v20 = sload v19 !metadata(storage=symbolic(v19))
-    ret v12, v20
+    v19 = add v18, 32
+    v20 = mload v19
+    v21 = sload v20 !metadata(storage=symbolic(v20))
+    ret v12, v21
   bb3:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 65 !metadata(memory=scratch)

--- a/tests/ui/codegen/lowering/library_storage_pointer_return.sol
+++ b/tests/ui/codegen/lowering/library_storage_pointer_return.sol
@@ -88,7 +88,7 @@ contract C {
 
     // Two return words share one output area, and the second one is the slot.
     // HOMESTEAD-LABEL: fn @pair
-    // HOMESTEAD: delegatecall {{.*}}, 64
+    // HOMESTEAD: delegatecall {{.*}}, [[IN:v[0-9]+]], {{v[0-9]+}}, [[IN]], 64
     // OSAKA-LABEL: fn @pair
     // OSAKA: abi_decode [u256, storageptr]
     function pair() external view returns (uint256, uint256) {

--- a/tests/ui/codegen/lowering/library_storage_pointer_return.sol
+++ b/tests/ui/codegen/lowering/library_storage_pointer_return.sol
@@ -1,0 +1,110 @@
+//@ revisions: homestead osaka
+//@[homestead] compile-flags: -O none --evm-version homestead --libraries Lib=0x1111111111111111111111111111111111111111 -Zdump=mir
+//@[homestead] filecheck: --check-prefix=HOMESTEAD
+//@[osaka] compile-flags: -O none --evm-version osaka --libraries Lib=0x1111111111111111111111111111111111111111 -Zdump=mir
+//@[osaka] filecheck: --check-prefix=OSAKA
+
+// A storage reference crossing a library call boundary travels as its slot number in both
+// directions, like solc's `ArrayType::encodingType`, so the ABI wrapper returns one word and the
+// caller decodes one word. Storage pointers are a single static word, so the call is legal before
+// Byzantium too. `run-call` cannot deploy an unlinked library, so this pins the lowering only.
+library Lib {
+    struct Plain {
+        uint256 a;
+    }
+
+    // The wrapper receives the slot and returns the slot, never a memory array.
+    // HOMESTEAD: fn @arrRef{{.*}}abi_params=[storageptr], abi_returns=[word]
+    // OSAKA: fn @arrRef{{.*}}abi_params=[storageptr], abi_returns=[word]
+    function arrRef(uint256[] storage a) external pure returns (uint256[] storage) {
+        return a;
+    }
+
+    // HOMESTEAD: fn @bytesRef{{.*}}abi_params=[storageptr], abi_returns=[word]
+    // OSAKA: fn @bytesRef{{.*}}abi_params=[storageptr], abi_returns=[word]
+    function bytesRef(bytes storage b) external pure returns (bytes storage) {
+        return b;
+    }
+
+    // HOMESTEAD: fn @plainRef{{.*}}abi_params=[storageptr], abi_returns=[word]
+    // OSAKA: fn @plainRef{{.*}}abi_params=[storageptr], abi_returns=[word]
+    function plainRef(Plain storage p) external pure returns (Plain storage) {
+        return p;
+    }
+
+    // A slot next to a value keeps the value's own shape.
+    // HOMESTEAD: fn @pairRef{{.*}}abi_returns=[word, word]
+    // OSAKA: fn @pairRef{{.*}}abi_returns=[word, word]
+    function pairRef(uint256[] storage a) external view returns (uint256, uint256[] storage) {
+        return (a.length, a);
+    }
+}
+
+contract C {
+    using Lib for uint256[];
+
+    uint256[] private nums;
+    bytes private bs;
+    Lib.Plain private plain;
+
+    // Before Byzantium the returned slot comes out of the delegatecall's own 32-byte output area,
+    // as solc's `delegatecall(..., out, 32)` does; from Byzantium on it is decoded out of the
+    // return data as a word and used as a slot.
+    // HOMESTEAD-LABEL: fn @len
+    // HOMESTEAD: delegatecall {{.*}}, 0, 32
+    // HOMESTEAD: mload
+    // HOMESTEAD: sload
+    // OSAKA-LABEL: fn @len
+    // OSAKA: delegatecall {{.*}}, 0, 0
+    // OSAKA: [[SLOT:v[0-9]+]] = abi_decode [storageptr]
+    // OSAKA: sload [[SLOT]]
+    function len() external view returns (uint256) {
+        return Lib.arrRef(nums).length;
+    }
+
+    // A `bytes` slot is a slot too: the length still comes from storage.
+    // HOMESTEAD-LABEL: fn @bytesLen
+    // HOMESTEAD: delegatecall {{.*}}, 0, 32
+    // HOMESTEAD: mload
+    // HOMESTEAD: sload
+    // OSAKA-LABEL: fn @bytesLen
+    // OSAKA: [[SLOT:v[0-9]+]] = abi_decode [storageptr]
+    // OSAKA: sload [[SLOT]]
+    function bytesLen() external view returns (uint256) {
+        return Lib.bytesRef(bs).length;
+    }
+
+    // A struct pointer indexes its member off the returned slot.
+    // HOMESTEAD-LABEL: fn @member
+    // HOMESTEAD: delegatecall {{.*}}, 0, 32
+    // HOMESTEAD: mload
+    // HOMESTEAD: sload
+    // OSAKA-LABEL: fn @member
+    // OSAKA: [[SLOT:v[0-9]+]] = abi_decode [storageptr]
+    // OSAKA: sload [[SLOT]]
+    function member() external view returns (uint256) {
+        return Lib.plainRef(plain).a;
+    }
+
+    // Two return words share one output area, and the second one is the slot.
+    // HOMESTEAD-LABEL: fn @pair
+    // HOMESTEAD: delegatecall {{.*}}, 64
+    // OSAKA-LABEL: fn @pair
+    // OSAKA: abi_decode [u256, storageptr]
+    function pair() external view returns (uint256, uint256) {
+        (uint256 n, uint256[] storage r) = Lib.pairRef(nums);
+        return (n, r.length);
+    }
+
+    // An attached call passes the receiver's slot and gets a slot back.
+    // HOMESTEAD-LABEL: fn @attached
+    // HOMESTEAD: delegatecall {{.*}}, 0, 32
+    // HOMESTEAD: mload
+    // HOMESTEAD: sload
+    // OSAKA-LABEL: fn @attached
+    // OSAKA: [[SLOT:v[0-9]+]] = abi_decode [storageptr]
+    // OSAKA: sload [[SLOT]]
+    function attached() external view returns (uint256) {
+        return nums.arrRef().length;
+    }
+}

--- a/tests/ui/codegen/lowering/library_storage_pointer_return.sol
+++ b/tests/ui/codegen/lowering/library_storage_pointer_return.sol
@@ -51,7 +51,7 @@ contract C {
     // as solc's `delegatecall(..., out, 32)` does; from Byzantium on it is decoded out of the
     // return data as a word and used as a slot.
     // HOMESTEAD-LABEL: fn @len
-    // HOMESTEAD: delegatecall {{.*}}, 0, 32
+    // HOMESTEAD: delegatecall {{.*}}, [[IN:v[0-9]+]], {{v[0-9]+}}, [[IN]], 32
     // HOMESTEAD: mload
     // HOMESTEAD: sload
     // OSAKA-LABEL: fn @len
@@ -64,7 +64,7 @@ contract C {
 
     // A `bytes` slot is a slot too: the length still comes from storage.
     // HOMESTEAD-LABEL: fn @bytesLen
-    // HOMESTEAD: delegatecall {{.*}}, 0, 32
+    // HOMESTEAD: delegatecall {{.*}}, [[IN:v[0-9]+]], {{v[0-9]+}}, [[IN]], 32
     // HOMESTEAD: mload
     // HOMESTEAD: sload
     // OSAKA-LABEL: fn @bytesLen
@@ -76,7 +76,7 @@ contract C {
 
     // A struct pointer indexes its member off the returned slot.
     // HOMESTEAD-LABEL: fn @member
-    // HOMESTEAD: delegatecall {{.*}}, 0, 32
+    // HOMESTEAD: delegatecall {{.*}}, [[IN:v[0-9]+]], {{v[0-9]+}}, [[IN]], 32
     // HOMESTEAD: mload
     // HOMESTEAD: sload
     // OSAKA-LABEL: fn @member
@@ -98,7 +98,7 @@ contract C {
 
     // An attached call passes the receiver's slot and gets a slot back.
     // HOMESTEAD-LABEL: fn @attached
-    // HOMESTEAD: delegatecall {{.*}}, 0, 32
+    // HOMESTEAD: delegatecall {{.*}}, [[IN:v[0-9]+]], {{v[0-9]+}}, [[IN]], 32
     // HOMESTEAD: mload
     // HOMESTEAD: sload
     // OSAKA-LABEL: fn @attached

--- a/tests/ui/codegen/lowering/run-call/library_storage_pointer_multi_return.mir.stdout
+++ b/tests/ui/codegen/lowering/run-call/library_storage_pointer_multi_return.mir.stdout
@@ -1,0 +1,450 @@
+// === ROOT/tests/ui/codegen/lowering/run-call/library_storage_pointer_multi_return.sol:Lib ===
+@module Lib
+
+// === ROOT/tests/ui/codegen/lowering/run-call/library_storage_pointer_multi_return.sol:LibraryStoragePointerMultiReturn ===
+@module LibraryStoragePointerMultiReturn
+fn @constructor() [constructor] {
+  bb0:
+    v0 = sload 0 !metadata(storage=slot(0))
+    v1 = add v0, 1
+    v2 = lt v1, v0
+    jumpi v2, bb1, bb2
+  bb2:
+    v3 = storage_array_data_slot 0
+    v4 = add v3, v0
+    sstore v4, 11 !metadata(storage=symbolic(v4))
+    sstore 0, v1 !metadata(storage=slot(0))
+    v5 = sload 0 !metadata(storage=slot(0))
+    v6 = add v5, 1
+    v7 = lt v6, v5
+    jumpi v7, bb1, bb3
+  bb3:
+    v8 = storage_array_data_slot 0
+    v9 = add v8, v5
+    sstore v9, 22 !metadata(storage=symbolic(v9))
+    sstore 0, v6 !metadata(storage=slot(0))
+    v10 = alloc memorybytes, exact, uninitialized, infallible, 64
+    set_memory_object_len memorybytes, v10, 3
+    v11 = memory_object_data memorybytes, v10
+    mstore v11, 0xaabbcc0000000000000000000000000000000000000000000000000000000000
+    internal_call @store_storage_bytes, 0, 1, v10
+    sstore 2, 7 !metadata(storage=slot(2))
+    v12 = add 2, 1
+    v13 = sload v12 !metadata(storage=slot(3))
+    v14 = add v13, 1
+    v15 = lt v14, v13
+    jumpi v15, bb1, bb4
+  bb4:
+    v16 = storage_array_data_slot v12
+    v17 = add v16, v13
+    sstore v17, 33 !metadata(storage=symbolic(v17))
+    sstore v12, v14 !metadata(storage=slot(3))
+    stop
+  bb1:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 65 !metadata(memory=scratch)
+    revert 0, 36
+}
+
+fn @forwardPair() -> (u256, memoryarray) [selector=0x9948ca45, view, abi_params=[], abi_returns=[word, memory_array<word>]] {
+  bb0:
+    v0 = internal_call @pair, 2, 0
+    v1 = frame_load multi_return, word, 0 !metadata(memory=scratch)
+    v2 = add v1, 32
+    v3 = mload v2
+    v4 = internal_call @load_storage_word_array, 1, v3
+    ret v0, v4
+}
+
+fn @forwardBytesPair() -> (u256, memorybytes) [selector=0x244e77d3, view, abi_params=[], abi_returns=[word, memory_bytes]] {
+  bb0:
+    v0 = internal_call @bytesPair, 2, 1
+    v1 = frame_load multi_return, word, 0 !metadata(memory=scratch)
+    v2 = add v1, 32
+    v3 = mload v2
+    v4 = sload v3 !metadata(storage=symbolic(v3))
+    v5 = and v4, 1
+    v6 = eq v5, 1
+    v7 = shr 1, v4
+    v8 = and v7, 127
+    v9 = select v6, v7, v8
+    v10 = lt v9, 32
+    v11 = eq v6, v10
+    jumpi v11, bb1, bb2
+  bb2:
+    v12 = add v9, 31
+    v13 = div v12, 32
+    v14 = add v9, 63
+    v15 = lt v14, v9
+    jumpi v15, bb3, bb4
+  bb4:
+    v16 = not 31
+    v17 = and v14, v16
+    v18 = alloc memorybytes, exact, uninitialized, panic, v17
+    set_memory_object_len memorybytes, v18, v9
+    jumpi v6, bb6, bb5
+  bb5:
+    v19 = and v4, 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff00
+    memory_object_store_word memorybytes, v18, 0, v19
+    jump bb7
+  bb6:
+    v20 = storage_array_data_slot v3
+    jump bb8
+  bb8:
+    v21 = phi [bb6: 0], [bb9: v26]
+    v22 = lt v21, v13
+    jumpi v22, bb9, bb10
+  bb10:
+    jump bb7
+  bb7:
+    ret v0, v18
+  bb9:
+    v23 = add v20, v21
+    v24 = sload v23 !metadata(storage=symbolic(v23))
+    v25 = mul v21, 32
+    memory_object_store_word memorybytes, v18, v25, v24
+    v26 = add v21, 1
+    jump bb8
+  bb3:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 65 !metadata(memory=scratch)
+    revert 0, 36
+  bb1:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 34 !metadata(memory=scratch)
+    revert 0, 36
+}
+
+fn @forwardStructPair() -> (u256, memorystruct) [selector=0x89663e35, view, abi_params=[], abi_returns=[word, tuple<word, memory_array<word>>]] {
+  bb0:
+    v0 = alloc memorystruct<2>, exact, uninitialized, infallible, 64
+    memory_object_store_field memorystruct<2>, v0, 0, 0
+    memory_object_store_field memorystruct<2>, v0, 1, 96
+    v1 = internal_call @structPair, 2, 2
+    v2 = frame_load multi_return, word, 0 !metadata(memory=scratch)
+    v3 = add v2, 32
+    v4 = mload v3
+    v5 = alloc memorystruct<2>, exact, uninitialized, panic, 64
+    v6 = sload v4 !metadata(storage=symbolic(v4))
+    memory_object_store_field memorystruct<2>, v5, 0, v6
+    v7 = add v4, 1
+    v8 = internal_call @load_storage_word_array, 1, v7
+    memory_object_store_field memorystruct<2>, v5, 1, v8
+    ret v1, v5
+}
+
+fn @forwardNarrowPair() -> (u256, memoryarray) [selector=0x1c173dc4, view, abi_params=[], abi_returns=[word, memory_array<word>]] {
+  bb0:
+    v0 = internal_call @narrowPair, 2, 0
+    v1 = frame_load multi_return, word, 0 !metadata(memory=scratch)
+    v2 = add v1, 32
+    v3 = mload v2
+    v4 = and v0, 255
+    v5 = internal_call @load_storage_word_array, 1, v3
+    ret v4, v5
+}
+
+fn @forwardLeadingPair() -> (memoryarray, u256) [selector=0x59d1f54e, view, abi_params=[], abi_returns=[memory_array<word>, word]] {
+  bb0:
+    v0 = internal_call @leadingPair, 2, 0
+    v1 = frame_load multi_return, word, 0 !metadata(memory=scratch)
+    v2 = add v1, 32
+    v3 = mload v2
+    v4 = internal_call @load_storage_word_array, 1, v0
+    ret v4, v3
+}
+
+fn @forwardTriple() -> (memoryarray, u256, memorybytes) [selector=0xd5d6b86b, view, abi_params=[], abi_returns=[memory_array<word>, word, memory_bytes]] {
+  bb0:
+    v0 = internal_call @triple, 3, 0, 1
+    v1 = frame_load multi_return, word, 0 !metadata(memory=scratch)
+    v2 = add v1, 32
+    v3 = mload v2
+    v4 = add v1, 64
+    v5 = mload v4
+    v6 = internal_call @load_storage_word_array, 1, v0
+    v7 = sload v5 !metadata(storage=symbolic(v5))
+    v8 = and v7, 1
+    v9 = eq v8, 1
+    v10 = shr 1, v7
+    v11 = and v10, 127
+    v12 = select v9, v10, v11
+    v13 = lt v12, 32
+    v14 = eq v9, v13
+    jumpi v14, bb1, bb2
+  bb2:
+    v15 = add v12, 31
+    v16 = div v15, 32
+    v17 = add v12, 63
+    v18 = lt v17, v12
+    jumpi v18, bb3, bb4
+  bb4:
+    v19 = not 31
+    v20 = and v17, v19
+    v21 = alloc memorybytes, exact, uninitialized, panic, v20
+    set_memory_object_len memorybytes, v21, v12
+    jumpi v9, bb6, bb5
+  bb5:
+    v22 = and v7, 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff00
+    memory_object_store_word memorybytes, v21, 0, v22
+    jump bb7
+  bb6:
+    v23 = storage_array_data_slot v5
+    jump bb8
+  bb8:
+    v24 = phi [bb6: 0], [bb9: v29]
+    v25 = lt v24, v16
+    jumpi v25, bb9, bb10
+  bb10:
+    jump bb7
+  bb7:
+    ret v6, v3, v21
+  bb9:
+    v26 = add v23, v24
+    v27 = sload v26 !metadata(storage=symbolic(v26))
+    v28 = mul v24, 32
+    memory_object_store_word memorybytes, v21, v28, v27
+    v29 = add v24, 1
+    jump bb8
+  bb3:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 65 !metadata(memory=scratch)
+    revert 0, 36
+  bb1:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 34 !metadata(memory=scratch)
+    revert 0, 36
+}
+
+fn @declarePair() -> (u256, memoryarray) [selector=0x2538210e, view, abi_params=[], abi_returns=[word, memory_array<word>]] {
+  bb0:
+    v0 = internal_call @pair, 2, 0
+    v1 = frame_load multi_return, word, 0 !metadata(memory=scratch)
+    v2 = add v1, 32
+    v3 = mload v2
+    v4 = internal_call @load_storage_word_array, 1, v3
+    ret v0, v4
+}
+
+fn @assignPair() -> (u256, memoryarray) [selector=0x9355e772, view, abi_params=[], abi_returns=[word, memory_array<word>]] {
+  bb0:
+    v0 = internal_call @pair, 2, 0
+    v1 = frame_load multi_return, word, 0 !metadata(memory=scratch)
+    v2 = add v1, 32
+    v3 = mload v2
+    v4 = internal_call @load_storage_word_array, 1, v3
+    ret v0, v4
+}
+
+fn @keepStorage() -> (u256, storageptr) [view] {
+  bb0:
+    v0 = internal_call @pair, 2, 0
+    v1 = frame_load multi_return, word, 0 !metadata(memory=scratch)
+    v2 = add v1, 32
+    v3 = mload v2
+    ret v0, v3
+}
+
+fn @forwardKeepingStorage() -> (u256, u256) [selector=0xe85db471, view, abi_params=[], abi_returns=[word, word]] {
+  bb0:
+    v0 = internal_call @keepStorage, 2
+    v1 = frame_load multi_return, word, 0 !metadata(memory=scratch)
+    v2 = add v1, 32
+    v3 = mload v2
+    v4 = sload v3 !metadata(storage=symbolic(v3))
+    ret v0, v4
+}
+
+fn @pair(arg0: storageptr) -> (u256, storageptr) [view] {
+  bb0:
+    v0 = sload arg0 !metadata(storage=symbolic(arg0))
+    ret v0, arg0
+}
+
+fn @bytesPair(arg0: storageptr) -> (u256, storageptr) [view] {
+  bb0:
+    v0 = sload arg0 !metadata(storage=symbolic(arg0))
+    v1 = and v0, 1
+    v2 = eq v1, 1
+    v3 = shr 1, v0
+    v4 = and v3, 127
+    v5 = select v2, v3, v4
+    v6 = lt v5, 32
+    v7 = eq v2, v6
+    jumpi v7, bb1, bb2
+  bb2:
+    ret v5, arg0
+  bb1:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 34 !metadata(memory=scratch)
+    revert 0, 36
+}
+
+fn @structPair(arg0: storageptr) -> (u256, storageptr) [view] {
+  bb0:
+    v0 = sload arg0 !metadata(storage=symbolic(arg0))
+    ret v0, arg0
+}
+
+fn @narrowPair(arg0: storageptr) -> (u8, storageptr) [view] {
+  bb0:
+    v0 = sload arg0 !metadata(storage=symbolic(arg0))
+    v1 = and v0, 255
+    ret v1, arg0
+}
+
+fn @leadingPair(arg0: storageptr) -> (storageptr, u256) [view] {
+  bb0:
+    v0 = sload arg0 !metadata(storage=symbolic(arg0))
+    ret arg0, v0
+}
+
+fn @triple(arg0: storageptr, arg1: storageptr) -> (storageptr, u256, storageptr) [view] {
+  bb0:
+    v0 = sload arg0 !metadata(storage=symbolic(arg0))
+    ret arg0, v0, arg1
+}
+
+fn @clear_storage_words(arg0: u256, arg1: u256, arg2: u256) {
+  bb0:
+    v0 = storage_array_data_slot arg0
+    jump bb1
+  bb1:
+    v1 = phi [bb0: arg1], [bb2: v4]
+    v2 = lt v1, arg2
+    jumpi v2, bb2, bb3
+  bb3:
+    stop
+  bb2:
+    v3 = add v0, v1
+    sstore v3, 0 !metadata(storage=symbolic(v3))
+    v4 = add v1, 1
+    jump bb1
+}
+
+fn @store_storage_bytes(arg0: u256, arg1: memorybytes) {
+  bb0:
+    v0 = sload arg0 !metadata(storage=symbolic(arg0))
+    v1 = and v0, 1
+    v2 = eq v1, 1
+    v3 = shr 1, v0
+    v4 = and v3, 127
+    v5 = select v2, v3, v4
+    v6 = lt v5, 32
+    v7 = eq v2, v6
+    jumpi v7, bb1, bb2
+  bb2:
+    v8 = memory_object_len memorybytes, arg1
+    v9 = memory_object_data memorybytes, arg1
+    v10 = make_memory_slice v9, v8
+    v11 = add v5, 31
+    v12 = div v11, 32
+    v13 = add v8, 31
+    v14 = lt v13, v8
+    jumpi v14, bb3, bb4
+  bb4:
+    v15 = div v13, 32
+    v16 = lt v8, 32
+    v17 = select v16, 0, v15
+    v18 = gt v5, v8
+    v19 = and v2, v18
+    jumpi v19, bb5, bb6
+  bb5:
+    internal_call @clear_storage_words, 0, arg0, v17, v12
+    jump bb6
+  bb6:
+    jumpi v16, bb7, bb8
+  bb8:
+    v29 = shl 1, v8
+    v30 = or v29, 1
+    sstore arg0, v30 !metadata(storage=symbolic(arg0))
+    v31 = storage_array_data_slot arg0
+    v32 = div v8, 32
+    jump bb10
+  bb10:
+    v33 = phi [bb8: 0], [bb11: v38]
+    v34 = lt v33, v32
+    jumpi v34, bb11, bb12
+  bb12:
+    v39 = and v8, 31
+    v40 = iszero v39
+    jumpi v40, bb9, bb13
+  bb13:
+    v41 = mul v32, 32
+    v42 = memory_slice_load_word memory, v10, v41
+    v43 = sub 32, v39
+    v44 = mul v43, 8
+    v45 = shl v44, 1
+    v46 = sub v45, 1
+    v47 = not v46
+    v48 = and v42, v47
+    v49 = add v31, v32
+    sstore v49, v48 !metadata(storage=symbolic(v49))
+    jump bb9
+  bb11:
+    v35 = mul v33, 32
+    v36 = memory_slice_load_word memory, v10, v35
+    v37 = add v31, v33
+    sstore v37, v36 !metadata(storage=symbolic(v37))
+    v38 = add v33, 1
+    jump bb10
+  bb7:
+    v20 = memory_slice_load_word memory, v10, 0
+    v21 = sub 32, v8
+    v22 = mul v21, 8
+    v23 = shl v22, 1
+    v24 = sub v23, 1
+    v25 = not v24
+    v26 = and v20, v25
+    v27 = mul v8, 2
+    v28 = or v26, v27
+    sstore arg0, v28 !metadata(storage=symbolic(arg0))
+    jump bb9
+  bb9:
+    stop
+  bb3:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 65 !metadata(memory=scratch)
+    revert 0, 36
+  bb1:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 34 !metadata(memory=scratch)
+    revert 0, 36
+}
+
+fn @load_storage_word_array(arg0: u256) -> memoryarray {
+  bb0:
+    v0 = sload arg0 !metadata(storage=symbolic(arg0))
+    v1 = add v0, 1
+    v2 = lt v1, v0
+    jumpi v2, bb1, bb2
+  bb2:
+    v3 = mul v1, 32
+    v4 = iszero 32
+    v5 = div v3, 32
+    v6 = eq v5, v1
+    v7 = or v4, v6
+    v8 = iszero v7
+    jumpi v8, bb1, bb3
+  bb3:
+    v9 = alloc memoryarray<1>, exact, uninitialized, panic, v3
+    set_memory_object_len memoryarray, v9, v0
+    v10 = storage_array_data_slot arg0
+    jump bb4
+  bb4:
+    v11 = phi [bb3: 0], [bb5: v15]
+    v12 = lt v11, v0
+    jumpi v12, bb5, bb6
+  bb6:
+    ret v9
+  bb5:
+    v13 = add v10, v11
+    v14 = sload v13 !metadata(storage=symbolic(v13))
+    memory_object_store_element memoryarray<1>, v9, v11, v14
+    v15 = add v11, 1
+    jump bb4
+  bb1:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 65 !metadata(memory=scratch)
+    revert 0, 36
+}

--- a/tests/ui/codegen/lowering/run-call/library_storage_pointer_multi_return.mir.stdout
+++ b/tests/ui/codegen/lowering/run-call/library_storage_pointer_multi_return.mir.stdout
@@ -27,7 +27,7 @@ fn @constructor() [constructor] {
     set_memory_object_len memorybytes, v10, 3
     v11 = memory_object_data memorybytes, v10
     mstore v11, 0xaabbcc0000000000000000000000000000000000000000000000000000000000
-    internal_call @store_storage_bytes, 0, 1, v10
+    icall @store_storage_bytes, 0, 1, v10
     sstore 2, 7 !metadata(storage=slot(2))
     v12 = add 2, 1
     v13 = sload v12 !metadata(storage=slot(3))
@@ -48,17 +48,17 @@ fn @constructor() [constructor] {
 
 fn @forwardPair() -> (u256, memoryarray) [selector=0x9948ca45, view, abi_params=[], abi_returns=[word, memory_array<word>]] {
   bb0:
-    v0 = internal_call @pair, 2, 0
+    v0 = icall @pair, 2, 0
     v1 = frame_load multi_return, word, 0 !metadata(memory=scratch)
     v2 = add v1, 32
     v3 = mload v2
-    v4 = internal_call @load_storage_word_array, 1, v3
+    v4 = icall @load_storage_word_array, 1, v3
     ret v0, v4
 }
 
 fn @forwardBytesPair() -> (u256, memorybytes) [selector=0x244e77d3, view, abi_params=[], abi_returns=[word, memory_bytes]] {
   bb0:
-    v0 = internal_call @bytesPair, 2, 1
+    v0 = icall @bytesPair, 2, 1
     v1 = frame_load multi_return, word, 0 !metadata(memory=scratch)
     v2 = add v1, 32
     v3 = mload v2
@@ -120,7 +120,7 @@ fn @forwardStructPair() -> (u256, memorystruct) [selector=0x89663e35, view, abi_
     v0 = alloc memorystruct<2>, exact, uninitialized, infallible, 64
     memory_object_store_field memorystruct<2>, v0, 0, 0
     memory_object_store_field memorystruct<2>, v0, 1, 96
-    v1 = internal_call @structPair, 2, 2
+    v1 = icall @structPair, 2, 2
     v2 = frame_load multi_return, word, 0 !metadata(memory=scratch)
     v3 = add v2, 32
     v4 = mload v3
@@ -128,41 +128,41 @@ fn @forwardStructPair() -> (u256, memorystruct) [selector=0x89663e35, view, abi_
     v6 = sload v4 !metadata(storage=symbolic(v4))
     memory_object_store_field memorystruct<2>, v5, 0, v6
     v7 = add v4, 1
-    v8 = internal_call @load_storage_word_array, 1, v7
+    v8 = icall @load_storage_word_array, 1, v7
     memory_object_store_field memorystruct<2>, v5, 1, v8
     ret v1, v5
 }
 
 fn @forwardNarrowPair() -> (u256, memoryarray) [selector=0x1c173dc4, view, abi_params=[], abi_returns=[word, memory_array<word>]] {
   bb0:
-    v0 = internal_call @narrowPair, 2, 0
+    v0 = icall @narrowPair, 2, 0
     v1 = frame_load multi_return, word, 0 !metadata(memory=scratch)
     v2 = add v1, 32
     v3 = mload v2
     v4 = and v0, 255
-    v5 = internal_call @load_storage_word_array, 1, v3
+    v5 = icall @load_storage_word_array, 1, v3
     ret v4, v5
 }
 
 fn @forwardLeadingPair() -> (memoryarray, u256) [selector=0x59d1f54e, view, abi_params=[], abi_returns=[memory_array<word>, word]] {
   bb0:
-    v0 = internal_call @leadingPair, 2, 0
+    v0 = icall @leadingPair, 2, 0
     v1 = frame_load multi_return, word, 0 !metadata(memory=scratch)
     v2 = add v1, 32
     v3 = mload v2
-    v4 = internal_call @load_storage_word_array, 1, v0
+    v4 = icall @load_storage_word_array, 1, v0
     ret v4, v3
 }
 
 fn @forwardTriple() -> (memoryarray, u256, memorybytes) [selector=0xd5d6b86b, view, abi_params=[], abi_returns=[memory_array<word>, word, memory_bytes]] {
   bb0:
-    v0 = internal_call @triple, 3, 0, 1
+    v0 = icall @triple, 3, 0, 1
     v1 = frame_load multi_return, word, 0 !metadata(memory=scratch)
     v2 = add v1, 32
     v3 = mload v2
     v4 = add v1, 64
     v5 = mload v4
-    v6 = internal_call @load_storage_word_array, 1, v0
+    v6 = icall @load_storage_word_array, 1, v0
     v7 = sload v5 !metadata(storage=symbolic(v5))
     v8 = and v7, 1
     v9 = eq v8, 1
@@ -218,27 +218,27 @@ fn @forwardTriple() -> (memoryarray, u256, memorybytes) [selector=0xd5d6b86b, vi
 
 fn @declarePair() -> (u256, memoryarray) [selector=0x2538210e, view, abi_params=[], abi_returns=[word, memory_array<word>]] {
   bb0:
-    v0 = internal_call @pair, 2, 0
+    v0 = icall @pair, 2, 0
     v1 = frame_load multi_return, word, 0 !metadata(memory=scratch)
     v2 = add v1, 32
     v3 = mload v2
-    v4 = internal_call @load_storage_word_array, 1, v3
+    v4 = icall @load_storage_word_array, 1, v3
     ret v0, v4
 }
 
 fn @assignPair() -> (u256, memoryarray) [selector=0x9355e772, view, abi_params=[], abi_returns=[word, memory_array<word>]] {
   bb0:
-    v0 = internal_call @pair, 2, 0
+    v0 = icall @pair, 2, 0
     v1 = frame_load multi_return, word, 0 !metadata(memory=scratch)
     v2 = add v1, 32
     v3 = mload v2
-    v4 = internal_call @load_storage_word_array, 1, v3
+    v4 = icall @load_storage_word_array, 1, v3
     ret v0, v4
 }
 
 fn @keepStorage() -> (u256, storageptr) [view] {
   bb0:
-    v0 = internal_call @pair, 2, 0
+    v0 = icall @pair, 2, 0
     v1 = frame_load multi_return, word, 0 !metadata(memory=scratch)
     v2 = add v1, 32
     v3 = mload v2
@@ -247,7 +247,7 @@ fn @keepStorage() -> (u256, storageptr) [view] {
 
 fn @forwardKeepingStorage() -> (u256, u256) [selector=0xe85db471, view, abi_params=[], abi_returns=[word, word]] {
   bb0:
-    v0 = internal_call @keepStorage, 2
+    v0 = icall @keepStorage, 2
     v1 = frame_load multi_return, word, 0 !metadata(memory=scratch)
     v2 = add v1, 32
     v3 = mload v2
@@ -350,7 +350,7 @@ fn @store_storage_bytes(arg0: u256, arg1: memorybytes) {
     v19 = and v2, v18
     jumpi v19, bb5, bb6
   bb5:
-    internal_call @clear_storage_words, 0, arg0, v17, v12
+    icall @clear_storage_words, 0, arg0, v17, v12
     jump bb6
   bb6:
     jumpi v16, bb7, bb8

--- a/tests/ui/codegen/lowering/run-call/library_storage_pointer_multi_return.sol
+++ b/tests/ui/codegen/lowering/run-call/library_storage_pointer_multi_return.sol
@@ -1,0 +1,113 @@
+//@ codegen-matrix: standard
+//@ run-call: LibraryStoragePointerMultiReturn::forwardPair => 2, [11, 22]
+//@ run-call: LibraryStoragePointerMultiReturn::forwardBytesPair => 3, 0xaabbcc
+//@ run-call: LibraryStoragePointerMultiReturn::forwardStructPair => 7, (7, [33])
+//@ run-call: LibraryStoragePointerMultiReturn::forwardNarrowPair => 2, [11, 22]
+//@ run-call: LibraryStoragePointerMultiReturn::forwardLeadingPair => [11, 22], 2
+//@ run-call: LibraryStoragePointerMultiReturn::forwardTriple => [11, 22], 2, 0xaabbcc
+//@ run-call: LibraryStoragePointerMultiReturn::declarePair => 2, [11, 22]
+//@ run-call: LibraryStoragePointerMultiReturn::assignPair => 2, [11, 22]
+//@ run-call: LibraryStoragePointerMultiReturn::forwardKeepingStorage => 2, 2
+
+// A library function returning a storage reference hands its caller the slot word, so a caller
+// declared to return the same component in memory must copy the object out of storage instead of
+// forwarding the slot as if it were a memory pointer. Expected values are solc 0.8.36's.
+library Lib {
+    struct S {
+        uint256 a;
+        uint256[] v;
+    }
+
+    function pair(uint256[] storage a) internal view returns (uint256, uint256[] storage) {
+        return (a.length, a);
+    }
+
+    function bytesPair(bytes storage b) internal view returns (uint256, bytes storage) {
+        return (b.length, b);
+    }
+
+    function structPair(S storage s) internal view returns (uint256, S storage) {
+        return (s.a, s);
+    }
+
+    function narrowPair(uint256[] storage a) internal view returns (uint8, uint256[] storage) {
+        return (uint8(a.length), a);
+    }
+
+    function leadingPair(uint256[] storage a)
+        internal
+        view
+        returns (uint256[] storage, uint256)
+    {
+        return (a, a.length);
+    }
+
+    function triple(uint256[] storage a, bytes storage b)
+        internal
+        view
+        returns (uint256[] storage, uint256, bytes storage)
+    {
+        return (a, a.length, b);
+    }
+}
+
+contract LibraryStoragePointerMultiReturn {
+    uint256[] private nums;
+    bytes private bs;
+    Lib.S private s;
+
+    constructor() {
+        nums.push(11);
+        nums.push(22);
+        bs = hex"aabbcc";
+        s.a = 7;
+        s.v.push(33);
+    }
+
+    function forwardPair() external view returns (uint256, uint256[] memory) {
+        return Lib.pair(nums);
+    }
+
+    function forwardBytesPair() external view returns (uint256, bytes memory) {
+        return Lib.bytesPair(bs);
+    }
+
+    function forwardStructPair() external view returns (uint256, Lib.S memory) {
+        return Lib.structPair(s);
+    }
+
+    // The value component also needs its own conversion, here a widening one.
+    function forwardNarrowPair() external view returns (uint256, uint256[] memory) {
+        return Lib.narrowPair(nums);
+    }
+
+    function forwardLeadingPair() external view returns (uint256[] memory, uint256) {
+        return Lib.leadingPair(nums);
+    }
+
+    function forwardTriple() external view returns (uint256[] memory, uint256, bytes memory) {
+        return Lib.triple(nums, bs);
+    }
+
+    function declarePair() external view returns (uint256, uint256[] memory) {
+        (uint256 n, uint256[] memory m) = Lib.pair(nums);
+        return (n, m);
+    }
+
+    function assignPair() external view returns (uint256, uint256[] memory) {
+        uint256 n;
+        uint256[] memory m;
+        (n, m) = Lib.pair(nums);
+        return (n, m);
+    }
+
+    // A declared storage return keeps the slot, which is what the callee already returned.
+    function keepStorage() internal view returns (uint256, uint256[] storage) {
+        return Lib.pair(nums);
+    }
+
+    function forwardKeepingStorage() external view returns (uint256, uint256) {
+        (uint256 n, uint256[] storage r) = keepStorage();
+        return (n, r.length);
+    }
+}

--- a/tests/ui/codegen/lowering/run-call/library_storage_pointer_nested.sol
+++ b/tests/ui/codegen/lowering/run-call/library_storage_pointer_nested.sol
@@ -1,0 +1,68 @@
+//@ revisions: homestead byzantium osaka
+//@[homestead] compile-flags: --evm-version homestead
+//@[byzantium] compile-flags: --evm-version byzantium
+//@[osaka] compile-flags: --evm-version osaka
+//@ run-call: C::memberWrite => 7
+//@ run-call: C::valueWrite => 9
+//@ run-call: C::nestedPop => 1
+//@ run-call: C::readBack => 12
+
+// A nested storage pointer crossing a library boundary is still one slot word, so the pointer
+// the library returns indexes, writes and resizes the caller's own storage. An external library
+// cannot be deployed by `run-call`, so these are internal calls, which also exercises the
+// pointer path before Byzantium, where an external call's return data is unreadable.
+library L {
+    struct S {
+        uint256[] arr;
+        mapping(uint256 => uint256[]) byKey;
+    }
+
+    // A pointer to a struct member.
+    function memberArr(S storage s) internal view returns (uint256[] storage) {
+        return s.arr;
+    }
+
+    // A pointer to a mapping value.
+    function valueArr(S storage s, uint256 key) internal view returns (uint256[] storage) {
+        return s.byKey[key];
+    }
+
+    // A pointer to an element of an array of arrays.
+    function nested(uint256[][] storage aa, uint256 i) internal view returns (uint256[] storage) {
+        return aa[i];
+    }
+}
+
+contract C {
+    L.S private s;
+    uint256[][] private aa;
+
+    // A returned pointer used as an lvalue writes the caller's storage.
+    function memberWrite() external returns (uint256) {
+        s.arr.push(1);
+        s.arr.push(2);
+        L.memberArr(s)[1] = 7;
+        return s.arr[1];
+    }
+
+    function valueWrite() external returns (uint256) {
+        L.valueArr(s, 3).push(9);
+        return s.byKey[3][0];
+    }
+
+    // Resizing through a returned pointer resizes the caller's array.
+    function nestedPop() external returns (uint256) {
+        aa.push();
+        aa[0].push(1);
+        aa[0].push(2);
+        L.nested(aa, 0).pop();
+        return aa[0].length;
+    }
+
+    // Reading through a pointer sees writes made through another pointer to the same object.
+    function readBack() external returns (uint256) {
+        L.memberArr(s).push(5);
+        L.valueArr(s, 1).push(7);
+        return L.memberArr(s)[0] + L.valueArr(s, 1)[0];
+    }
+}

--- a/tests/ui/codegen/run-call/library_mapping_pointer_destructuring.sol
+++ b/tests/ui/codegen/run-call/library_mapping_pointer_destructuring.sol
@@ -1,0 +1,37 @@
+//@ run-call: sum() => 45
+//@ run-call: writeThrough() => 7
+
+// A destructuring declaration binds its targets from the statement's initializer, so a mapping
+// storage pointer declared there is initialized even though the target itself carries no
+// initializer. Writing through the pointer writes the state variable's mapping.
+library IL {
+    struct S {
+        mapping(uint256 => uint256) m;
+        uint256 n;
+    }
+
+    function both(S storage s)
+        internal
+        view
+        returns (mapping(uint256 => uint256) storage, uint256)
+    {
+        return (s.m, s.n);
+    }
+}
+
+contract C {
+    IL.S private s;
+
+    function sum() external returns (uint256) {
+        s.n = 5;
+        (mapping(uint256 => uint256) storage m, uint256 n) = IL.both(s);
+        m[1] = 40;
+        return m[1] + n;
+    }
+
+    function writeThrough() external returns (uint256) {
+        (mapping(uint256 => uint256) storage m, ) = IL.both(s);
+        m[2] = 7;
+        return s.m[2];
+    }
+}


### PR DESCRIPTION
Part of the split of the solc-vs-solar differential audit branch (#1360). Based on #1367, whose pre-byzantium inaccessible-value check this relaxes for storage references; #1372 builds on it.

An external library function returning a storage pointer encoded the return as a memory array, so from byzantium on the caller decoded an offset instead of a slot, read zeros through the pointer and pushed into another slot. Storage references now cross the library ABI boundary as slot words in both directions, as solc's `encodingType` and `decodingType` prescribe, the pre-byzantium inaccessible-value check exempts them, and the last memory rewrite of an external call's reference returns is gone. A Foundry project pins solc's values for reads, sums, and pushes through the returned pointer.
