### PR TITLE
fix(sema): check the try returns clause against the callee

### DIFF
--- a/crates/codegen/src/lower/function/control_flow.rs
+++ b/crates/codegen/src/lower/function/control_flow.rs
@@ -186,7 +186,12 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
     }
 
     pub(super) fn lower_try(&mut self, try_stmt: &hir::StmtTry<'_>) -> Option<()> {
-        let ExprKind::Call(callee, args, call_opts) = &try_stmt.expr.kind else {
+        // Parenthesizing the target changes nothing about the call it wraps, so peel the parens
+        // here exactly as the checker does when it accepts the statement. solc rejects
+        // `try (c.f()) { ... }` because its target must be a call syntactically, but the
+        // statement has only one meaning and we compile it.
+        let try_expr = try_stmt.expr.peel_parens();
+        let ExprKind::Call(callee, args, call_opts) = &try_expr.kind else {
             return self.cx.report_unsupported(try_stmt.expr.span, "try expression");
         };
         let target = if let ExprKind::New(ty) = &callee.kind {

--- a/crates/sema/src/ty/mod.rs
+++ b/crates/sema/src/ty/mod.rs
@@ -1958,7 +1958,7 @@ fn var_type<'gcx>(gcx: Gcx<'gcx>, var: &'gcx hir::Variable<'gcx>, ty: Ty<'gcx>) 
     let mut has_reference_or_mapping_type_slot = None;
     let mut has_reference_or_mapping_type = || {
         *has_reference_or_mapping_type_slot
-            .get_or_insert_with(|| ty.is_reference_type() || ty.has_mapping(gcx))
+            .get_or_insert_with(|| ty.has_reference_or_mapping_type(gcx))
     };
 
     let mut func_vis = None;

--- a/crates/sema/src/ty/mod.rs
+++ b/crates/sema/src/ty/mod.rs
@@ -1967,6 +1967,11 @@ fn var_type<'gcx>(gcx: Gcx<'gcx>, var: &'gcx hir::Variable<'gcx>, ty: Ty<'gcx>) 
         &[None, Some(Transient)]
     } else if !has_reference_or_mapping_type() || var.is_event_or_error_parameter() {
         &[None]
+    } else if var.is_try_catch_parameter() {
+        // A `try` clause parameter is declared in the `TryCatchClause`'s own scope, not in the
+        // enclosing callable's, so the enclosing function's kind and visibility do not widen
+        // its locations: the decoder always writes the value into a fresh memory object.
+        &[Some(Memory)]
     } else if var.is_callable_or_catch_parameter() {
         locs = SmallVec::<[_; 3]>::new();
         locs.push(Some(Memory));
@@ -1974,7 +1979,7 @@ fn var_type<'gcx>(gcx: Gcx<'gcx>, var: &'gcx hir::Variable<'gcx>, ty: Ty<'gcx>) 
         if let Some(hir::ItemId::Function(f)) = var.parent {
             let f = gcx.hir.function(f);
             is_constructor_parameter = f.kind.is_constructor();
-            if !var.is_try_catch_parameter() && !is_constructor_parameter {
+            if !is_constructor_parameter {
                 func_vis = Some(f.visibility);
             }
             if is_constructor_parameter
@@ -1984,7 +1989,7 @@ fn var_type<'gcx>(gcx: Gcx<'gcx>, var: &'gcx hir::Variable<'gcx>, ty: Ty<'gcx>) 
                 locs.push(Some(Storage));
             }
         }
-        if !var.is_try_catch_parameter() && !is_constructor_parameter {
+        if !is_constructor_parameter {
             locs.push(Some(Calldata));
         }
         &locs

--- a/crates/sema/src/ty/ty.rs
+++ b/crates/sema/src/ty/ty.rs
@@ -302,6 +302,15 @@ impl<'gcx> Ty<'gcx> {
         .is_break()
     }
 
+    /// Returns `true` if the type takes a data location.
+    ///
+    /// This is solc's `hasReferenceOrMappingType`, which every data-location rule is written
+    /// against. The mapping half is redundant, since a reference type is anything that can
+    /// contain a mapping, but it keeps the predicate recognizable against the upstream rules.
+    pub fn has_reference_or_mapping_type(self, gcx: Gcx<'gcx>) -> bool {
+        self.is_reference_type() || self.has_mapping(gcx)
+    }
+
     /// Returns `true` if this type contains a library contract type.
     pub fn contains_library(self, gcx: Gcx<'gcx>) -> bool {
         self.visit_with_structs(gcx, &mut |ty| match ty.kind {

--- a/crates/sema/src/typeck/checker/mod.rs
+++ b/crates/sema/src/typeck/checker/mod.rs
@@ -1334,6 +1334,70 @@ impl<'gcx> TypeChecker<'gcx> {
         Ok(())
     }
 
+    /// Checks a `try` statement's `returns` clause against the callee's return values.
+    ///
+    /// solc requires the clause to repeat the callee's return types exactly, without implicit
+    /// conversions and with the same data location (`TypeChecker::endVisit(TryStatement)`): the
+    /// decoder writes the callee's values straight into the clause's variables, so a differing
+    /// declaration would reinterpret them.
+    fn check_try_returns_clause(&self, try_: &'gcx hir::StmtTry<'gcx>) {
+        let clause = &try_.clauses[0];
+        if clause.args.is_empty() {
+            return;
+        }
+        let hir::ExprKind::Call(callee, ..) = try_.expr.peel_parens().kind else { return };
+        let Some(&callee_ty) = self.results.expr_types.get(&callee.id) else { return };
+        let TyKind::Fn(f) = callee_ty.kind else { return };
+
+        if f.returns.len() != clause.args.len() {
+            self.dcx()
+                .err(format!(
+                    "function returns {} value{}, but the `returns` clause has {} variable{}",
+                    f.returns.len(),
+                    pluralize!(f.returns.len()),
+                    clause.args.len(),
+                    pluralize!(clause.args.len())
+                ))
+                .code(error_code!(2800))
+                .span(clause.span)
+                .emit();
+        }
+
+        // solc still compares the pairs it has, so a count mismatch can carry a type mismatch.
+        for (&id, &expected) in std::iter::zip(clause.args, f.returns) {
+            let var = self.gcx.hir.variable(id);
+            let actual = self.gcx.type_of_item(id.into());
+            if actual == expected || actual.references_error() || expected.references_error() {
+                continue;
+            }
+            // A clause variable's only valid data location is `memory`; a rejected one has
+            // already been reported and rewritten to `memory`, so its type says nothing.
+            if matches!(actual.kind, TyKind::Ref(..))
+                && var.data_location != Some(DataLocation::Memory)
+            {
+                continue;
+            }
+            // Before Byzantium a dynamically encoded return value has no accessible type, and
+            // `check_inaccessible_dynamic_return` has already reported the binding with 6509.
+            if !self.gcx.sess.opts.evm_version.supports_returndata()
+                && !expected.encodes_as_slot()
+                && expected.is_dynamically_encoded(self.gcx)
+            {
+                continue;
+            }
+            self.dcx()
+                .err("mismatched types")
+                .code(error_code!(6509))
+                .span(var.span)
+                .span_label(
+                    var.span,
+                    TyConvertError::Incompatible.message(actual, expected, self.gcx),
+                )
+                .note("a `returns` clause must repeat the callee's return types exactly")
+                .emit();
+        }
+    }
+
     fn fn_call_return_type(&self, returns: &'gcx [Ty<'gcx>]) -> Ty<'gcx> {
         match returns {
             [] => self.gcx.types.unit,
@@ -3185,6 +3249,11 @@ impl<'gcx> hir::Visit<'gcx> for TypeChecker<'gcx> {
                 } else {
                     self.value_position = ValuePosition::TryReturns;
                 }
+                // The clause is checked against the call's type, so only after visiting it, as
+                // in solc's `endVisit(TryStatement)`.
+                self.walk_stmt(stmt)?;
+                self.check_try_returns_clause(try_);
+                return ControlFlow::Continue(());
             }
             hir::StmtKind::Emit(call_expr) | hir::StmtKind::Revert(call_expr) => {
                 let is_emit = matches!(stmt.kind, hir::StmtKind::Emit(_));

--- a/crates/sema/src/typeck/checker/mod.rs
+++ b/crates/sema/src/typeck/checker/mod.rs
@@ -1339,7 +1339,8 @@ impl<'gcx> TypeChecker<'gcx> {
     /// solc requires the clause to repeat the callee's return types exactly, without implicit
     /// conversions and with the same data location (`TypeChecker::endVisit(TryStatement)`): the
     /// decoder writes the callee's values straight into the clause's variables, so a differing
-    /// declaration would reinterpret them.
+    /// declaration would reinterpret them. Only an external, delegate, or creation call decodes
+    /// anything, and solc checks the clause of no other callee.
     fn check_try_returns_clause(&self, try_: &'gcx hir::StmtTry<'gcx>) {
         let clause = &try_.clauses[0];
         if clause.args.is_empty() {
@@ -1348,6 +1349,12 @@ impl<'gcx> TypeChecker<'gcx> {
         let hir::ExprKind::Call(callee, ..) = try_.expr.peel_parens().kind else { return };
         let Some(&callee_ty) = self.results.expr_types.get(&callee.id) else { return };
         let TyKind::Fn(f) = callee_ty.kind else { return };
+        // solc reaches the clause only for the callee kinds `try` accepts, returning after 2536
+        // for any other one. The return values of the rest are not what the clause would bind:
+        // a builtin's are not even always a type, so comparing them says nothing.
+        if !matches!(f.kind, TyFnKind::External | TyFnKind::DelegateCall | TyFnKind::Creation) {
+            return;
+        }
 
         if f.returns.len() != clause.args.len() {
             self.dcx()

--- a/crates/sema/src/typeck/checker/mod.rs
+++ b/crates/sema/src/typeck/checker/mod.rs
@@ -1353,6 +1353,10 @@ impl<'gcx> TypeChecker<'gcx> {
     /// codes and checks no clause of either: 5347 for a target that is not a call, and 2536 for a
     /// call of another kind.
     fn check_try_target(&self, try_: &'gcx hir::StmtTry<'gcx>) -> Option<&'gcx TyFn<'gcx>> {
+        // solc requires the target to be a call syntactically, so it rejects `try (c.f())`.
+        // Parentheses do not change the call they wrap, so we accept it; lowering peels them
+        // the same way, so an accepted statement compiles. See TYPECK-005 in
+        // `docs/SOLC_DIVERGENCE.md`.
         let expr = try_.expr.peel_parens();
         let callee_ty = match expr.kind {
             hir::ExprKind::Call(callee, ..) => self.results.expr_types.get(&callee.id).copied(),

--- a/crates/sema/src/typeck/checker/mod.rs
+++ b/crates/sema/src/typeck/checker/mod.rs
@@ -1349,14 +1349,16 @@ impl<'gcx> TypeChecker<'gcx> {
     ///
     /// Only an external call, a delegate call, and a contract creation call have a revert of
     /// their own to catch and return data to decode; every other callee either cannot fail
-    /// separately from the caller or has no return data. solc reports 5347 for a target that is
-    /// not a function call at all and 2536 for a call of another kind, with the same message,
-    /// and checks no clause of either.
+    /// separately from the caller or has no return data. solc reports the same message under two
+    /// codes and checks no clause of either: 5347 for a target that is not a call, and 2536 for a
+    /// call of another kind.
     fn check_try_target(&self, try_: &'gcx hir::StmtTry<'gcx>) -> Option<&'gcx TyFn<'gcx>> {
         let expr = try_.expr.peel_parens();
-        if let hir::ExprKind::Call(callee, ..) = expr.kind
-            && let Some(&callee_ty) = self.results.expr_types.get(&callee.id)
-        {
+        let callee_ty = match expr.kind {
+            hir::ExprKind::Call(callee, ..) => self.results.expr_types.get(&callee.id).copied(),
+            _ => None,
+        };
+        if let Some(callee_ty) = callee_ty {
             // A callee that failed to check says nothing about the statement.
             if callee_ty.references_error() {
                 return None;
@@ -1370,9 +1372,14 @@ impl<'gcx> TypeChecker<'gcx> {
                 return Some(f);
             }
         }
+        // A type conversion and a struct construction are calls in the grammar only: their
+        // callee names a type rather than a callable, and solc reports them with 5347 like a
+        // target that is no call at all.
+        let is_call = callee_ty.is_some_and(|ty| !matches!(ty.kind, TyKind::Type(_)));
+        let code = if is_call { error_code!(2536) } else { error_code!(5347) };
         self.dcx()
             .err("`try` can only be used with external function calls and contract creation calls")
-            .code(error_code!(2536))
+            .code(code)
             .span(try_.expr.span)
             .emit();
         None

--- a/crates/sema/src/typeck/checker/mod.rs
+++ b/crates/sema/src/typeck/checker/mod.rs
@@ -1377,11 +1377,17 @@ impl<'gcx> TypeChecker<'gcx> {
             if actual == expected || actual.references_error() || expected.references_error() {
                 continue;
             }
-            // A clause variable's only valid data location is `memory`; a rejected one has
-            // already been reported and rewritten to `memory`, so its type says nothing.
-            if matches!(actual.kind, TyKind::Ref(..))
-                && var.data_location != Some(DataLocation::Memory)
-            {
+            // A clause variable's only valid data location is `memory`, and only for a type
+            // that takes one at all: `bool memory` is as illegal as `uint256[] storage`. Either
+            // way `var_type` has already reported it and rewritten the location, so the
+            // variable's type says nothing and solc reports only the declaration.
+            let bare = actual.peel_refs();
+            let valid_location = if bare.is_reference_type() || bare.has_mapping(self.gcx) {
+                Some(DataLocation::Memory)
+            } else {
+                None
+            };
+            if var.data_location != valid_location {
                 continue;
             }
             // Before Byzantium a dynamically encoded return value has no accessible type, and

--- a/crates/sema/src/typeck/checker/mod.rs
+++ b/crates/sema/src/typeck/checker/mod.rs
@@ -1427,7 +1427,7 @@ impl<'gcx> TypeChecker<'gcx> {
             // way `var_type` has already reported it and rewritten the location, so the
             // variable's type says nothing and solc reports only the declaration.
             let bare = actual.peel_refs();
-            let valid_location = if bare.is_reference_type() || bare.has_mapping(self.gcx) {
+            let valid_location = if bare.has_reference_or_mapping_type(self.gcx) {
                 Some(DataLocation::Memory)
             } else {
                 None

--- a/crates/sema/src/typeck/checker/mod.rs
+++ b/crates/sema/src/typeck/checker/mod.rs
@@ -1334,25 +1334,59 @@ impl<'gcx> TypeChecker<'gcx> {
         Ok(())
     }
 
+    /// Checks a `try` statement, as in solc's `TypeChecker::endVisit(TryStatement)`.
+    ///
+    /// Must run after the called expression has been checked: every clause is checked against
+    /// the callee's type.
+    fn check_try(&self, try_: &'gcx hir::StmtTry<'gcx>) {
+        let Some(f) = self.check_try_target(try_) else { return };
+        self.check_try_returns_clause(try_, f);
+        self.check_try_catch_clauses(try_);
+    }
+
+    /// Checks that a `try` statement's target is a call whose failure the statement can catch,
+    /// returning the called function's type.
+    ///
+    /// Only an external call, a delegate call, and a contract creation call have a revert of
+    /// their own to catch and return data to decode; every other callee either cannot fail
+    /// separately from the caller or has no return data. solc reports 5347 for a target that is
+    /// not a function call at all and 2536 for a call of another kind, with the same message,
+    /// and checks no clause of either.
+    fn check_try_target(&self, try_: &'gcx hir::StmtTry<'gcx>) -> Option<&'gcx TyFn<'gcx>> {
+        let expr = try_.expr.peel_parens();
+        if let hir::ExprKind::Call(callee, ..) = expr.kind
+            && let Some(&callee_ty) = self.results.expr_types.get(&callee.id)
+        {
+            // A callee that failed to check says nothing about the statement.
+            if callee_ty.references_error() {
+                return None;
+            }
+            if let TyKind::Fn(f) = callee_ty.kind
+                && matches!(
+                    f.kind,
+                    TyFnKind::External | TyFnKind::DelegateCall | TyFnKind::Creation
+                )
+            {
+                return Some(f);
+            }
+        }
+        self.dcx()
+            .err("`try` can only be used with external function calls and contract creation calls")
+            .code(error_code!(2536))
+            .span(try_.expr.span)
+            .emit();
+        None
+    }
+
     /// Checks a `try` statement's `returns` clause against the callee's return values.
     ///
     /// solc requires the clause to repeat the callee's return types exactly, without implicit
     /// conversions and with the same data location (`TypeChecker::endVisit(TryStatement)`): the
     /// decoder writes the callee's values straight into the clause's variables, so a differing
-    /// declaration would reinterpret them. Only an external, delegate, or creation call decodes
-    /// anything, and solc checks the clause of no other callee.
-    fn check_try_returns_clause(&self, try_: &'gcx hir::StmtTry<'gcx>) {
+    /// declaration would reinterpret them.
+    fn check_try_returns_clause(&self, try_: &'gcx hir::StmtTry<'gcx>, f: &'gcx TyFn<'gcx>) {
         let clause = &try_.clauses[0];
         if clause.args.is_empty() {
-            return;
-        }
-        let hir::ExprKind::Call(callee, ..) = try_.expr.peel_parens().kind else { return };
-        let Some(&callee_ty) = self.results.expr_types.get(&callee.id) else { return };
-        let TyKind::Fn(f) = callee_ty.kind else { return };
-        // solc reaches the clause only for the callee kinds `try` accepts, returning after 2536
-        // for any other one. The return values of the rest are not what the clause would bind:
-        // a builtin's are not even always a type, so comparing them says nothing.
-        if !matches!(f.kind, TyFnKind::External | TyFnKind::DelegateCall | TyFnKind::Creation) {
             return;
         }
 
@@ -1408,6 +1442,117 @@ impl<'gcx> TypeChecker<'gcx> {
                 )
                 .note("a `returns` clause must repeat the callee's return types exactly")
                 .emit();
+        }
+    }
+
+    /// Checks a `try` statement's `catch` clauses.
+    ///
+    /// Each clause decodes one shape of revert data, so its parameter list is fixed: the
+    /// `Error(string)` and `Panic(uint256)` builtin errors carry exactly their own argument, and
+    /// a low-level clause takes the raw return data as `bytes memory` or nothing at all. Only
+    /// one clause of each kind can ever run, so a second one is dead and solc rejects it
+    /// (`TypeChecker::endVisit(TryStatement)`).
+    fn check_try_catch_clauses(&self, try_: &'gcx hir::StmtTry<'gcx>) {
+        let supports_returndata = self.gcx.sess.opts.evm_version.supports_returndata();
+        // A clause takes exactly the one argument its error carries. A parameter whose data
+        // location was rejected has already been reported and rewritten, so its type matches
+        // and solc reports only the declaration.
+        let takes = |clause: &hir::TryCatchClause<'gcx>, ty| {
+            let &[arg] = clause.args else { return false };
+            self.gcx.type_of_item(arg.into()) == ty
+        };
+        let mut error_clause = None;
+        let mut panic_clause = None;
+        let mut low_level_clause = None;
+        for clause in &try_.clauses[1..] {
+            let name = clause.name.map(|name| name.name);
+            // `Error` and `Panic` are the only clause names there are, at every EVM version.
+            if !matches!(name, None | Some(sym::Error | sym::Panic)) {
+                self.dcx()
+                    .err("invalid catch clause name")
+                    .code(error_code!(3542))
+                    .span(clause.span)
+                    .help("expected `catch (...)`, `catch Error(...)`, or `catch Panic(...)`")
+                    .emit();
+                continue;
+            }
+
+            let first = match name {
+                None => &mut low_level_clause,
+                Some(sym::Error) => &mut error_clause,
+                _ => &mut panic_clause,
+            };
+            if let Some(first) = *first {
+                let (code, kind) = match name {
+                    None => (error_code!(5320), "a low-level"),
+                    Some(sym::Error) => (error_code!(1036), "an `Error`"),
+                    _ => (error_code!(6732), "a `Panic`"),
+                };
+                self.dcx()
+                    .err(format!("this `try` statement already has {kind} catch clause"))
+                    .code(code)
+                    .span(clause.span)
+                    .span_note(first, "the first clause is here")
+                    .emit();
+            } else {
+                *first = Some(clause.span);
+            }
+
+            match name {
+                // A bare `catch { }` needs no return data and stays accepted.
+                None if clause.args.is_empty() => {}
+                None => {
+                    if !takes(clause, self.gcx.types.bytes_ref.memory) {
+                        self.dcx()
+                            .err("invalid low-level catch clause parameters")
+                            .code(error_code!(6231))
+                            .span(clause.span)
+                            .help("expected `catch (bytes memory ...) { ... }` or `catch { ... }`")
+                            .emit();
+                    }
+                    if !supports_returndata {
+                        self.evm_version_error(
+                            clause.span,
+                            "typed catch clause",
+                            EvmVersion::Byzantium,
+                        )
+                        .code(error_code!(9908))
+                        .emit();
+                    }
+                }
+                Some(name) => {
+                    if !supports_returndata {
+                        self.evm_version_error(
+                            clause.span,
+                            "typed catch clause",
+                            EvmVersion::Byzantium,
+                        )
+                        .code(error_code!(1812))
+                        .emit();
+                    }
+                    let (ty, code, help) = if name == sym::Error {
+                        (
+                            self.gcx.types.string_ref.memory,
+                            error_code!(2943),
+                            "expected `catch Error(string memory ...) { ... }`",
+                        )
+                    } else {
+                        (
+                            self.gcx.types.uint(256),
+                            error_code!(1271),
+                            "expected `catch Panic(uint ...) { ... }`",
+                        )
+                    };
+                    if !takes(clause, ty) {
+                        self.dcx()
+                            .err(format!("invalid `{name}` catch clause parameters"))
+                            .code(code)
+                            .span(clause.span)
+                            .help(help)
+                            .emit();
+                    }
+                }
+            }
         }
     }
 
@@ -3215,45 +3360,6 @@ impl<'gcx> hir::Visit<'gcx> for TypeChecker<'gcx> {
                 return ControlFlow::Continue(());
             }
             hir::StmtKind::Try(try_) => {
-                let supports_returndata = self.gcx.sess.opts.evm_version.supports_returndata();
-                for clause in &try_.clauses[1..] {
-                    // `Error` and `Panic` are the only clause names there are, at every EVM
-                    // version.
-                    if let Some(name) = clause.name
-                        && name.name != sym::Error
-                        && name.name != sym::Panic
-                    {
-                        self.dcx()
-                            .err("invalid catch clause name")
-                            .code(error_code!(3542))
-                            .span(clause.span)
-                            .help(
-                                "expected `catch (...)`, `catch Error(...)`, or `catch Panic(...)`",
-                            )
-                            .emit();
-                        continue;
-                    }
-                    if supports_returndata {
-                        continue;
-                    }
-                    // A bare `catch { }` needs no return data and stays accepted; solc
-                    // reports 1812 for `catch Error`/`catch Panic` and 9908 for
-                    // `catch (bytes memory)`.
-                    let code = if clause.name.is_some() {
-                        error_code!(1812)
-                    } else if !clause.args.is_empty() {
-                        error_code!(9908)
-                    } else {
-                        continue;
-                    };
-                    self.evm_version_error(
-                        clause.span,
-                        "typed catch clause",
-                        EvmVersion::Byzantium,
-                    )
-                    .code(code)
-                    .emit();
-                }
                 // A `returns` clause binds the call's values; without one they are discarded.
                 // Binding an inaccessible one is the mismatch solc reports as 6509, and the
                 // walk below checks the call expression before any clause body.
@@ -3262,10 +3368,10 @@ impl<'gcx> hir::Visit<'gcx> for TypeChecker<'gcx> {
                 } else {
                     self.value_position = ValuePosition::TryReturns;
                 }
-                // The clause is checked against the call's type, so only after visiting it, as
-                // in solc's `endVisit(TryStatement)`.
+                // The clauses are checked against the call's type, so only after visiting it,
+                // as in solc's `endVisit(TryStatement)`.
                 self.walk_stmt(stmt)?;
-                self.check_try_returns_clause(try_);
+                self.check_try(try_);
                 return ControlFlow::Continue(());
             }
             hir::StmtKind::Emit(call_expr) | hir::StmtKind::Revert(call_expr) => {

--- a/docs/SOLC_DIVERGENCE.md
+++ b/docs/SOLC_DIVERGENCE.md
@@ -129,6 +129,23 @@ Coverage: `tests/ui/typeck/base_arguments.sol`,
 `tests/ui/codegen/lowering/base_constructor_args.sol`, and
 `tests/ui/codegen/lowering/run-call/named_arguments_extended.sol`.
 
+### TYPECK-005: Parenthesized `try` targets
+
+Status: intentional.
+
+Difference: `solc` requires a `try` statement's target to be a call
+syntactically and reports 5347 ("Try can only be used with external function
+calls and contract creation calls") for `try (c.f()) { ... }`, because the
+parenthesized expression is a tuple rather than a call. `solar` peels the
+parentheses and compiles the statement as if they were not written.
+
+Rationale: parentheses do not change the call they wrap, so the statement has
+one unambiguous meaning; rejecting it would be a grammar restriction rather
+than a language rule. The checker and lowering peel them identically, so an
+accepted statement always compiles.
+
+Coverage: `tests/ui/codegen/lowering/run-call/try_parenthesized_target.sol`.
+
 ## Contract-Level Checks
 
 No intentional divergences documented yet.

--- a/tests/ui/codegen/lowering/run-call/try_parenthesized_target.mir.stdout
+++ b/tests/ui/codegen/lowering/run-call/try_parenthesized_target.mir.stdout
@@ -1,0 +1,174 @@
+// === ROOT/tests/ui/codegen/lowering/run-call/try_parenthesized_target.sol:Target ===
+@module Target
+fn @ok() -> u256 [selector=0xd909b403, pure, abi_params=[], abi_returns=[word]] {
+  bb0:
+    ret 5
+}
+
+fn @bad() [selector=0x9c3674fc, pure, abi_params=[], abi_returns=[word]] {
+  bb0:
+    icall @revert_error, 0, 2, 0x6e6f000000000000000000000000000000000000000000000000000000000000
+    invalid
+}
+
+fn @revert_error(arg0: u256, arg1: u256) {
+  bb0:
+    mstore 0, 0x8c379a000000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 32 !metadata(memory=scratch)
+    mstore 36, arg0 !metadata(memory=scratch)
+    mstore 68, arg1 !metadata(memory=scratch)
+    revert 0, 100
+}
+
+// === ROOT/tests/ui/codegen/lowering/run-call/try_parenthesized_target.sol:Caller ===
+@module Caller
+data:
+  Target_initcode_0: hex"34600d5760a58060115f395ff35b5f5ffd346028575f3560e01c80639c3674fc146020578063d909b403146024576028565b603e565b602c565b5f5ffd5b60056080526020608001608090036080f35b60e0604052600260a0527f6e6f00000000000000000000000000000000000000000000000000000000000060c0527f08c379a0000000000000000000000000000000000000000000000000000000005f52602060045260a05160245260c05160445260645ffd"
+
+fn @constructor() [constructor] {
+  bb0:
+    v0 = abi_encode []
+    v1 = not 31
+    v2 = and 213, v1
+    v3 = alloc raw, exact, uninitialized, infallible, v2
+    data_copy Target_initcode_0, v3, 182
+    v4 = slice_ptr v0
+    v5 = add v3, 182
+    mcopy v5, v4, 0 !metadata(memory=heap)
+    v6 = create 0, v3, 182
+    jumpi v6, bb2, bb1
+  bb1:
+    revert_returndata
+  bb2:
+    v7 = sload 0 !metadata(storage=slot(0))
+    v8 = not 0xffffffffffffffffffffffffffffffffffffffff
+    v9 = and v7, v8
+    v10 = and v6, 0xffffffffffffffffffffffffffffffffffffffff
+    v11 = or v9, v10
+    sstore 0, v11 !metadata(storage=slot(0))
+    stop
+}
+
+fn @success() -> u256 [selector=0x0b93381b, view, abi_params=[], abi_returns=[word]] {
+  bb0:
+    v0 = sload 0 !metadata(storage=slot(0))
+    v1 = and v0, 0xffffffffffffffffffffffffffffffffffffffff
+    v2 = gas
+    v3 = abi_encode [], selector 0xd909b40300000000000000000000000000000000000000000000000000000000
+    v4 = slice_ptr v3
+    v5 = slice_len v3
+    v6 = staticcall v2, v1, v4, v5, 0, 0
+    jumpi v6, bb1, bb2
+  bb2:
+    v15 = returndatasize
+    v16 = add v15, 63
+    v17 = lt v16, v15
+    jumpi v17, bb4, bb6
+  bb6:
+    v18 = not 31
+    v19 = and v16, v18
+    v20 = alloc memorybytes, exact, uninitialized, infallible, v19
+    set_memory_object_len memorybytes, v20, v15
+    v21 = make_returndata_slice 0, v15
+    memory_object_copy_from_slice memorybytes, v20, v21
+    v22 = memory_object_data memorybytes, v20
+    v23 = memory_object_len memorybytes, v20
+    v24 = make_memory_slice v22, v23
+    v25 = memory_slice_load_word memory, v24, 0
+    v26 = lt v23, 4
+    v27 = iszero v26
+    v28 = shr 224, v25
+    v29 = eq v28, 0x8c379a0
+    v30 = and v27, v29
+    v31 = lt v23, 36
+    v32 = iszero v31
+    v33 = eq v28, 0x4e487b71
+    v34 = and v32, v33
+    jumpi 1, bb7, bb8
+  bb8:
+    revert v22, v23
+  bb7:
+    ret 1
+  bb1:
+    v7 = returndatasize
+    v8 = add v7, 63
+    v9 = lt v8, v7
+    jumpi v9, bb4, bb5
+  bb5:
+    v10 = not 31
+    v11 = and v8, v10
+    v12 = alloc memorybytes, exact, uninitialized, infallible, v11
+    set_memory_object_len memorybytes, v12, v7
+    v13 = make_returndata_slice 0, v7
+    memory_object_copy_from_slice memorybytes, v12, v13
+    v14 = abi_decode [u256], v12
+    ret v14
+  bb4:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 65 !metadata(memory=scratch)
+    revert 0, 36
+  bb3:
+    ret 0
+}
+
+fn @failure() -> u256 [selector=0x76ffb887, view, abi_params=[], abi_returns=[word]] {
+  bb0:
+    v0 = sload 0 !metadata(storage=slot(0))
+    v1 = and v0, 0xffffffffffffffffffffffffffffffffffffffff
+    v2 = gas
+    v3 = abi_encode [], selector 0x9c3674fc00000000000000000000000000000000000000000000000000000000
+    v4 = slice_ptr v3
+    v5 = slice_len v3
+    v6 = staticcall v2, v1, v4, v5, 0, 0
+    jumpi v6, bb1, bb2
+  bb2:
+    v15 = returndatasize
+    v16 = add v15, 63
+    v17 = lt v16, v15
+    jumpi v17, bb4, bb6
+  bb6:
+    v18 = not 31
+    v19 = and v16, v18
+    v20 = alloc memorybytes, exact, uninitialized, infallible, v19
+    set_memory_object_len memorybytes, v20, v15
+    v21 = make_returndata_slice 0, v15
+    memory_object_copy_from_slice memorybytes, v20, v21
+    v22 = memory_object_data memorybytes, v20
+    v23 = memory_object_len memorybytes, v20
+    v24 = make_memory_slice v22, v23
+    v25 = memory_slice_load_word memory, v24, 0
+    v26 = lt v23, 4
+    v27 = iszero v26
+    v28 = shr 224, v25
+    v29 = eq v28, 0x8c379a0
+    v30 = and v27, v29
+    v31 = lt v23, 36
+    v32 = iszero v31
+    v33 = eq v28, 0x4e487b71
+    v34 = and v32, v33
+    jumpi 1, bb7, bb8
+  bb8:
+    revert v22, v23
+  bb7:
+    ret 2
+  bb1:
+    v7 = returndatasize
+    v8 = add v7, 63
+    v9 = lt v8, v7
+    jumpi v9, bb4, bb5
+  bb5:
+    v10 = not 31
+    v11 = and v8, v10
+    v12 = alloc memorybytes, exact, uninitialized, infallible, v11
+    set_memory_object_len memorybytes, v12, v7
+    v13 = make_returndata_slice 0, v7
+    memory_object_copy_from_slice memorybytes, v12, v13
+    v14 = abi_decode [u256], v12
+    ret v14
+  bb4:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 65 !metadata(memory=scratch)
+    revert 0, 36
+  bb3:
+    ret 0
+}

--- a/tests/ui/codegen/lowering/run-call/try_parenthesized_target.sol
+++ b/tests/ui/codegen/lowering/run-call/try_parenthesized_target.sol
@@ -1,0 +1,40 @@
+//@ codegen-matrix: standard
+//@ run-call: Caller::success => 5
+//@ run-call: Caller::failure => 2
+// Parenthesizing a `try` target changes nothing about the call it wraps, so
+// both the checker and lowering peel the parentheses. solc requires the target
+// to be a call syntactically and rejects the form; see TYPECK-005 in
+// docs/SOLC_DIVERGENCE.md.
+contract Target {
+    function ok() external pure returns (uint256) {
+        return 5;
+    }
+
+    function bad() external pure returns (uint256) {
+        revert("no");
+    }
+}
+
+contract Caller {
+    Target private target;
+
+    constructor() {
+        target = new Target();
+    }
+
+    function success() external view returns (uint256) {
+        try (target.ok()) returns (uint256 v) {
+            return v;
+        } catch {
+            return 1;
+        }
+    }
+
+    function failure() external view returns (uint256) {
+        try ((target.bad())) returns (uint256 v) {
+            return v;
+        } catch {
+            return 2;
+        }
+    }
+}

--- a/tests/ui/typeck/evm_version/byzantium.homestead.stderr
+++ b/tests/ui/typeck/evm_version/byzantium.homestead.stderr
@@ -34,7 +34,7 @@ error[9908]: typed catch clause requires Byzantium-compatible EVM
 LL │           } catch (bytes memory) {
    │ ┏━━━━━━━━━━━┛
 LL │ ┃
-LL │ ┃         } catch {
+LL │ ┃         }
    │ ┗━━━━━━━━━┛
    │
    ╰ help: compile with `--evm-version byzantium` or newer

--- a/tests/ui/typeck/evm_version/byzantium.sol
+++ b/tests/ui/typeck/evm_version/byzantium.sol
@@ -21,7 +21,6 @@ contract C {
         //~[homestead]^ ERROR: typed catch clause requires Byzantium-compatible EVM
         } catch (bytes memory) {
         //~[homestead]^ ERROR: typed catch clause requires Byzantium-compatible EVM
-        } catch {
         }
     }
 }

--- a/tests/ui/typeck/try_catch_clause_checks.sol
+++ b/tests/ui/typeck/try_catch_clause_checks.sol
@@ -4,10 +4,17 @@
 
 interface I {
     function f() external returns (uint256);
+
+    function pay() external payable returns (uint256);
 }
 
 struct S {
     uint256 a;
+}
+
+// A payable constructor, so a creation call can carry a `value` option.
+contract Created {
+    constructor() payable {}
 }
 
 contract C {
@@ -150,5 +157,17 @@ contract C {
             c;
         } catch {}
         try this.valid(a) {} catch {}
+    }
+
+    // Call options are part of the call expression, so an option-bearing target is checked
+    // like any other: the callee's kind decides, and the clauses are checked against it.
+    function validCallOptions(I i, uint256 v, bytes32 s, uint256 g) external payable {
+        try i.pay{value: v}() returns (uint256 x) {
+            x;
+        } catch {}
+        try new Created{value: v, salt: s}() returns (Created c) {
+            c;
+        } catch {}
+        try this.validCallOptions{gas: g}(i, v, s, g) {} catch {}
     }
 }

--- a/tests/ui/typeck/try_catch_clause_checks.sol
+++ b/tests/ui/typeck/try_catch_clause_checks.sol
@@ -6,6 +6,10 @@ interface I {
     function f() external returns (uint256);
 }
 
+struct S {
+    uint256 a;
+}
+
 contract C {
     function internal_() internal returns (uint256) {
         return 1;
@@ -13,7 +17,7 @@ contract C {
 
     // Only an external call, a delegate call, and a contract creation call have a revert of
     // their own to catch. An internal call, a builtin, and a type conversion do not, and the
-    // clauses of such a statement are not checked at all.
+    // clauses of such a statement are not checked at all. A call of another kind is 2536.
     function target(address a, bytes memory d) external {
         try internal_() returns (uint256 v) {
             //~^ ERROR: `try` can only be used with external function calls and contract creation calls
@@ -27,9 +31,30 @@ contract C {
             //~^ ERROR: `try` can only be used with external function calls and contract creation calls
             v;
         } catch {}
+        try new bytes(4) returns (bytes memory b) {
+            //~^ ERROR: `try` can only be used with external function calls and contract creation calls
+            b;
+        } catch {}
+    }
+
+    // A target that is no call at all is 5347, and so are the two constructs that are calls in
+    // the grammar only: a type conversion and a struct construction.
+    function targetNotACall(address a, uint256 x) external {
         try I(a) returns (I i) {
             //~^ ERROR: `try` can only be used with external function calls and contract creation calls
             i;
+        } catch {}
+        try uint256(x) returns (uint256 v) {
+            //~^ ERROR: `try` can only be used with external function calls and contract creation calls
+            v;
+        } catch {}
+        try S(1) returns (S memory s) {
+            //~^ ERROR: `try` can only be used with external function calls and contract creation calls
+            s;
+        } catch {}
+        try x++ returns (uint256 v) {
+            //~^ ERROR: `try` can only be used with external function calls and contract creation calls
+            v;
         } catch {}
     }
 

--- a/tests/ui/typeck/try_catch_clause_checks.sol
+++ b/tests/ui/typeck/try_catch_clause_checks.sol
@@ -1,0 +1,129 @@
+// A `try` statement only makes sense on a call that can revert on its own and hand back return
+// data, and each `catch` clause decodes one fixed shape of that data, so a second clause of the
+// same kind is dead and a differently typed parameter list decodes nothing.
+
+interface I {
+    function f() external returns (uint256);
+}
+
+contract C {
+    function internal_() internal returns (uint256) {
+        return 1;
+    }
+
+    // Only an external call, a delegate call, and a contract creation call have a revert of
+    // their own to catch. An internal call, a builtin, and a type conversion do not, and the
+    // clauses of such a statement are not checked at all.
+    function target(address a, bytes memory d) external {
+        try internal_() returns (uint256 v) {
+            //~^ ERROR: `try` can only be used with external function calls and contract creation calls
+            v;
+        } catch {}
+        try abi.decode(d, (uint256)) returns (uint256 v) {
+            //~^ ERROR: `try` can only be used with external function calls and contract creation calls
+            v;
+        } catch {}
+        try gasleft() returns (uint256 v) {
+            //~^ ERROR: `try` can only be used with external function calls and contract creation calls
+            v;
+        } catch {}
+        try I(a) returns (I i) {
+            //~^ ERROR: `try` can only be used with external function calls and contract creation calls
+            i;
+        } catch {}
+    }
+
+    // A pruned function still has to pass semantic analysis: nothing reaches this call, so
+    // lowering never sees it and only the checker can reject it.
+    function pruned() external {
+        if (false) {
+            try internal_() {
+                //~^ ERROR: `try` can only be used with external function calls and contract creation calls
+            } catch {}
+        }
+    }
+
+    // Only one clause of each kind can ever run, so a second one is dead. A bare `catch` and
+    // `catch (bytes memory)` are the same, low-level kind.
+    function duplicates(address a) external {
+        try I(a).f() returns (uint256 v) {
+            v;
+        } catch Error(string memory) {} catch Error(string memory) {}
+        //~^ ERROR: this `try` statement already has an `Error` catch clause
+        try I(a).f() returns (uint256 v) {
+            v;
+        } catch Panic(uint256) {} catch Panic(uint256) {}
+        //~^ ERROR: this `try` statement already has a `Panic` catch clause
+        try I(a).f() returns (uint256 v) {
+            v;
+        } catch (bytes memory) {} catch {}
+        //~^ ERROR: this `try` statement already has a low-level catch clause
+        try I(a).f() returns (uint256 v) {
+            v;
+        } catch {} catch (bytes memory) {}
+        //~^ ERROR: this `try` statement already has a low-level catch clause
+        try I(a).f() returns (uint256 v) {
+            v;
+        } catch {} catch {}
+        //~^ ERROR: this `try` statement already has a low-level catch clause
+    }
+
+    // A clause takes exactly the one argument its error carries, or nothing for a bare `catch`.
+    function parameters(address a) external {
+        try I(a).f() returns (uint256 v) {
+            v;
+        } catch Error(uint256) {}
+        //~^ ERROR: invalid `Error` catch clause parameters
+        try I(a).f() returns (uint256 v) {
+            v;
+        } catch Panic(uint8) {}
+        //~^ ERROR: invalid `Panic` catch clause parameters
+        try I(a).f() returns (uint256 v) {
+            v;
+        } catch (uint256) {}
+        //~^ ERROR: invalid low-level catch clause parameters
+        try I(a).f() returns (uint256 v) {
+            v;
+        } catch (bytes memory, uint256) {}
+        //~^ ERROR: invalid low-level catch clause parameters
+    }
+
+    // A rejected data location is reported once, on the declaration; solc rewrites it and does
+    // not also complain about the clause's parameter type.
+    function parameterLocation(address a) external {
+        try I(a).f() returns (uint256 v) {
+            v;
+        } catch Error(string calldata) {}
+        //~^ ERROR: invalid data location `calldata`
+        try I(a).f() returns (uint256 v) {
+            v;
+        } catch (bytes storage) {}
+        //~^ ERROR: invalid data location `storage`
+    }
+
+    // `Error` and `Panic` are the only clause names there are.
+    function name(address a) external {
+        try I(a).f() returns (uint256 v) {
+            v;
+        } catch Custom(uint256) {}
+        //~^ ERROR: invalid catch clause name
+    }
+
+    // Valid companions: every accepted target, every clause kind once, and `uint` as the alias
+    // of the `Panic` argument's type.
+    function valid(address a) external {
+        try I(a).f() returns (uint256 v) {
+            v;
+        } catch Error(string memory reason) {
+            reason;
+        } catch Panic(uint code) {
+            code;
+        } catch (bytes memory data) {
+            data;
+        }
+        try new C() returns (C c) {
+            c;
+        } catch {}
+        try this.valid(a) {} catch {}
+    }
+}

--- a/tests/ui/typeck/try_catch_clause_checks.stderr
+++ b/tests/ui/typeck/try_catch_clause_checks.stderr
@@ -1,0 +1,148 @@
+error: invalid data location `calldata`
+   ╭▸ ROOT/tests/ui/typeck/try_catch_clause_checks.sol:LL:CC
+   │
+LL │         } catch Error(string calldata) {}
+   │                       ━━━━━━━━━━━━━━━
+   │
+   ╰ note: data location must be `memory` for try/catch clause, but got `calldata`
+
+error: invalid data location `storage`
+   ╭▸ ROOT/tests/ui/typeck/try_catch_clause_checks.sol:LL:CC
+   │
+LL │         } catch (bytes storage) {}
+   │                  ━━━━━━━━━━━━━
+   │
+   ╰ note: data location must be `memory` for try/catch clause, but got `storage`
+
+error[2536]: `try` can only be used with external function calls and contract creation calls
+   ╭▸ ROOT/tests/ui/typeck/try_catch_clause_checks.sol:LL:CC
+   │
+LL │         try internal_() returns (uint256 v) {
+   ╰╴            ━━━━━━━━━━━
+
+error[2536]: `try` can only be used with external function calls and contract creation calls
+   ╭▸ ROOT/tests/ui/typeck/try_catch_clause_checks.sol:LL:CC
+   │
+LL │         try abi.decode(d, (uint256)) returns (uint256 v) {
+   ╰╴            ━━━━━━━━━━━━━━━━━━━━━━━━
+
+error[2536]: `try` can only be used with external function calls and contract creation calls
+   ╭▸ ROOT/tests/ui/typeck/try_catch_clause_checks.sol:LL:CC
+   │
+LL │         try gasleft() returns (uint256 v) {
+   ╰╴            ━━━━━━━━━
+
+error[2536]: `try` can only be used with external function calls and contract creation calls
+   ╭▸ ROOT/tests/ui/typeck/try_catch_clause_checks.sol:LL:CC
+   │
+LL │         try I(a) returns (I i) {
+   ╰╴            ━━━━
+
+error[2536]: `try` can only be used with external function calls and contract creation calls
+   ╭▸ ROOT/tests/ui/typeck/try_catch_clause_checks.sol:LL:CC
+   │
+LL │             try internal_() {
+   ╰╴                ━━━━━━━━━━━
+
+error[1036]: this `try` statement already has an `Error` catch clause
+   ╭▸ ROOT/tests/ui/typeck/try_catch_clause_checks.sol:LL:CC
+   │
+LL │         } catch Error(string memory) {} catch Error(string memory) {}
+   │                                         ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   ╰╴
+note: the first clause is here
+   ╭▸ ROOT/tests/ui/typeck/try_catch_clause_checks.sol:LL:CC
+   │
+LL │         } catch Error(string memory) {} catch Error(string memory) {}
+   ╰╴          ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+error[6732]: this `try` statement already has a `Panic` catch clause
+   ╭▸ ROOT/tests/ui/typeck/try_catch_clause_checks.sol:LL:CC
+   │
+LL │         } catch Panic(uint256) {} catch Panic(uint256) {}
+   │                                   ━━━━━━━━━━━━━━━━━━━━━━━
+   ╰╴
+note: the first clause is here
+   ╭▸ ROOT/tests/ui/typeck/try_catch_clause_checks.sol:LL:CC
+   │
+LL │         } catch Panic(uint256) {} catch Panic(uint256) {}
+   ╰╴          ━━━━━━━━━━━━━━━━━━━━━━━
+
+error[5320]: this `try` statement already has a low-level catch clause
+   ╭▸ ROOT/tests/ui/typeck/try_catch_clause_checks.sol:LL:CC
+   │
+LL │         } catch (bytes memory) {} catch {}
+   │                                   ━━━━━━━━
+   ╰╴
+note: the first clause is here
+   ╭▸ ROOT/tests/ui/typeck/try_catch_clause_checks.sol:LL:CC
+   │
+LL │         } catch (bytes memory) {} catch {}
+   ╰╴          ━━━━━━━━━━━━━━━━━━━━━━━
+
+error[5320]: this `try` statement already has a low-level catch clause
+   ╭▸ ROOT/tests/ui/typeck/try_catch_clause_checks.sol:LL:CC
+   │
+LL │         } catch {} catch (bytes memory) {}
+   │                    ━━━━━━━━━━━━━━━━━━━━━━━
+   ╰╴
+note: the first clause is here
+   ╭▸ ROOT/tests/ui/typeck/try_catch_clause_checks.sol:LL:CC
+   │
+LL │         } catch {} catch (bytes memory) {}
+   ╰╴          ━━━━━━━━
+
+error[5320]: this `try` statement already has a low-level catch clause
+   ╭▸ ROOT/tests/ui/typeck/try_catch_clause_checks.sol:LL:CC
+   │
+LL │         } catch {} catch {}
+   │                    ━━━━━━━━
+   ╰╴
+note: the first clause is here
+   ╭▸ ROOT/tests/ui/typeck/try_catch_clause_checks.sol:LL:CC
+   │
+LL │         } catch {} catch {}
+   ╰╴          ━━━━━━━━
+
+error[2943]: invalid `Error` catch clause parameters
+   ╭▸ ROOT/tests/ui/typeck/try_catch_clause_checks.sol:LL:CC
+   │
+LL │         } catch Error(uint256) {}
+   │           ━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: expected `catch Error(string memory ...) { ... }`
+
+error[1271]: invalid `Panic` catch clause parameters
+   ╭▸ ROOT/tests/ui/typeck/try_catch_clause_checks.sol:LL:CC
+   │
+LL │         } catch Panic(uint8) {}
+   │           ━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: expected `catch Panic(uint ...) { ... }`
+
+error[6231]: invalid low-level catch clause parameters
+   ╭▸ ROOT/tests/ui/typeck/try_catch_clause_checks.sol:LL:CC
+   │
+LL │         } catch (uint256) {}
+   │           ━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: expected `catch (bytes memory ...) { ... }` or `catch { ... }`
+
+error[6231]: invalid low-level catch clause parameters
+   ╭▸ ROOT/tests/ui/typeck/try_catch_clause_checks.sol:LL:CC
+   │
+LL │         } catch (bytes memory, uint256) {}
+   │           ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: expected `catch (bytes memory ...) { ... }` or `catch { ... }`
+
+error[3542]: invalid catch clause name
+   ╭▸ ROOT/tests/ui/typeck/try_catch_clause_checks.sol:LL:CC
+   │
+LL │         } catch Custom(uint256) {}
+   │           ━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: expected `catch (...)`, `catch Error(...)`, or `catch Panic(...)`
+
+error: aborting due to 17 previous errors
+

--- a/tests/ui/typeck/try_catch_clause_checks.stderr
+++ b/tests/ui/typeck/try_catch_clause_checks.stderr
@@ -35,8 +35,32 @@ LL │         try gasleft() returns (uint256 v) {
 error[2536]: `try` can only be used with external function calls and contract creation calls
    ╭▸ ROOT/tests/ui/typeck/try_catch_clause_checks.sol:LL:CC
    │
+LL │         try new bytes(4) returns (bytes memory b) {
+   ╰╴            ━━━━━━━━━━━━
+
+error[5347]: `try` can only be used with external function calls and contract creation calls
+   ╭▸ ROOT/tests/ui/typeck/try_catch_clause_checks.sol:LL:CC
+   │
 LL │         try I(a) returns (I i) {
    ╰╴            ━━━━
+
+error[5347]: `try` can only be used with external function calls and contract creation calls
+   ╭▸ ROOT/tests/ui/typeck/try_catch_clause_checks.sol:LL:CC
+   │
+LL │         try uint256(x) returns (uint256 v) {
+   ╰╴            ━━━━━━━━━━
+
+error[5347]: `try` can only be used with external function calls and contract creation calls
+   ╭▸ ROOT/tests/ui/typeck/try_catch_clause_checks.sol:LL:CC
+   │
+LL │         try S(1) returns (S memory s) {
+   ╰╴            ━━━━
+
+error[5347]: `try` can only be used with external function calls and contract creation calls
+   ╭▸ ROOT/tests/ui/typeck/try_catch_clause_checks.sol:LL:CC
+   │
+LL │         try x++ returns (uint256 v) {
+   ╰╴            ━━━
 
 error[2536]: `try` can only be used with external function calls and contract creation calls
    ╭▸ ROOT/tests/ui/typeck/try_catch_clause_checks.sol:LL:CC
@@ -144,5 +168,5 @@ LL │         } catch Custom(uint256) {}
    │
    ╰ help: expected `catch (...)`, `catch Error(...)`, or `catch Panic(...)`
 
-error: aborting due to 17 previous errors
+error: aborting due to 21 previous errors
 

--- a/tests/ui/typeck/try_returns_clause.sol
+++ b/tests/ui/typeck/try_returns_clause.sol
@@ -19,6 +19,25 @@ library L {
     function slot(uint256[] storage s) external returns (uint256[] storage) {
         return s;
     }
+
+    // A clause parameter is declared in the clause's own scope, so a library function does not
+    // widen its locations the way it widens its own parameters'.
+    function inLibrary(address a) internal {
+        try I(a).arr() returns (uint256[] storage r) {
+            //~^ ERROR: invalid data location `storage`
+            r;
+        } catch {}
+    }
+}
+
+// A constructor's parameters may be `storage` pointers; a clause's may not.
+contract Constructing {
+    constructor(address a) {
+        try I(a).arr() returns (uint256[] storage r) {
+            //~^ ERROR: invalid data location `storage`
+            r;
+        } catch {}
+    }
 }
 
 contract Mismatch {
@@ -149,6 +168,14 @@ contract C {
 
     function internal_() internal pure returns (uint256) {
         return 1;
+    }
+
+    // Nor does an internal function, whose own parameters may be `storage` pointers.
+    function inInternal(address a) internal {
+        try I(a).arr() returns (uint256[] storage r) {
+            //~^ ERROR: invalid data location `storage`
+            r;
+        } catch {}
     }
 
     // Valid companions: the same types, a creation call, no `returns` clause at all, and a

--- a/tests/ui/typeck/try_returns_clause.sol
+++ b/tests/ui/typeck/try_returns_clause.sol
@@ -107,6 +107,28 @@ contract C {
         } catch {}
     }
 
+    // Only an external, delegate, or creation call decodes return values into the clause.
+    // solc rejects every other callee outright and compares nothing, so neither do we: a
+    // builtin's return values are not even always a type.
+    function otherCallees(bytes memory d) external {
+        try internal_() returns (bool b) {
+            b;
+        } catch {}
+        try abi.decode(d, (uint256)) returns (uint256 x) {
+            x;
+        } catch {}
+        try gasleft() returns (bool b) {
+            b;
+        } catch {}
+        try address(this).call("") returns (uint256 ok) {
+            ok;
+        } catch {}
+    }
+
+    function internal_() internal pure returns (uint256) {
+        return 1;
+    }
+
     // Valid companions: the same types, a creation call, no `returns` clause at all, and a
     // mixed static and dynamic return.
     function valid(address a) external {

--- a/tests/ui/typeck/try_returns_clause.sol
+++ b/tests/ui/typeck/try_returns_clause.sol
@@ -125,20 +125,24 @@ contract C {
         } catch {}
     }
 
-    // Only an external, delegate, or creation call decodes return values into the clause.
-    // solc rejects every other callee outright and compares nothing, so neither do we: a
-    // builtin's return values are not even always a type.
+    // Only an external, delegate, or creation call decodes return values into the clause. Every
+    // other callee is rejected outright and its clause compared to nothing: a builtin's return
+    // values are not even always a type. See `try_catch_clause_checks.sol`.
     function otherCallees(bytes memory d) external {
         try internal_() returns (bool b) {
+            //~^ ERROR: `try` can only be used with external function calls and contract creation calls
             b;
         } catch {}
         try abi.decode(d, (uint256)) returns (uint256 x) {
+            //~^ ERROR: `try` can only be used with external function calls and contract creation calls
             x;
         } catch {}
         try gasleft() returns (bool b) {
+            //~^ ERROR: `try` can only be used with external function calls and contract creation calls
             b;
         } catch {}
         try address(this).call("") returns (uint256 ok) {
+            //~^ ERROR: `try` can only be used with external function calls and contract creation calls
             ok;
         } catch {}
     }

--- a/tests/ui/typeck/try_returns_clause.sol
+++ b/tests/ui/typeck/try_returns_clause.sol
@@ -85,6 +85,24 @@ contract C {
         } catch {}
     }
 
+    // A location on a type that takes none is just as illegal, and the declaration is the only
+    // error: the variable's rewritten type is not what was written, so comparing it would
+    // report a second, invented mismatch.
+    function nonReferenceLocation(address a) external {
+        try I(a).one() returns (bool memory b) {
+            //~^ ERROR: data location can only be specified for array, struct or mapping types
+            b;
+        } catch {}
+        try I(a).one() returns (uint256 calldata x) {
+            //~^ ERROR: data location can only be specified for array, struct or mapping types
+            x;
+        } catch {}
+        try I(a).one() returns (bool storage c) {
+            //~^ ERROR: data location can only be specified for array, struct or mapping types
+            c;
+        } catch {}
+    }
+
     // A creation call returns the new contract, not its address.
     function creation() external {
         try new D() returns (address b) {

--- a/tests/ui/typeck/try_returns_clause.sol
+++ b/tests/ui/typeck/try_returns_clause.sol
@@ -1,0 +1,130 @@
+// ported-from: test/libsolidity/syntaxTests/tryCatch/invalid_returns.sol
+// ported-from: test/libsolidity/syntaxTests/tryCatch/returns_mismatch.sol
+
+// A `returns` clause has to repeat the callee's return types exactly. The decoder writes the
+// call's values straight into the clause's variables, so neither an implicit conversion nor a
+// data location other than `memory` is accepted.
+
+interface I {
+    function none() external;
+    function one() external returns (uint256);
+    function two() external returns (uint8, uint256);
+    function arr() external returns (uint256[] memory);
+    function mixed() external returns (uint256, bytes memory);
+}
+
+contract D {}
+
+library L {
+    function slot(uint256[] storage s) external returns (uint256[] storage) {
+        return s;
+    }
+}
+
+contract Mismatch {
+    function f() public returns (uint8, uint256) {
+        // Implicitly convertible, but not exactly the same type.
+        try this.f() returns (uint256, int256 x) {
+            //~^ ERROR: mismatched types
+            //~| ERROR: mismatched types
+            x;
+        } catch {}
+    }
+
+    function g() public returns (uint256, uint256) {
+        try this.g() returns (uint256 a) {
+            //~^ ERROR: function returns 2 values, but the `returns` clause has 1 variable
+            a = 1;
+        } catch {}
+    }
+}
+
+contract C {
+    uint256[] s;
+
+    // A count mismatch in either direction, including against a callee with no return values.
+    function count(address a) external {
+        try I(a).one() returns (uint256 x, uint256 y) {
+            //~^ ERROR: function returns 1 value, but the `returns` clause has 2 variables
+            x;
+            y;
+        } catch {}
+        try I(a).none() returns (uint256 x) {
+            //~^ ERROR: function returns 0 values, but the `returns` clause has 1 variable
+            x;
+        } catch {}
+    }
+
+    // A count mismatch does not stop the pairs that are there from being compared.
+    function countAndType(address a) external {
+        try I(a).two() returns (bool b) {
+            //~^ ERROR: function returns 2 values, but the `returns` clause has 1 variable
+            //~| ERROR: mismatched types
+            b;
+        } catch {}
+    }
+
+    function type_(address a) external {
+        try I(a).one() returns (bool b) {
+            //~^ ERROR: mismatched types
+            b;
+        } catch {}
+    }
+
+    // The data location is part of the type, so a memory binding of a storage pointer is a
+    // mismatch. A library function returning one cannot be bound at all: every other location
+    // is rejected outright.
+    function location() external {
+        try L.slot(s) returns (uint256[] memory r) {
+            //~^ ERROR: mismatched types
+            r;
+        } catch {}
+        try L.slot(s) returns (uint256[] storage r) {
+            //~^ ERROR: invalid data location `storage`
+            r;
+        } catch {}
+    }
+
+    // A creation call returns the new contract, not its address.
+    function creation() external {
+        try new D() returns (address b) {
+            //~^ ERROR: mismatched types
+            b;
+        } catch {}
+        try new D() returns (D d, uint256 x) {
+            //~^ ERROR: function returns 1 value, but the `returns` clause has 2 variables
+            d;
+            x;
+        } catch {}
+    }
+
+    // An external function pointer callee carries the same return types.
+    function pointer(address a) external {
+        function() external returns (uint256) p = I(a).one;
+        try p() returns (bool b) {
+            //~^ ERROR: mismatched types
+            b;
+        } catch {}
+    }
+
+    // Valid companions: the same types, a creation call, no `returns` clause at all, and a
+    // mixed static and dynamic return.
+    function valid(address a) external {
+        try I(a).two() returns (uint8 x, uint256 y) {
+            x;
+            y;
+        } catch {}
+        try I(a).arr() returns (uint256[] memory r) {
+            r;
+        } catch {}
+        try I(a).mixed() returns (uint256 x, bytes memory b) {
+            x;
+            b;
+        } catch {}
+        try new D() returns (D d) {
+            d;
+        } catch {}
+        try I(a).two() {} catch {}
+        try I(a).none() {} catch {}
+    }
+}

--- a/tests/ui/typeck/try_returns_clause.stderr
+++ b/tests/ui/typeck/try_returns_clause.stderr
@@ -133,5 +133,29 @@ LL │         try p() returns (bool b) {
    │
    ╰ note: a `returns` clause must repeat the callee's return types exactly
 
-error: aborting due to 16 previous errors
+error[2536]: `try` can only be used with external function calls and contract creation calls
+   ╭▸ ROOT/tests/ui/typeck/try_returns_clause.sol:LL:CC
+   │
+LL │         try internal_() returns (bool b) {
+   ╰╴            ━━━━━━━━━━━
+
+error[2536]: `try` can only be used with external function calls and contract creation calls
+   ╭▸ ROOT/tests/ui/typeck/try_returns_clause.sol:LL:CC
+   │
+LL │         try abi.decode(d, (uint256)) returns (uint256 x) {
+   ╰╴            ━━━━━━━━━━━━━━━━━━━━━━━━
+
+error[2536]: `try` can only be used with external function calls and contract creation calls
+   ╭▸ ROOT/tests/ui/typeck/try_returns_clause.sol:LL:CC
+   │
+LL │         try gasleft() returns (bool b) {
+   ╰╴            ━━━━━━━━━
+
+error[2536]: `try` can only be used with external function calls and contract creation calls
+   ╭▸ ROOT/tests/ui/typeck/try_returns_clause.sol:LL:CC
+   │
+LL │         try address(this).call("") returns (uint256 ok) {
+   ╰╴            ━━━━━━━━━━━━━━━━━━━━━━
+
+error: aborting due to 20 previous errors
 

--- a/tests/ui/typeck/try_returns_clause.stderr
+++ b/tests/ui/typeck/try_returns_clause.stderr
@@ -1,0 +1,119 @@
+error: invalid data location `storage`
+   ╭▸ ROOT/tests/ui/typeck/try_returns_clause.sol:LL:CC
+   │
+LL │         try L.slot(s) returns (uint256[] storage r) {
+   │                                ━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ note: data location must be `memory` for try/catch clause, but got `storage`
+
+error[6509]: mismatched types
+   ╭▸ ROOT/tests/ui/typeck/try_returns_clause.sol:LL:CC
+   │
+LL │         try this.f() returns (uint256, int256 x) {
+   │                               ━━━━━━━ expected `uint8`, found `uint256`
+   │
+   ╰ note: a `returns` clause must repeat the callee's return types exactly
+
+error[6509]: mismatched types
+   ╭▸ ROOT/tests/ui/typeck/try_returns_clause.sol:LL:CC
+   │
+LL │         try this.f() returns (uint256, int256 x) {
+   │                                        ━━━━━━━━ expected `uint256`, found `int256`
+   │
+   ╰ note: a `returns` clause must repeat the callee's return types exactly
+
+error[2800]: function returns 2 values, but the `returns` clause has 1 variable
+   ╭▸ ROOT/tests/ui/typeck/try_returns_clause.sol:LL:CC
+   │
+LL │           try this.g() returns (uint256 a) {
+   │ ┏━━━━━━━━━━━━━━━━━━━━━━┛
+LL │ ┃
+LL │ ┃             a = 1;
+LL │ ┃         } catch {}
+   ╰╴┗━━━━━━━━━┛
+
+error[2800]: function returns 1 value, but the `returns` clause has 2 variables
+   ╭▸ ROOT/tests/ui/typeck/try_returns_clause.sol:LL:CC
+   │
+LL │           try I(a).one() returns (uint256 x, uint256 y) {
+   │ ┏━━━━━━━━━━━━━━━━━━━━━━━━┛
+LL │ ┃
+LL │ ┃             x;
+LL │ ┃             y;
+LL │ ┃         } catch {}
+   ╰╴┗━━━━━━━━━┛
+
+error[2800]: function returns 0 values, but the `returns` clause has 1 variable
+   ╭▸ ROOT/tests/ui/typeck/try_returns_clause.sol:LL:CC
+   │
+LL │           try I(a).none() returns (uint256 x) {
+   │ ┏━━━━━━━━━━━━━━━━━━━━━━━━━┛
+LL │ ┃
+LL │ ┃             x;
+LL │ ┃         } catch {}
+   ╰╴┗━━━━━━━━━┛
+
+error[2800]: function returns 2 values, but the `returns` clause has 1 variable
+   ╭▸ ROOT/tests/ui/typeck/try_returns_clause.sol:LL:CC
+   │
+LL │           try I(a).two() returns (bool b) {
+   │ ┏━━━━━━━━━━━━━━━━━━━━━━━━┛
+LL │ ┃
+LL │ ┃
+LL │ ┃             b;
+LL │ ┃         } catch {}
+   ╰╴┗━━━━━━━━━┛
+
+error[6509]: mismatched types
+   ╭▸ ROOT/tests/ui/typeck/try_returns_clause.sol:LL:CC
+   │
+LL │         try I(a).two() returns (bool b) {
+   │                                 ━━━━━━ expected `uint8`, found `bool`
+   │
+   ╰ note: a `returns` clause must repeat the callee's return types exactly
+
+error[6509]: mismatched types
+   ╭▸ ROOT/tests/ui/typeck/try_returns_clause.sol:LL:CC
+   │
+LL │         try I(a).one() returns (bool b) {
+   │                                 ━━━━━━ expected `uint256`, found `bool`
+   │
+   ╰ note: a `returns` clause must repeat the callee's return types exactly
+
+error[6509]: mismatched types
+   ╭▸ ROOT/tests/ui/typeck/try_returns_clause.sol:LL:CC
+   │
+LL │         try L.slot(s) returns (uint256[] memory r) {
+   │                                ━━━━━━━━━━━━━━━━━━ expected `uint256[] storage`, found `uint256[] memory`
+   │
+   ╰ note: a `returns` clause must repeat the callee's return types exactly
+
+error[6509]: mismatched types
+   ╭▸ ROOT/tests/ui/typeck/try_returns_clause.sol:LL:CC
+   │
+LL │         try new D() returns (address b) {
+   │                              ━━━━━━━━━ expected `contract D`, found `address`
+   │
+   ╰ note: a `returns` clause must repeat the callee's return types exactly
+
+error[2800]: function returns 1 value, but the `returns` clause has 2 variables
+   ╭▸ ROOT/tests/ui/typeck/try_returns_clause.sol:LL:CC
+   │
+LL │           try new D() returns (D d, uint256 x) {
+   │ ┏━━━━━━━━━━━━━━━━━━━━━┛
+LL │ ┃
+LL │ ┃             d;
+LL │ ┃             x;
+LL │ ┃         } catch {}
+   ╰╴┗━━━━━━━━━┛
+
+error[6509]: mismatched types
+   ╭▸ ROOT/tests/ui/typeck/try_returns_clause.sol:LL:CC
+   │
+LL │         try p() returns (bool b) {
+   │                          ━━━━━━ expected `uint256`, found `bool`
+   │
+   ╰ note: a `returns` clause must repeat the callee's return types exactly
+
+error: aborting due to 13 previous errors
+

--- a/tests/ui/typeck/try_returns_clause.stderr
+++ b/tests/ui/typeck/try_returns_clause.stderr
@@ -6,6 +6,24 @@ LL │         try L.slot(s) returns (uint256[] storage r) {
    │
    ╰ note: data location must be `memory` for try/catch clause, but got `storage`
 
+error: data location can only be specified for array, struct or mapping types
+   ╭▸ ROOT/tests/ui/typeck/try_returns_clause.sol:LL:CC
+   │
+LL │         try I(a).one() returns (bool memory b) {
+   ╰╴                                ━━━━━━━━━━━━━
+
+error: data location can only be specified for array, struct or mapping types
+   ╭▸ ROOT/tests/ui/typeck/try_returns_clause.sol:LL:CC
+   │
+LL │         try I(a).one() returns (uint256 calldata x) {
+   ╰╴                                ━━━━━━━━━━━━━━━━━━
+
+error: data location can only be specified for array, struct or mapping types
+   ╭▸ ROOT/tests/ui/typeck/try_returns_clause.sol:LL:CC
+   │
+LL │         try I(a).one() returns (bool storage c) {
+   ╰╴                                ━━━━━━━━━━━━━━
+
 error[6509]: mismatched types
    ╭▸ ROOT/tests/ui/typeck/try_returns_clause.sol:LL:CC
    │
@@ -115,5 +133,5 @@ LL │         try p() returns (bool b) {
    │
    ╰ note: a `returns` clause must repeat the callee's return types exactly
 
-error: aborting due to 13 previous errors
+error: aborting due to 16 previous errors
 

--- a/tests/ui/typeck/try_returns_clause.stderr
+++ b/tests/ui/typeck/try_returns_clause.stderr
@@ -1,6 +1,22 @@
 error: invalid data location `storage`
    ╭▸ ROOT/tests/ui/typeck/try_returns_clause.sol:LL:CC
    │
+LL │         try I(a).arr() returns (uint256[] storage r) {
+   │                                 ━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ note: data location must be `memory` for try/catch clause, but got `storage`
+
+error: invalid data location `storage`
+   ╭▸ ROOT/tests/ui/typeck/try_returns_clause.sol:LL:CC
+   │
+LL │         try I(a).arr() returns (uint256[] storage r) {
+   │                                 ━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ note: data location must be `memory` for try/catch clause, but got `storage`
+
+error: invalid data location `storage`
+   ╭▸ ROOT/tests/ui/typeck/try_returns_clause.sol:LL:CC
+   │
 LL │         try L.slot(s) returns (uint256[] storage r) {
    │                                ━━━━━━━━━━━━━━━━━━━
    │
@@ -23,6 +39,14 @@ error: data location can only be specified for array, struct or mapping types
    │
 LL │         try I(a).one() returns (bool storage c) {
    ╰╴                                ━━━━━━━━━━━━━━
+
+error: invalid data location `storage`
+   ╭▸ ROOT/tests/ui/typeck/try_returns_clause.sol:LL:CC
+   │
+LL │         try I(a).arr() returns (uint256[] storage r) {
+   │                                 ━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ note: data location must be `memory` for try/catch clause, but got `storage`
 
 error[6509]: mismatched types
    ╭▸ ROOT/tests/ui/typeck/try_returns_clause.sol:LL:CC
@@ -157,5 +181,5 @@ error[2536]: `try` can only be used with external function calls and contract cr
 LL │         try address(this).call("") returns (uint256 ok) {
    ╰╴            ━━━━━━━━━━━━━━━━━━━━━━
 
-error: aborting due to 20 previous errors
+error: aborting due to 23 previous errors
 


### PR DESCRIPTION
Part of the split of the solc-vs-solar differential audit branch (#1360). Based on #1369 because the check reuses the pre-byzantium discard tracking and the slot-encoding rule introduced there.

solc compares a `try` statement's `returns` clause with the callee's return types and reports 2800 for a count mismatch and 6509 for a type mismatch, requiring exact types including data location; we bound the variables without any comparison, so a `bool` binding on a `uint256` return or a two-variable clause on a one-value callee compiled. The check runs after the statement is walked, applies to external, library, and creation callees only (solc rejects the rest with its own codes), and avoids double reports next to the declaration-location and pre-byzantium checks. solc's `invalid_returns.sol` and `returns_mismatch.sol` are ported 1-1.
