### PR TITLE
fix(sema): add solc's interface and free function checks

### DIFF
--- a/crates/sema/src/ast_lowering/resolve.rs
+++ b/crates/sema/src/ast_lowering/resolve.rs
@@ -365,7 +365,7 @@ impl<'gcx> ResolveContext<'gcx> {
 
             let func = self.hir.function(id);
             self.hir.functions[id].overrides =
-                self.lower_overrides(ast_func.header.override_.as_ref(), func.contract, true);
+                self.lower_overrides(ast_func.header.override_.as_ref(), func.contract);
 
             self.hir.functions[id].parameters = self.lower_variables(
                 *ast_func.header.parameters,
@@ -670,7 +670,7 @@ impl<'gcx> ResolveContext<'gcx> {
         self.hir.variables[id].initializer = init;
         self.hir.variables[id].ty = ty;
 
-        let overrides = self.lower_overrides(ast_var.override_.as_ref(), var_contract, false);
+        let overrides = self.lower_overrides(ast_var.override_.as_ref(), var_contract);
         self.hir.variables[id].overrides = overrides;
         if let Some(getter_id) = var_getter {
             self.hir.functions[getter_id].overrides = overrides;
@@ -1943,7 +1943,6 @@ impl<'gcx> ResolveContext<'gcx> {
         &mut self,
         override_: Option<&ast::Override<'_>>,
         contract: Option<hir::ContractId>,
-        is_function: bool,
     ) -> &'gcx [hir::ContractId] {
         let Some(ov) = override_ else {
             return &[];
@@ -1955,14 +1954,9 @@ impl<'gcx> ResolveContext<'gcx> {
                 continue;
             };
 
+            // A free function with an override specifier, with or without a contract list, is
+            // reported by `typeck::check_free_function`.
             let Some(c) = contract else {
-                if is_function {
-                    self.dcx()
-                        .err("free functions cannot override")
-                        .code(error_code!(1750))
-                        .span(ov.span)
-                        .emit();
-                }
                 continue;
             };
 

--- a/crates/sema/src/ast_lowering/resolve.rs
+++ b/crates/sema/src/ast_lowering/resolve.rs
@@ -398,14 +398,16 @@ impl<'gcx> ResolveContext<'gcx> {
                                     self.hir.contract(c).linearized_bases[1..].contains(&base)
                                 }) => {}
                         hir::ItemId::Function(f) if self.hir.function(f).kind.is_modifier() => {
+                            // A modifier on a free function is reported by
+                            // `ast_passes::AstValidator`, so solc only looks at the modifier's
+                            // contract for a function that is in one.
+                            let Some(current) = func.contract else { continue };
                             let modifier_contract = self.hir.function(f).contract;
-                            let allowed = func.contract.is_some_and(|current| {
-                                modifier_contract.is_some_and(|modifier_contract| {
-                                    self.hir
-                                        .contract(current)
-                                        .linearized_bases
-                                        .contains(&modifier_contract)
-                                })
+                            let allowed = modifier_contract.is_some_and(|modifier_contract| {
+                                self.hir
+                                    .contract(current)
+                                    .linearized_bases
+                                    .contains(&modifier_contract)
                             });
                             if !allowed {
                                 self.dcx().emit_err(modifier.name.span(), "can only use modifiers defined in the current contract or in base contracts");

--- a/crates/sema/src/ast_passes.rs
+++ b/crates/sema/src/ast_passes.rs
@@ -3,7 +3,7 @@
 use alloy_primitives::Address;
 use solar_ast::{self as ast, visit::Visit};
 use solar_data_structures::Never;
-use solar_interface::{Session, Span, diagnostics::DiagCtxt, sym};
+use solar_interface::{Session, Span, diagnostics::DiagCtxt, error_code, sym};
 use std::ops::ControlFlow;
 
 #[instrument(name = "ast_passes", level = "debug", skip_all)]
@@ -325,6 +325,15 @@ impl<'ast> Visit<'ast> for AstValidator<'_, 'ast> {
         if self.contract.is_none() && func.kind.is_function() {
             if !func.is_implemented() {
                 self.dcx().emit_err(self.item_span, "free functions must be implemented");
+            }
+            // Checked here rather than in `typeck` because a modifier invocation on a free
+            // function never resolves, so it is never lowered into the HIR function.
+            if !func.header.modifiers.is_empty() {
+                self.dcx()
+                    .err("free functions cannot have modifiers")
+                    .code(error_code!(5811))
+                    .span(self.item_span)
+                    .emit();
             }
             if let Some(visibility) = func.header.visibility {
                 self.dcx()

--- a/crates/sema/src/hir/mod.rs
+++ b/crates/sema/src/hir/mod.rs
@@ -907,15 +907,20 @@ impl Contract<'_> {
             || (!self.bases.is_empty() && self.linearized_bases.len() == 1)
     }
 
-    /// Returns an iterator over functions declared in the contract.
+    /// Returns an iterator over the functions declared in the contract itself, including its
+    /// constructor, modifiers, and `fallback` and `receive` functions.
     ///
-    /// Note that this does not include the constructor and fallback functions, as they are stored
-    /// separately. Use [`Contract::all_functions`] to include them.
+    /// Note that this does not include the inherited `fallback` and `receive` functions; use
+    /// [`Contract::all_functions`] for those.
     pub fn functions(&self) -> impl Iterator<Item = FunctionId> + Clone + use<'_> {
         self.items.iter().filter_map(ItemId::as_function)
     }
 
-    /// Returns an iterator over all functions declared in the contract.
+    /// Returns an iterator over the functions declared in the contract itself, followed by its
+    /// resolved constructor and `fallback` and `receive` functions.
+    ///
+    /// Note that the resolved functions repeat the ones declared in the contract itself, so this
+    /// can yield the same function twice.
     pub fn all_functions(&self) -> impl Iterator<Item = FunctionId> + Clone + use<'_> {
         self.functions().chain(self.ctor).chain(self.fallback).chain(self.receive)
     }

--- a/crates/sema/src/typeck/mod.rs
+++ b/crates/sema/src/typeck/mod.rs
@@ -335,11 +335,30 @@ fn same_external_params<'gcx>(gcx: Gcx<'gcx>, a: Ty<'gcx>, b: Ty<'gcx>) -> bool 
     key(a) == key(b)
 }
 
+/// Checks that every declaration without a body is allowed to have none.
+///
+/// References:
+/// - functions: <https://github.com/argotorg/solidity/blob/8a079791d9cca7a6c03fd6a8429b93aa3bddefed/libsolidity/analysis/TypeChecker.cpp#L448-L460>
+/// - `virtual`: <https://github.com/argotorg/solidity/blob/8a079791d9cca7a6c03fd6a8429b93aa3bddefed/libsolidity/analysis/TypeChecker.cpp#L306-L318>
+/// - modifiers: <https://github.com/argotorg/solidity/blob/8a079791d9cca7a6c03fd6a8429b93aa3bddefed/libsolidity/analysis/TypeChecker.cpp#L300-L301>
 fn check_unimplemented_functions(gcx: Gcx<'_>, contract_id: hir::ContractId) {
     let contract = gcx.hir.contract(contract_id);
 
     for f_id in contract.functions() {
         let f = gcx.hir.function(f_id);
+
+        // Modifiers are not functions in solc, so they get their own error instead of the
+        // function ones below, and they are never implicitly `virtual` in an interface.
+        if f.kind.is_modifier() {
+            if f.body.is_none() && !f.marked_virtual {
+                gcx.dcx()
+                    .err("modifiers without implementation must be marked `virtual`")
+                    .code(error_code!(8063))
+                    .span(f.span)
+                    .emit();
+            }
+            continue;
+        }
 
         // In an interface, solc's `virtual` chain stops at the implicitly-`virtual` warning
         // reported by `check_interface_members`.

--- a/crates/sema/src/typeck/mod.rs
+++ b/crates/sema/src/typeck/mod.rs
@@ -42,6 +42,7 @@ fn check_contract(gcx: Gcx<'_>, id: hir::ContractId) {
     check_external_type_clashes(gcx, id);
     check_receive_function(gcx, id);
     check_library_functions(gcx, id);
+    check_interface_functions(gcx, id);
     for f_id in gcx.hir.contract(id).functions() {
         check_payable_function(gcx, gcx.hir.function(f_id));
     }
@@ -56,7 +57,9 @@ fn check_source(gcx: Gcx<'_>, id: hir::SourceId) {
     check_duplicate_definitions(gcx, &gcx.symbol_resolver.source_scopes[id]);
     check_break_continue(gcx, id);
     for f_id in gcx.hir.source(id).items.iter().filter_map(ItemId::as_function) {
-        check_payable_function(gcx, gcx.hir.function(f_id));
+        let f = gcx.hir.function(f_id);
+        check_free_function(gcx, f);
+        check_payable_function(gcx, f);
     }
     for using in gcx.hir.source(id).usings {
         check_using_directive(gcx, using);
@@ -454,6 +457,47 @@ fn check_library_functions(gcx: Gcx<'_>, contract_id: hir::ContractId) {
                 .span(f.span)
                 .emit();
         }
+    }
+}
+
+/// Checks restrictions that only apply to functions declared in an interface.
+///
+/// Reference: <https://github.com/argotorg/solidity/blob/8a079791d9cca7a6c03fd6a8429b93aa3bddefed/libsolidity/analysis/TypeChecker.cpp#L434-L443>
+fn check_interface_functions(gcx: Gcx<'_>, contract_id: hir::ContractId) {
+    let contract = gcx.hir.contract(contract_id);
+    if !contract.kind.is_interface() {
+        return;
+    }
+
+    for f_id in contract.functions() {
+        let f = gcx.hir.function(f_id);
+
+        // Constructors and modifiers cannot be declared in an interface at all, and getters are
+        // always `external`.
+        if f.is_constructor() || f.kind.is_modifier() {
+            continue;
+        }
+
+        if f.visibility != Visibility::External {
+            gcx.dcx()
+                .err("functions in interfaces must be declared `external`")
+                .code(error_code!(1560))
+                .span(f.span)
+                .emit();
+        }
+    }
+}
+
+/// Checks restrictions that only apply to free functions.
+///
+/// Reference: <https://github.com/argotorg/solidity/blob/8a079791d9cca7a6c03fd6a8429b93aa3bddefed/libsolidity/analysis/TypeChecker.cpp#L306-L309>
+fn check_free_function(gcx: Gcx<'_>, f: &hir::Function<'_>) {
+    if f.marked_virtual {
+        gcx.dcx()
+            .err("free functions cannot be `virtual`")
+            .code(error_code!(4493))
+            .span(f.span)
+            .emit();
     }
 }
 

--- a/crates/sema/src/typeck/mod.rs
+++ b/crates/sema/src/typeck/mod.rs
@@ -531,8 +531,9 @@ fn check_interface_members(gcx: Gcx<'_>, contract_id: hir::ContractId) {
 
                 // Getters have no declaration of their own in solc, and are always lowered as an
                 // implemented `external` function here; the variable they belong to is rejected
-                // below instead.
-                if f.is_getter() {
+                // below instead. Yul functions from inline assembly are items too, but they
+                // belong to the function that contains them, which is reported on its own.
+                if f.is_getter() || f.is_yul {
                     continue;
                 }
 

--- a/crates/sema/src/typeck/mod.rs
+++ b/crates/sema/src/typeck/mod.rs
@@ -42,7 +42,7 @@ fn check_contract(gcx: Gcx<'_>, id: hir::ContractId) {
     check_external_type_clashes(gcx, id);
     check_receive_function(gcx, id);
     check_library_functions(gcx, id);
-    check_interface_functions(gcx, id);
+    check_interface_members(gcx, id);
     for f_id in gcx.hir.contract(id).functions() {
         check_payable_function(gcx, gcx.hir.function(f_id));
     }
@@ -341,7 +341,10 @@ fn check_unimplemented_functions(gcx: Gcx<'_>, contract_id: hir::ContractId) {
     for f_id in contract.functions() {
         let f = gcx.hir.function(f_id);
 
-        if f.marked_virtual && f.visibility == Visibility::Private {
+        // In an interface, solc's `virtual` chain stops at the implicitly-`virtual` warning
+        // reported by `check_interface_members`.
+        let virtual_private = f.marked_virtual && f.visibility == Visibility::Private;
+        if virtual_private && !contract.kind.is_interface() {
             gcx.dcx()
                 .err("`virtual` and `private` cannot be used together")
                 .code(error_code!(3942))
@@ -382,7 +385,10 @@ fn check_receive_function(gcx: Gcx<'_>, contract_id: hir::ContractId) {
     if contract.kind.is_library() {
         if let Some(receive) = contract.receive {
             gcx.dcx()
-                .emit_err(gcx.item_span(receive), "libraries cannot have receive ether functions");
+                .err("libraries cannot have receive ether functions")
+                .code(error_code!(4549))
+                .span(gcx.item_span(receive))
+                .emit();
         }
         return;
     }
@@ -425,6 +431,7 @@ fn check_receive_function(gcx: Gcx<'_>, contract_id: hir::ContractId) {
 /// - `virtual`: <https://github.com/argotorg/solidity/blob/8a079791d9cca7a6c03fd6a8429b93aa3bddefed/libsolidity/analysis/TypeChecker.cpp#L306-L318>
 /// - constructor: <https://github.com/argotorg/solidity/blob/8a079791d9cca7a6c03fd6a8429b93aa3bddefed/libsolidity/analysis/TypeChecker.cpp#L444-L446>
 /// - `fallback`: <https://github.com/argotorg/solidity/blob/8a079791d9cca7a6c03fd6a8429b93aa3bddefed/libsolidity/analysis/TypeChecker.cpp#L2016-L2017>
+/// - modifiers: <https://github.com/argotorg/solidity/blob/8a079791d9cca7a6c03fd6a8429b93aa3bddefed/libsolidity/analysis/TypeChecker.cpp#L282-L291>
 fn check_library_functions(gcx: Gcx<'_>, contract_id: hir::ContractId) {
     let contract = gcx.hir.contract(contract_id);
     if !contract.kind.is_library() {
@@ -433,6 +440,19 @@ fn check_library_functions(gcx: Gcx<'_>, contract_id: hir::ContractId) {
 
     for f_id in contract.functions() {
         let f = gcx.hir.function(f_id);
+
+        // Modifiers are not functions in solc, so they get their own error instead of the
+        // function ones below.
+        if f.kind.is_modifier() {
+            if f.marked_virtual {
+                gcx.dcx()
+                    .err("modifiers in a library cannot be `virtual`")
+                    .code(error_code!(3275))
+                    .span(f.span)
+                    .emit();
+            }
+            continue;
+        }
 
         // A `private virtual` function is reported by `check_unimplemented_functions` instead.
         if f.marked_virtual && f.visibility != Visibility::Private {
@@ -460,37 +480,95 @@ fn check_library_functions(gcx: Gcx<'_>, contract_id: hir::ContractId) {
     }
 }
 
-/// Checks restrictions that only apply to functions declared in an interface.
+/// Checks restrictions that only apply to members declared in an interface.
 ///
-/// Reference: <https://github.com/argotorg/solidity/blob/8a079791d9cca7a6c03fd6a8429b93aa3bddefed/libsolidity/analysis/TypeChecker.cpp#L434-L443>
-fn check_interface_functions(gcx: Gcx<'_>, contract_id: hir::ContractId) {
+/// References:
+/// - functions: <https://github.com/argotorg/solidity/blob/8a079791d9cca7a6c03fd6a8429b93aa3bddefed/libsolidity/analysis/TypeChecker.cpp#L432-L443>
+/// - `virtual`: <https://github.com/argotorg/solidity/blob/8a079791d9cca7a6c03fd6a8429b93aa3bddefed/libsolidity/analysis/TypeChecker.cpp#L306-L318>
+/// - modifiers: <https://github.com/argotorg/solidity/blob/8a079791d9cca7a6c03fd6a8429b93aa3bddefed/libsolidity/analysis/TypeChecker.cpp#L292-L297>
+/// - variables: <https://github.com/argotorg/solidity/blob/8a079791d9cca7a6c03fd6a8429b93aa3bddefed/libsolidity/analysis/PostTypeChecker.cpp#L391-L401>
+fn check_interface_members(gcx: Gcx<'_>, contract_id: hir::ContractId) {
     let contract = gcx.hir.contract(contract_id);
     if !contract.kind.is_interface() {
         return;
     }
 
-    for f_id in contract.functions() {
-        let f = gcx.hir.function(f_id);
+    // Iterate over the items in declaration order to report them in the same order solc does.
+    for &item in contract.items {
+        match item {
+            ItemId::Function(f_id) => {
+                let f = gcx.hir.function(f_id);
 
-        // Constructors and modifiers cannot be declared in an interface at all, and getters are
-        // always `external`.
-        if f.is_constructor() || f.kind.is_modifier() {
-            continue;
-        }
+                // Modifiers are not functions in solc, so they get their own error instead of the
+                // function ones below.
+                if f.kind.is_modifier() {
+                    gcx.dcx()
+                        .err("modifiers cannot be defined or declared in interfaces")
+                        .code(error_code!(6408))
+                        .span(f.span)
+                        .emit();
+                    continue;
+                }
 
-        if f.visibility != Visibility::External {
-            gcx.dcx()
-                .err("functions in interfaces must be declared `external`")
-                .code(error_code!(1560))
-                .span(f.span)
-                .emit();
+                // Getters have no declaration of their own in solc, and are always lowered as an
+                // implemented `external` function here; the variable they belong to is rejected
+                // below instead.
+                if f.is_getter() {
+                    continue;
+                }
+
+                // `virtual` is implied here, and ends solc's `virtual` chain: see
+                // `check_library_functions` and `check_unimplemented_functions`.
+                if f.marked_virtual {
+                    gcx.dcx()
+                        .warn("interface functions are implicitly `virtual`")
+                        .code(error_code!(5815))
+                        .span(f.span)
+                        .emit();
+                }
+
+                if f.body.is_some() {
+                    gcx.dcx()
+                        .err("functions in interfaces cannot have an implementation")
+                        .code(error_code!(4726))
+                        .span(f.span)
+                        .emit();
+                }
+
+                if f.is_constructor() {
+                    gcx.dcx()
+                        .err("constructor cannot be defined in interfaces")
+                        .code(error_code!(6482))
+                        .span(f.span)
+                        .emit();
+                } else if f.visibility != Visibility::External {
+                    gcx.dcx()
+                        .err("functions in interfaces must be declared `external`")
+                        .code(error_code!(1560))
+                        .span(f.span)
+                        .emit();
+                }
+            }
+            // Parameters and struct fields are not items, so every variable item declared in an
+            // interface is rejected, `constant` ones included.
+            ItemId::Variable(v_id) => {
+                let v = gcx.hir.variable(v_id);
+                gcx.dcx()
+                    .err("variables cannot be declared in interfaces")
+                    .code(error_code!(8274))
+                    .span(v.span)
+                    .emit();
+            }
+            _ => {}
         }
     }
 }
 
 /// Checks restrictions that only apply to free functions.
 ///
-/// Reference: <https://github.com/argotorg/solidity/blob/8a079791d9cca7a6c03fd6a8429b93aa3bddefed/libsolidity/analysis/TypeChecker.cpp#L306-L309>
+/// References:
+/// - `virtual`: <https://github.com/argotorg/solidity/blob/8a079791d9cca7a6c03fd6a8429b93aa3bddefed/libsolidity/analysis/TypeChecker.cpp#L306-L309>
+/// - `override`: <https://github.com/argotorg/solidity/blob/8a079791d9cca7a6c03fd6a8429b93aa3bddefed/libsolidity/analysis/TypeChecker.cpp#L319-L320>
 fn check_free_function(gcx: Gcx<'_>, f: &hir::Function<'_>) {
     if f.marked_virtual {
         gcx.dcx()
@@ -498,6 +576,10 @@ fn check_free_function(gcx: Gcx<'_>, f: &hir::Function<'_>) {
             .code(error_code!(4493))
             .span(f.span)
             .emit();
+    }
+
+    if f.override_ {
+        gcx.dcx().err("free functions cannot override").code(error_code!(1750)).span(f.span).emit();
     }
 }
 

--- a/tests/ui/resolve/func_modifiers.sol
+++ b/tests/ui/resolve/func_modifiers.sol
@@ -7,7 +7,7 @@ abstract contract A {
 }
 
 interface B {
-    modifier x() {
+    modifier x() { //~ERROR: modifiers cannot be defined or declared in interfaces
         _;
     }
 

--- a/tests/ui/resolve/func_modifiers.stderr
+++ b/tests/ui/resolve/func_modifiers.stderr
@@ -10,5 +10,13 @@ error: functions in interfaces cannot have modifiers
 LL │     function j() external x;
    ╰╴    ━━━━━━━━━━━━━━━━━━━━━━━━
 
-error: aborting due to 2 previous errors
+error[6408]: modifiers cannot be defined or declared in interfaces
+   ╭▸ ROOT/tests/ui/resolve/func_modifiers.sol:LL:CC
+   │
+LL │ ┏     modifier x() {
+LL │ ┃         _;
+LL │ ┃     }
+   ╰╴┗━━━━━┛
+
+error: aborting due to 3 previous errors
 

--- a/tests/ui/resolve/func_visibility.sol
+++ b/tests/ui/resolve/func_visibility.sol
@@ -8,6 +8,7 @@ contract U1 {
 
 interface U2 {
     function c() {} //~ERROR: no visibility specified
+    //~^ ERROR: functions in interfaces must be declared `external`
 }
 
 contract U3 {

--- a/tests/ui/resolve/func_visibility.sol
+++ b/tests/ui/resolve/func_visibility.sol
@@ -8,7 +8,8 @@ contract U1 {
 
 interface U2 {
     function c() {} //~ERROR: no visibility specified
-    //~^ ERROR: functions in interfaces must be declared `external`
+    //~^ ERROR: functions in interfaces cannot have an implementation
+    //~| ERROR: functions in interfaces must be declared `external`
 }
 
 contract U3 {

--- a/tests/ui/resolve/func_visibility.stderr
+++ b/tests/ui/resolve/func_visibility.stderr
@@ -44,11 +44,17 @@ error: free functions must be implemented
 LL │ function xyz();
    ╰╴━━━━━━━━━━━━━━━
 
+error[1560]: functions in interfaces must be declared `external`
+   ╭▸ ROOT/tests/ui/resolve/func_visibility.sol:LL:CC
+   │
+LL │     function c() {}
+   ╰╴    ━━━━━━━━━━━━━━━
+
 error: receive ether function must be defined as `external`
    ╭▸ ROOT/tests/ui/resolve/func_visibility.sol:LL:CC
    │
 LL │     receive() payable {}
    ╰╴    ━━━━━━━━━━━━━━━━━━━━
 
-error: aborting due to 7 previous errors
+error: aborting due to 8 previous errors
 

--- a/tests/ui/resolve/func_visibility.stderr
+++ b/tests/ui/resolve/func_visibility.stderr
@@ -44,6 +44,12 @@ error: free functions must be implemented
 LL │ function xyz();
    ╰╴━━━━━━━━━━━━━━━
 
+error[4726]: functions in interfaces cannot have an implementation
+   ╭▸ ROOT/tests/ui/resolve/func_visibility.sol:LL:CC
+   │
+LL │     function c() {}
+   ╰╴    ━━━━━━━━━━━━━━━
+
 error[1560]: functions in interfaces must be declared `external`
    ╭▸ ROOT/tests/ui/resolve/func_visibility.sol:LL:CC
    │
@@ -56,5 +62,5 @@ error: receive ether function must be defined as `external`
 LL │     receive() payable {}
    ╰╴    ━━━━━━━━━━━━━━━━━━━━
 
-error: aborting due to 8 previous errors
+error: aborting due to 9 previous errors
 

--- a/tests/ui/resolve/override_specifier.stderr
+++ b/tests/ui/resolve/override_specifier.stderr
@@ -1,9 +1,3 @@
-error[1750]: free functions cannot override
-   ╭▸ ROOT/tests/ui/resolve/override_specifier.sol:LL:CC
-   │
-LL │ function freeFunc() override(A) returns (uint) { return 42; }
-   ╰╴                    ━━━━━━━━━━━
-
 error[2353]: invalid contract `B` specified in override list
    ╭▸ ROOT/tests/ui/resolve/override_specifier.sol:LL:CC
    │
@@ -11,6 +5,12 @@ LL │     function foo() public override(A, B) returns (uint) { return 3; }
    │                           ━━━━━━━━━━━━━━
    │
    ╰ note: contract is not a direct or indirect base
+
+error[1750]: free functions cannot override
+   ╭▸ ROOT/tests/ui/resolve/override_specifier.sol:LL:CC
+   │
+LL │ function freeFunc() override(A) returns (uint) { return 42; }
+   ╰╴━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/resolve/receive_func.stderr
+++ b/tests/ui/resolve/receive_func.stderr
@@ -1,4 +1,4 @@
-error: libraries cannot have receive ether functions
+error[4549]: libraries cannot have receive ether functions
    ╭▸ ROOT/tests/ui/resolve/receive_func.sol:LL:CC
    │
 LL │     receive() external payable {}

--- a/tests/ui/typeck/free_function_modifiers.sol
+++ b/tests/ui/typeck/free_function_modifiers.sol
@@ -5,7 +5,6 @@ contract C {
 }
 
 function fun() C.someModifier { //~ ERROR: free functions cannot have modifiers
-//~^ ERROR: can only use modifiers defined in the current contract or in base contracts
 }
 
 // A file-level name in the modifier position is rejected too; solc reports that the declaration is

--- a/tests/ui/typeck/free_function_modifiers.sol
+++ b/tests/ui/typeck/free_function_modifiers.sol
@@ -1,0 +1,19 @@
+// ported-from: test/libsolidity/syntaxTests/freeFunctions/free_function_qualified_modifier.sol
+
+contract C {
+  modifier someModifier() { _; }
+}
+
+function fun() C.someModifier { //~ ERROR: free functions cannot have modifiers
+//~^ ERROR: can only use modifiers defined in the current contract or in base contracts
+}
+
+// A file-level name in the modifier position is rejected too; solc reports that the declaration is
+// neither a modifier nor a base class instead.
+function fun2() fun {} //~ ERROR: free functions cannot have modifiers
+//~^ ERROR: expected modifier, found function
+
+// The restriction only applies to free functions.
+contract D is C {
+    function f() public someModifier {}
+}

--- a/tests/ui/typeck/free_function_modifiers.stderr
+++ b/tests/ui/typeck/free_function_modifiers.stderr
@@ -1,0 +1,28 @@
+error[5811]: free functions cannot have modifiers
+   ╭▸ ROOT/tests/ui/typeck/free_function_modifiers.sol:LL:CC
+   │
+LL │ ┏ function fun() C.someModifier {
+LL │ ┃
+LL │ ┃ }
+   ╰╴┗━┛
+
+error[5811]: free functions cannot have modifiers
+   ╭▸ ROOT/tests/ui/typeck/free_function_modifiers.sol:LL:CC
+   │
+LL │ function fun2() fun {}
+   ╰╴━━━━━━━━━━━━━━━━━━━━━━
+
+error: can only use modifiers defined in the current contract or in base contracts
+   ╭▸ ROOT/tests/ui/typeck/free_function_modifiers.sol:LL:CC
+   │
+LL │ function fun() C.someModifier {
+   ╰╴               ━━━━━━━━━━━━━━
+
+error: expected modifier, found function
+   ╭▸ ROOT/tests/ui/typeck/free_function_modifiers.sol:LL:CC
+   │
+LL │ function fun2() fun {}
+   ╰╴                ━━━
+
+error: aborting due to 4 previous errors
+

--- a/tests/ui/typeck/free_function_modifiers.stderr
+++ b/tests/ui/typeck/free_function_modifiers.stderr
@@ -2,7 +2,6 @@ error[5811]: free functions cannot have modifiers
    ╭▸ ROOT/tests/ui/typeck/free_function_modifiers.sol:LL:CC
    │
 LL │ ┏ function fun() C.someModifier {
-LL │ ┃
 LL │ ┃ }
    ╰╴┗━┛
 
@@ -12,17 +11,11 @@ error[5811]: free functions cannot have modifiers
 LL │ function fun2() fun {}
    ╰╴━━━━━━━━━━━━━━━━━━━━━━
 
-error: can only use modifiers defined in the current contract or in base contracts
-   ╭▸ ROOT/tests/ui/typeck/free_function_modifiers.sol:LL:CC
-   │
-LL │ function fun() C.someModifier {
-   ╰╴               ━━━━━━━━━━━━━━
-
 error: expected modifier, found function
    ╭▸ ROOT/tests/ui/typeck/free_function_modifiers.sol:LL:CC
    │
 LL │ function fun2() fun {}
    ╰╴                ━━━
 
-error: aborting due to 4 previous errors
+error: aborting due to 3 previous errors
 

--- a/tests/ui/typeck/free_function_override.sol
+++ b/tests/ui/typeck/free_function_override.sol
@@ -1,0 +1,16 @@
+// ported-from: test/libsolidity/syntaxTests/freeFunctions/free_override.sol
+
+function fun() override { //~ ERROR: free functions cannot override
+}
+
+// An override specifier with a contract list is rejected the same way.
+function fun2() override(A) {} //~ ERROR: free functions cannot override
+
+// The restriction only applies to free functions.
+contract A {
+    function foo() public virtual {}
+}
+
+contract B is A {
+    function foo() public override {}
+}

--- a/tests/ui/typeck/free_function_override.stderr
+++ b/tests/ui/typeck/free_function_override.stderr
@@ -1,0 +1,15 @@
+error[1750]: free functions cannot override
+   ╭▸ ROOT/tests/ui/typeck/free_function_override.sol:LL:CC
+   │
+LL │ ┏ function fun() override {
+LL │ ┃ }
+   ╰╴┗━┛
+
+error[1750]: free functions cannot override
+   ╭▸ ROOT/tests/ui/typeck/free_function_override.sol:LL:CC
+   │
+LL │ function fun2() override(A) {}
+   ╰╴━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+error: aborting due to 2 previous errors
+

--- a/tests/ui/typeck/function_implementation_checks.sol
+++ b/tests/ui/typeck/function_implementation_checks.sol
@@ -10,9 +10,15 @@ library L { //~ ERROR: contract `L` has unimplemented functions
     function f() public; //~ ERROR: library functions must be implemented if declared
 }
 
+// A modifier is not a function in solc, so an unimplemented one gets its own error.
+contract M { //~ ERROR: contract `M` has unimplemented functions
+    modifier m(); //~ ERROR: modifiers without implementation must be marked `virtual`
+}
+
 // Valid cases
 abstract contract ValidAbstract {
     function f() public virtual;
+    modifier m() virtual;
 }
 
 contract ValidConcrete {

--- a/tests/ui/typeck/function_implementation_checks.stderr
+++ b/tests/ui/typeck/function_implementation_checks.stderr
@@ -43,5 +43,25 @@ LL │     function f() public;
    │     ━━━━━━━━━━━━━━━━━━━━
    ╰ help: implement all functions
 
-error: aborting due to 5 previous errors
+error[8063]: modifiers without implementation must be marked `virtual`
+   ╭▸ ROOT/tests/ui/typeck/function_implementation_checks.sol:LL:CC
+   │
+LL │     modifier m();
+   ╰╴    ━━━━━━━━━━━━━
+
+error[3656]: contract `M` has unimplemented functions
+   ╭▸ ROOT/tests/ui/typeck/function_implementation_checks.sol:LL:CC
+   │
+LL │ contract M {
+   │ ┬─────── ━
+   │ │
+   │ help: mark the contract as abstract: `abstract contract`
+   ╰╴
+note: unimplemented modifier `m` defined in `M`
+   ╭▸ ROOT/tests/ui/typeck/function_implementation_checks.sol:LL:CC
+   │
+LL │     modifier m();
+   ╰╴    ━━━━━━━━━━━━━
+
+error: aborting due to 7 previous errors
 

--- a/tests/ui/typeck/interface_constructor.sol
+++ b/tests/ui/typeck/interface_constructor.sol
@@ -1,0 +1,23 @@
+interface I {
+    // solc also rejects `constructor();`, which is a parse error here.
+    constructor() {}
+    //~^ ERROR: functions in interfaces cannot have an implementation
+    //~| ERROR: constructor cannot be defined in interfaces
+}
+
+// A constructor in an interface is never the missing visibility error, and never the one for a
+// function that is not `external`.
+interface J {
+    constructor(uint256 x) {}
+    //~^ ERROR: functions in interfaces cannot have an implementation
+    //~| ERROR: constructor cannot be defined in interfaces
+}
+
+// Other contract kinds have their own errors, and a contract accepts a constructor.
+library L {
+    constructor() {} //~ ERROR: constructor cannot be defined in libraries
+}
+
+contract C {
+    constructor() {}
+}

--- a/tests/ui/typeck/interface_constructor.stderr
+++ b/tests/ui/typeck/interface_constructor.stderr
@@ -1,0 +1,32 @@
+error[4726]: functions in interfaces cannot have an implementation
+   ╭▸ ROOT/tests/ui/typeck/interface_constructor.sol:LL:CC
+   │
+LL │     constructor() {}
+   ╰╴    ━━━━━━━━━━━━━━━━
+
+error[6482]: constructor cannot be defined in interfaces
+   ╭▸ ROOT/tests/ui/typeck/interface_constructor.sol:LL:CC
+   │
+LL │     constructor() {}
+   ╰╴    ━━━━━━━━━━━━━━━━
+
+error[4726]: functions in interfaces cannot have an implementation
+   ╭▸ ROOT/tests/ui/typeck/interface_constructor.sol:LL:CC
+   │
+LL │     constructor(uint256 x) {}
+   ╰╴    ━━━━━━━━━━━━━━━━━━━━━━━━━
+
+error[6482]: constructor cannot be defined in interfaces
+   ╭▸ ROOT/tests/ui/typeck/interface_constructor.sol:LL:CC
+   │
+LL │     constructor(uint256 x) {}
+   ╰╴    ━━━━━━━━━━━━━━━━━━━━━━━━━
+
+error[7634]: constructor cannot be defined in libraries
+   ╭▸ ROOT/tests/ui/typeck/interface_constructor.sol:LL:CC
+   │
+LL │     constructor() {}
+   ╰╴    ━━━━━━━━━━━━━━━━
+
+error: aborting due to 5 previous errors
+

--- a/tests/ui/typeck/interface_function_implementation.sol
+++ b/tests/ui/typeck/interface_function_implementation.sol
@@ -12,6 +12,17 @@ interface J {
     receive() external payable {} //~ ERROR: functions in interfaces cannot have an implementation
 }
 
+// A Yul function inside the body is an item of its own, but only the Solidity function is
+// reported.
+interface L {
+    function g() external pure { //~ ERROR: functions in interfaces cannot have an implementation
+        assembly {
+            function inner() -> r { r := 1 }
+            pop(inner())
+        }
+    }
+}
+
 // Declarations without a body are what an interface is for.
 interface K {
     function f() external pure returns (uint256);

--- a/tests/ui/typeck/interface_function_implementation.sol
+++ b/tests/ui/typeck/interface_function_implementation.sol
@@ -1,0 +1,26 @@
+// ported-from: test/libsolidity/syntaxTests/nameAndTypeResolution/416_interface_function_bodies.sol
+
+interface I {
+    function f() external pure { //~ ERROR: functions in interfaces cannot have an implementation
+    }
+}
+
+// An empty body is an implementation too, for every kind of function.
+interface J {
+    function f() external {} //~ ERROR: functions in interfaces cannot have an implementation
+    fallback() external {} //~ ERROR: functions in interfaces cannot have an implementation
+    receive() external payable {} //~ ERROR: functions in interfaces cannot have an implementation
+}
+
+// Declarations without a body are what an interface is for.
+interface K {
+    function f() external pure returns (uint256);
+    fallback() external;
+    receive() external payable;
+}
+
+// The restriction only applies to interfaces.
+abstract contract C {
+    function f() external pure {}
+    function g() external pure virtual;
+}

--- a/tests/ui/typeck/interface_function_implementation.stderr
+++ b/tests/ui/typeck/interface_function_implementation.stderr
@@ -1,0 +1,27 @@
+error[4726]: functions in interfaces cannot have an implementation
+   ╭▸ ROOT/tests/ui/typeck/interface_function_implementation.sol:LL:CC
+   │
+LL │ ┏     function f() external pure {
+LL │ ┃     }
+   ╰╴┗━━━━━┛
+
+error[4726]: functions in interfaces cannot have an implementation
+   ╭▸ ROOT/tests/ui/typeck/interface_function_implementation.sol:LL:CC
+   │
+LL │     function f() external {}
+   ╰╴    ━━━━━━━━━━━━━━━━━━━━━━━━
+
+error[4726]: functions in interfaces cannot have an implementation
+   ╭▸ ROOT/tests/ui/typeck/interface_function_implementation.sol:LL:CC
+   │
+LL │     fallback() external {}
+   ╰╴    ━━━━━━━━━━━━━━━━━━━━━━
+
+error[4726]: functions in interfaces cannot have an implementation
+   ╭▸ ROOT/tests/ui/typeck/interface_function_implementation.sol:LL:CC
+   │
+LL │     receive() external payable {}
+   ╰╴    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+error: aborting due to 4 previous errors
+

--- a/tests/ui/typeck/interface_function_implementation.stderr
+++ b/tests/ui/typeck/interface_function_implementation.stderr
@@ -23,5 +23,16 @@ error[4726]: functions in interfaces cannot have an implementation
 LL │     receive() external payable {}
    ╰╴    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-error: aborting due to 4 previous errors
+error[4726]: functions in interfaces cannot have an implementation
+   ╭▸ ROOT/tests/ui/typeck/interface_function_implementation.sol:LL:CC
+   │
+LL │ ┏     function g() external pure {
+LL │ ┃         assembly {
+LL │ ┃             function inner() -> r { r := 1 }
+LL │ ┃             pop(inner())
+LL │ ┃         }
+LL │ ┃     }
+   ╰╴┗━━━━━┛
+
+error: aborting due to 5 previous errors
 

--- a/tests/ui/typeck/interface_function_visibility.sol
+++ b/tests/ui/typeck/interface_function_visibility.sol
@@ -23,6 +23,15 @@ interface K {
     receive() external payable;
 }
 
+// Members that are not ordinary functions keep their own checks: solc rejects a constructor, a
+// modifier, and a variable in an interface with a different error each, and the getter of a public
+// variable is `external`, so none of them may report this one.
+interface L {
+    constructor() {}
+    modifier m() { _; }
+    uint256 public x;
+}
+
 // The restriction only applies to interfaces.
 contract C {
     function f() public {}

--- a/tests/ui/typeck/interface_function_visibility.sol
+++ b/tests/ui/typeck/interface_function_visibility.sol
@@ -28,8 +28,10 @@ interface K {
 // variable is `external`, so none of them may report this one.
 interface L {
     constructor() {}
-    modifier m() { _; }
-    uint256 public x;
+    //~^ ERROR: functions in interfaces cannot have an implementation
+    //~| ERROR: constructor cannot be defined in interfaces
+    modifier m() { _; } //~ ERROR: modifiers cannot be defined or declared in interfaces
+    uint256 public x; //~ ERROR: variables cannot be declared in interfaces
 }
 
 // The restriction only applies to interfaces.

--- a/tests/ui/typeck/interface_function_visibility.sol
+++ b/tests/ui/typeck/interface_function_visibility.sol
@@ -1,0 +1,32 @@
+// ported-from: test/libsolidity/syntaxTests/visibility/interface/function_default.sol
+// ported-from: test/libsolidity/syntaxTests/visibility/interface/function_external.sol
+// ported-from: test/libsolidity/syntaxTests/visibility/interface/function_internal.sol
+// ported-from: test/libsolidity/syntaxTests/visibility/interface/function_private.sol
+// ported-from: test/libsolidity/syntaxTests/visibility/interface/function_public.sol
+
+interface I {
+    function f() public; //~ ERROR: functions in interfaces must be declared `external`
+    function g() internal; //~ ERROR: functions in interfaces must be declared `external`
+    function h() private; //~ ERROR: functions in interfaces must be declared `external`
+    function i() external;
+}
+
+interface J {
+    // An omitted visibility is an error of its own, and defaults to `public`.
+    function f(); //~ ERROR: no visibility specified
+    //~^ ERROR: functions in interfaces must be declared `external`
+}
+
+// `fallback` and `receive` are already required to be `external`.
+interface K {
+    fallback() external;
+    receive() external payable;
+}
+
+// The restriction only applies to interfaces.
+contract C {
+    function f() public {}
+    function g() internal {}
+    function h() private {}
+    function i() external {}
+}

--- a/tests/ui/typeck/interface_function_visibility.stderr
+++ b/tests/ui/typeck/interface_function_visibility.stderr
@@ -30,5 +30,29 @@ error[1560]: functions in interfaces must be declared `external`
 LL │     function f();
    ╰╴    ━━━━━━━━━━━━━
 
-error: aborting due to 5 previous errors
+error[4726]: functions in interfaces cannot have an implementation
+   ╭▸ ROOT/tests/ui/typeck/interface_function_visibility.sol:LL:CC
+   │
+LL │     constructor() {}
+   ╰╴    ━━━━━━━━━━━━━━━━
+
+error[6482]: constructor cannot be defined in interfaces
+   ╭▸ ROOT/tests/ui/typeck/interface_function_visibility.sol:LL:CC
+   │
+LL │     constructor() {}
+   ╰╴    ━━━━━━━━━━━━━━━━
+
+error[6408]: modifiers cannot be defined or declared in interfaces
+   ╭▸ ROOT/tests/ui/typeck/interface_function_visibility.sol:LL:CC
+   │
+LL │     modifier m() { _; }
+   ╰╴    ━━━━━━━━━━━━━━━━━━━
+
+error[8274]: variables cannot be declared in interfaces
+   ╭▸ ROOT/tests/ui/typeck/interface_function_visibility.sol:LL:CC
+   │
+LL │     uint256 public x;
+   ╰╴    ━━━━━━━━━━━━━━━━━
+
+error: aborting due to 9 previous errors
 

--- a/tests/ui/typeck/interface_function_visibility.stderr
+++ b/tests/ui/typeck/interface_function_visibility.stderr
@@ -1,0 +1,34 @@
+error: no visibility specified
+   ╭▸ ROOT/tests/ui/typeck/interface_function_visibility.sol:LL:CC
+   │
+LL │     function f();
+   │     ━━━━━━━━━━━━━
+   │
+   ╰ help: add `external` to the declaration
+
+error[1560]: functions in interfaces must be declared `external`
+   ╭▸ ROOT/tests/ui/typeck/interface_function_visibility.sol:LL:CC
+   │
+LL │     function f() public;
+   ╰╴    ━━━━━━━━━━━━━━━━━━━━
+
+error[1560]: functions in interfaces must be declared `external`
+   ╭▸ ROOT/tests/ui/typeck/interface_function_visibility.sol:LL:CC
+   │
+LL │     function g() internal;
+   ╰╴    ━━━━━━━━━━━━━━━━━━━━━━
+
+error[1560]: functions in interfaces must be declared `external`
+   ╭▸ ROOT/tests/ui/typeck/interface_function_visibility.sol:LL:CC
+   │
+LL │     function h() private;
+   ╰╴    ━━━━━━━━━━━━━━━━━━━━━
+
+error[1560]: functions in interfaces must be declared `external`
+   ╭▸ ROOT/tests/ui/typeck/interface_function_visibility.sol:LL:CC
+   │
+LL │     function f();
+   ╰╴    ━━━━━━━━━━━━━
+
+error: aborting due to 5 previous errors
+

--- a/tests/ui/typeck/interface_modifiers.sol
+++ b/tests/ui/typeck/interface_modifiers.sol
@@ -3,12 +3,14 @@
 interface I {
     modifier m { _; } //~ ERROR: modifiers cannot be defined or declared in interfaces
     modifier mu; //~ ERROR: modifiers cannot be defined or declared in interfaces
+    //~^ ERROR: modifiers without implementation must be marked `virtual`
     modifier mv virtual { _; } //~ ERROR: modifiers cannot be defined or declared in interfaces
     modifier muv virtual; //~ ERROR: modifiers cannot be defined or declared in interfaces
 }
 
-// A modifier in an interface reports this error and no function one: not the implicitly `virtual`
-// warning, not the missing implementation, and not the visibility.
+// A modifier in an interface reports the modifier errors and no function one: not the implicitly
+// `virtual` warning, and not the visibility. `virtual` is only implied for functions, so an
+// unimplemented modifier still has to be marked `virtual`.
 interface J {
     modifier m() virtual { _; } //~ ERROR: modifiers cannot be defined or declared in interfaces
     function f() external;

--- a/tests/ui/typeck/interface_modifiers.sol
+++ b/tests/ui/typeck/interface_modifiers.sol
@@ -1,0 +1,21 @@
+// ported-from: test/libsolidity/syntaxTests/modifiers/definition_in_interface.sol
+
+interface I {
+    modifier m { _; } //~ ERROR: modifiers cannot be defined or declared in interfaces
+    modifier mu; //~ ERROR: modifiers cannot be defined or declared in interfaces
+    modifier mv virtual { _; } //~ ERROR: modifiers cannot be defined or declared in interfaces
+    modifier muv virtual; //~ ERROR: modifiers cannot be defined or declared in interfaces
+}
+
+// A modifier in an interface reports this error and no function one: not the implicitly `virtual`
+// warning, not the missing implementation, and not the visibility.
+interface J {
+    modifier m() virtual { _; } //~ ERROR: modifiers cannot be defined or declared in interfaces
+    function f() external;
+}
+
+// The restriction only applies to interfaces.
+contract C {
+    modifier m() { _; }
+    function f() public m {}
+}

--- a/tests/ui/typeck/interface_modifiers.stderr
+++ b/tests/ui/typeck/interface_modifiers.stderr
@@ -22,11 +22,17 @@ error[6408]: modifiers cannot be defined or declared in interfaces
 LL │     modifier muv virtual;
    ╰╴    ━━━━━━━━━━━━━━━━━━━━━
 
+error[8063]: modifiers without implementation must be marked `virtual`
+   ╭▸ ROOT/tests/ui/typeck/interface_modifiers.sol:LL:CC
+   │
+LL │     modifier mu;
+   ╰╴    ━━━━━━━━━━━━
+
 error[6408]: modifiers cannot be defined or declared in interfaces
    ╭▸ ROOT/tests/ui/typeck/interface_modifiers.sol:LL:CC
    │
 LL │     modifier m() virtual { _; }
    ╰╴    ━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-error: aborting due to 5 previous errors
+error: aborting due to 6 previous errors
 

--- a/tests/ui/typeck/interface_modifiers.stderr
+++ b/tests/ui/typeck/interface_modifiers.stderr
@@ -1,0 +1,32 @@
+error[6408]: modifiers cannot be defined or declared in interfaces
+   ╭▸ ROOT/tests/ui/typeck/interface_modifiers.sol:LL:CC
+   │
+LL │     modifier m { _; }
+   ╰╴    ━━━━━━━━━━━━━━━━━
+
+error[6408]: modifiers cannot be defined or declared in interfaces
+   ╭▸ ROOT/tests/ui/typeck/interface_modifiers.sol:LL:CC
+   │
+LL │     modifier mu;
+   ╰╴    ━━━━━━━━━━━━
+
+error[6408]: modifiers cannot be defined or declared in interfaces
+   ╭▸ ROOT/tests/ui/typeck/interface_modifiers.sol:LL:CC
+   │
+LL │     modifier mv virtual { _; }
+   ╰╴    ━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+error[6408]: modifiers cannot be defined or declared in interfaces
+   ╭▸ ROOT/tests/ui/typeck/interface_modifiers.sol:LL:CC
+   │
+LL │     modifier muv virtual;
+   ╰╴    ━━━━━━━━━━━━━━━━━━━━━
+
+error[6408]: modifiers cannot be defined or declared in interfaces
+   ╭▸ ROOT/tests/ui/typeck/interface_modifiers.sol:LL:CC
+   │
+LL │     modifier m() virtual { _; }
+   ╰╴    ━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+error: aborting due to 5 previous errors
+

--- a/tests/ui/typeck/interface_variables.sol
+++ b/tests/ui/typeck/interface_variables.sol
@@ -1,0 +1,31 @@
+// ported-from: test/libsolidity/syntaxTests/nameAndTypeResolution/420_interface_variables.sol
+
+interface I {
+    uint a; //~ ERROR: variables cannot be declared in interfaces
+}
+
+// Every state variable is rejected, whatever its visibility or mutability, and the getter of a
+// public variable is not reported as an interface function of its own.
+interface J {
+    uint256 internal_; //~ ERROR: variables cannot be declared in interfaces
+    uint256 public x; //~ ERROR: variables cannot be declared in interfaces
+    uint256 constant CST = 1; //~ ERROR: variables cannot be declared in interfaces
+    uint256 immutable IMM = 2; //~ ERROR: variables cannot be declared in interfaces
+}
+
+// Only variable declarations are rejected: parameters, return parameters, struct fields and
+// event or error parameters are all allowed.
+interface K {
+    struct S {
+        uint256 a;
+    }
+    event E(uint256 indexed a);
+    error Err(uint256 a);
+    function f(S memory s, uint256 a) external returns (uint256 b);
+}
+
+// The restriction only applies to interfaces.
+contract C {
+    uint256 x;
+    uint256 constant Y = 1;
+}

--- a/tests/ui/typeck/interface_variables.stderr
+++ b/tests/ui/typeck/interface_variables.stderr
@@ -1,0 +1,32 @@
+error[8274]: variables cannot be declared in interfaces
+   ╭▸ ROOT/tests/ui/typeck/interface_variables.sol:LL:CC
+   │
+LL │     uint a;
+   ╰╴    ━━━━━━━
+
+error[8274]: variables cannot be declared in interfaces
+   ╭▸ ROOT/tests/ui/typeck/interface_variables.sol:LL:CC
+   │
+LL │     uint256 internal_;
+   ╰╴    ━━━━━━━━━━━━━━━━━━
+
+error[8274]: variables cannot be declared in interfaces
+   ╭▸ ROOT/tests/ui/typeck/interface_variables.sol:LL:CC
+   │
+LL │     uint256 public x;
+   ╰╴    ━━━━━━━━━━━━━━━━━
+
+error[8274]: variables cannot be declared in interfaces
+   ╭▸ ROOT/tests/ui/typeck/interface_variables.sol:LL:CC
+   │
+LL │     uint256 constant CST = 1;
+   ╰╴    ━━━━━━━━━━━━━━━━━━━━━━━━━
+
+error[8274]: variables cannot be declared in interfaces
+   ╭▸ ROOT/tests/ui/typeck/interface_variables.sol:LL:CC
+   │
+LL │     uint256 immutable IMM = 2;
+   ╰╴    ━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+error: aborting due to 5 previous errors
+

--- a/tests/ui/typeck/interface_virtual_function.allow.stderr
+++ b/tests/ui/typeck/interface_virtual_function.allow.stderr
@@ -1,0 +1,14 @@
+error[1560]: functions in interfaces must be declared `external`
+   ╭▸ ROOT/tests/ui/typeck/interface_virtual_function.sol:LL:CC
+   │
+LL │     function foo() private virtual;
+   ╰╴    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+error[3942]: `virtual` and `private` cannot be used together
+   ╭▸ ROOT/tests/ui/typeck/interface_virtual_function.sol:LL:CC
+   │
+LL │     function bar() private virtual {}
+   ╰╴    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+error: aborting due to 2 previous errors
+

--- a/tests/ui/typeck/interface_virtual_function.default.stderr
+++ b/tests/ui/typeck/interface_virtual_function.default.stderr
@@ -1,0 +1,26 @@
+warning[5815]: interface functions are implicitly `virtual`
+   ╭▸ ROOT/tests/ui/typeck/interface_virtual_function.sol:LL:CC
+   │
+LL │     function foo() virtual external;
+   ╰╴    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+warning[5815]: interface functions are implicitly `virtual`
+   ╭▸ ROOT/tests/ui/typeck/interface_virtual_function.sol:LL:CC
+   │
+LL │     function foo() private virtual;
+   ╰╴    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+error[1560]: functions in interfaces must be declared `external`
+   ╭▸ ROOT/tests/ui/typeck/interface_virtual_function.sol:LL:CC
+   │
+LL │     function foo() private virtual;
+   ╰╴    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+error[3942]: `virtual` and `private` cannot be used together
+   ╭▸ ROOT/tests/ui/typeck/interface_virtual_function.sol:LL:CC
+   │
+LL │     function bar() private virtual {}
+   ╰╴    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+error: aborting due to 2 previous errors; 2 warnings emitted
+

--- a/tests/ui/typeck/interface_virtual_function.sol
+++ b/tests/ui/typeck/interface_virtual_function.sol
@@ -1,0 +1,21 @@
+//@ revisions: default allow
+//@[allow] compile-flags: --allow=5815
+// ported-from: test/libsolidity/syntaxTests/inheritance/interface_virtual_warning.sol
+
+interface I {
+    function foo() virtual external; //~[default] WARN: interface functions are implicitly `virtual`
+}
+
+// The warning ends the chain solc walks for a `virtual` function: an interface function that is
+// also `private` reports it instead of the `virtual` and `private` error.
+interface J {
+    function foo() private virtual;
+    //~[default]^ WARN: interface functions are implicitly `virtual`
+    //~^^ ERROR: functions in interfaces must be declared `external`
+}
+
+// Elsewhere `virtual` is not implied, so there is nothing to warn about.
+abstract contract C {
+    function foo() external virtual;
+    function bar() private virtual {} //~ ERROR: `virtual` and `private` cannot be used together
+}

--- a/tests/ui/typeck/library_fallback_function.stderr
+++ b/tests/ui/typeck/library_fallback_function.stderr
@@ -4,7 +4,7 @@ error[5982]: libraries cannot have fallback functions
 LL │     fallback() external {}
    ╰╴    ━━━━━━━━━━━━━━━━━━━━━━
 
-error: libraries cannot have receive ether functions
+error[4549]: libraries cannot have receive ether functions
    ╭▸ ROOT/tests/ui/typeck/library_fallback_function.sol:LL:CC
    │
 LL │     receive() external payable {}

--- a/tests/ui/typeck/library_modifier_virtual.sol
+++ b/tests/ui/typeck/library_modifier_virtual.sol
@@ -1,0 +1,22 @@
+// ported-from: test/libsolidity/syntaxTests/modifiers/definition_in_library.sol
+
+library L {
+    modifier mv virtual { _; } //~ ERROR: modifiers in a library cannot be `virtual`
+}
+
+// The library function error has its own code and wording.
+library L2 {
+    modifier m() virtual { _; } //~ ERROR: modifiers in a library cannot be `virtual`
+    function f() internal virtual returns (uint256) { return 1; }
+    //~^ ERROR: library functions cannot be `virtual`
+}
+
+// A non-`virtual` modifier in a library is fine, and so is a `virtual` modifier anywhere else.
+library L3 {
+    modifier m() { _; }
+    function f() internal m returns (uint256) { return 1; }
+}
+
+contract C {
+    modifier m() virtual { _; }
+}

--- a/tests/ui/typeck/library_modifier_virtual.stderr
+++ b/tests/ui/typeck/library_modifier_virtual.stderr
@@ -1,0 +1,20 @@
+error[3275]: modifiers in a library cannot be `virtual`
+   ╭▸ ROOT/tests/ui/typeck/library_modifier_virtual.sol:LL:CC
+   │
+LL │     modifier mv virtual { _; }
+   ╰╴    ━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+error[3275]: modifiers in a library cannot be `virtual`
+   ╭▸ ROOT/tests/ui/typeck/library_modifier_virtual.sol:LL:CC
+   │
+LL │     modifier m() virtual { _; }
+   ╰╴    ━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+error[7801]: library functions cannot be `virtual`
+   ╭▸ ROOT/tests/ui/typeck/library_modifier_virtual.sol:LL:CC
+   │
+LL │     function f() internal virtual returns (uint256) { return 1; }
+   ╰╴    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+error: aborting due to 3 previous errors
+

--- a/tests/ui/typeck/receive.stderr
+++ b/tests/ui/typeck/receive.stderr
@@ -16,7 +16,7 @@ error: `pure` not allowed here; allowed values: payable
 LL │     receive() external pure {}
    ╰╴                       ━━━━
 
-error: libraries cannot have receive ether functions
+error[4549]: libraries cannot have receive ether functions
    ╭▸ ROOT/tests/ui/typeck/receive.sol:LL:CC
    │
 LL │     receive() external payable {}

--- a/tests/ui/typeck/virtual_free_function.sol
+++ b/tests/ui/typeck/virtual_free_function.sol
@@ -2,8 +2,12 @@
 
 function fun() virtual {} //~ ERROR: free functions cannot be `virtual`
 
+// An unimplemented free function is an error of its own, reported first.
+function fun2() virtual; //~ ERROR: free functions must be implemented
+//~^ ERROR: free functions cannot be `virtual`
+
 // The restriction only applies to free functions.
-function fun2() {}
+function fun3() {}
 
 contract C {
     function f() public virtual {}

--- a/tests/ui/typeck/virtual_free_function.sol
+++ b/tests/ui/typeck/virtual_free_function.sol
@@ -14,7 +14,7 @@ contract C {
 }
 
 interface I {
-    function f() external virtual;
+    function f() external virtual; //~ WARN: interface functions are implicitly `virtual`
 }
 
 library L {

--- a/tests/ui/typeck/virtual_free_function.sol
+++ b/tests/ui/typeck/virtual_free_function.sol
@@ -1,0 +1,18 @@
+// ported-from: test/libsolidity/syntaxTests/freeFunctions/free_virtual.sol
+
+function fun() virtual {} //~ ERROR: free functions cannot be `virtual`
+
+// The restriction only applies to free functions.
+function fun2() {}
+
+contract C {
+    function f() public virtual {}
+}
+
+interface I {
+    function f() external virtual;
+}
+
+library L {
+    function f() internal pure returns (uint) { return 0; }
+}

--- a/tests/ui/typeck/virtual_free_function.stderr
+++ b/tests/ui/typeck/virtual_free_function.stderr
@@ -1,8 +1,20 @@
+error: free functions must be implemented
+   ╭▸ ROOT/tests/ui/typeck/virtual_free_function.sol:LL:CC
+   │
+LL │ function fun2() virtual;
+   ╰╴━━━━━━━━━━━━━━━━━━━━━━━━
+
 error[4493]: free functions cannot be `virtual`
    ╭▸ ROOT/tests/ui/typeck/virtual_free_function.sol:LL:CC
    │
 LL │ function fun() virtual {}
    ╰╴━━━━━━━━━━━━━━━━━━━━━━━━━
 
-error: aborting due to 1 previous error
+error[4493]: free functions cannot be `virtual`
+   ╭▸ ROOT/tests/ui/typeck/virtual_free_function.sol:LL:CC
+   │
+LL │ function fun2() virtual;
+   ╰╴━━━━━━━━━━━━━━━━━━━━━━━━
+
+error: aborting due to 3 previous errors
 

--- a/tests/ui/typeck/virtual_free_function.stderr
+++ b/tests/ui/typeck/virtual_free_function.stderr
@@ -16,5 +16,11 @@ error[4493]: free functions cannot be `virtual`
 LL │ function fun2() virtual;
    ╰╴━━━━━━━━━━━━━━━━━━━━━━━━
 
-error: aborting due to 3 previous errors
+warning[5815]: interface functions are implicitly `virtual`
+   ╭▸ ROOT/tests/ui/typeck/virtual_free_function.sol:LL:CC
+   │
+LL │     function f() external virtual;
+   ╰╴    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+error: aborting due to 3 previous errors; 1 warning emitted
 

--- a/tests/ui/typeck/virtual_free_function.stderr
+++ b/tests/ui/typeck/virtual_free_function.stderr
@@ -1,0 +1,8 @@
+error[4493]: free functions cannot be `virtual`
+   ╭▸ ROOT/tests/ui/typeck/virtual_free_function.sol:LL:CC
+   │
+LL │ function fun() virtual {}
+   ╰╴━━━━━━━━━━━━━━━━━━━━━━━━━
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
Part of the split of the solc-vs-solar differential audit branch (#1360). Based on #1363, next to whose library checks these live. The `try` clause checks moved to their own PR (#1372) because they reuse the pre-byzantium discard tracking.

Declaration checks solc applies that we lacked: non-`external` interface functions (1560), `virtual` free functions (4493), interface constructors, implemented interface functions, interface modifiers and variables (6482, 4726, 6408, 8274), the `virtual` interface function warning (5815), `virtual` library modifiers (3275 instead of the function message), bodiless modifiers (8063), bare `override` on free functions (1750), free functions with modifiers (5811), and the missing 4549 on the library `receive` error. solc's syntax tests for these are ported where they exist.
