### PR TITLE
refactor(lint): pass only gcx to late lint hooks

### DIFF
--- a/crates/lint/src/late.rs
+++ b/crates/lint/src/late.rs
@@ -4,251 +4,240 @@ use solar_sema::{Gcx, hir};
 use std::ops::ControlFlow;
 
 /// A lint pass that runs on Solar's analyzed HIR.
-pub trait LateLintPass<'hir>: Send + Sync {
+///
+/// Every hook receives the global context; the HIR is available as `gcx.hir`.
+pub trait LateLintPass<'gcx>: Send + Sync {
     fn check_nested_source(
         &mut self,
         _ctx: &LintContext<'_, '_>,
-        _gcx: Gcx<'hir>,
-        _hir: &'hir hir::Hir<'hir>,
+        _gcx: Gcx<'gcx>,
         _id: hir::SourceId,
     ) {
     }
-    fn check_nested_item(
-        &mut self,
-        _ctx: &LintContext<'_, '_>,
-        _hir: &'hir hir::Hir<'hir>,
-        _id: hir::ItemId,
-    ) {
+    fn check_nested_item(&mut self, _ctx: &LintContext<'_, '_>, _gcx: Gcx<'gcx>, _id: hir::ItemId) {
     }
     fn check_nested_contract(
         &mut self,
         _ctx: &LintContext<'_, '_>,
-        _gcx: Gcx<'hir>,
-        _hir: &'hir hir::Hir<'hir>,
+        _gcx: Gcx<'gcx>,
         _id: hir::ContractId,
     ) {
     }
     fn check_nested_function(
         &mut self,
         _ctx: &LintContext<'_, '_>,
-        _hir: &'hir hir::Hir<'hir>,
+        _gcx: Gcx<'gcx>,
         _id: hir::FunctionId,
     ) {
     }
     fn check_nested_var(
         &mut self,
         _ctx: &LintContext<'_, '_>,
-        _hir: &'hir hir::Hir<'hir>,
+        _gcx: Gcx<'gcx>,
         _id: hir::VariableId,
     ) {
     }
     fn check_item(
         &mut self,
         _ctx: &LintContext<'_, '_>,
-        _hir: &'hir hir::Hir<'hir>,
-        _item: hir::Item<'hir, 'hir>,
+        _gcx: Gcx<'gcx>,
+        _item: hir::Item<'gcx, 'gcx>,
     ) {
     }
     fn check_contract(
         &mut self,
         _ctx: &LintContext<'_, '_>,
-        _gcx: Gcx<'hir>,
-        _hir: &'hir hir::Hir<'hir>,
-        _contract: &'hir hir::Contract<'hir>,
+        _gcx: Gcx<'gcx>,
+        _contract: &'gcx hir::Contract<'gcx>,
     ) {
     }
     fn check_function(
         &mut self,
         _ctx: &LintContext<'_, '_>,
-        _gcx: Gcx<'hir>,
-        _hir: &'hir hir::Hir<'hir>,
-        _function: &'hir hir::Function<'hir>,
+        _gcx: Gcx<'gcx>,
+        _function: &'gcx hir::Function<'gcx>,
     ) {
     }
     fn check_modifier(
         &mut self,
         _ctx: &LintContext<'_, '_>,
-        _hir: &'hir hir::Hir<'hir>,
-        _modifier: &'hir hir::Modifier<'hir>,
+        _gcx: Gcx<'gcx>,
+        _modifier: &'gcx hir::Modifier<'gcx>,
     ) {
     }
     fn check_var(
         &mut self,
         _ctx: &LintContext<'_, '_>,
-        _hir: &'hir hir::Hir<'hir>,
-        _var: &'hir hir::Variable<'hir>,
+        _gcx: Gcx<'gcx>,
+        _var: &'gcx hir::Variable<'gcx>,
     ) {
     }
     fn check_expr(
         &mut self,
         _ctx: &LintContext<'_, '_>,
-        _gcx: Gcx<'hir>,
-        _hir: &'hir hir::Hir<'hir>,
-        _expr: &'hir hir::Expr<'hir>,
+        _gcx: Gcx<'gcx>,
+        _expr: &'gcx hir::Expr<'gcx>,
     ) {
     }
     fn check_call_args(
         &mut self,
         _ctx: &LintContext<'_, '_>,
-        _hir: &'hir hir::Hir<'hir>,
-        _args: &'hir hir::CallArgs<'hir>,
+        _gcx: Gcx<'gcx>,
+        _args: &'gcx hir::CallArgs<'gcx>,
     ) {
     }
     fn check_stmt(
         &mut self,
         _ctx: &LintContext<'_, '_>,
-        _gcx: Gcx<'hir>,
-        _hir: &'hir hir::Hir<'hir>,
-        _stmt: &'hir hir::Stmt<'hir>,
+        _gcx: Gcx<'gcx>,
+        _stmt: &'gcx hir::Stmt<'gcx>,
     ) {
     }
     fn check_ty(
         &mut self,
         _ctx: &LintContext<'_, '_>,
-        _hir: &'hir hir::Hir<'hir>,
-        _ty: &'hir hir::Type<'hir>,
+        _gcx: Gcx<'gcx>,
+        _ty: &'gcx hir::Type<'gcx>,
     ) {
     }
 }
 
 /// Dispatches a HIR traversal to a collection of late lint passes.
-pub struct LateLintVisitor<'a, 's, 'hir> {
+pub struct LateLintVisitor<'a, 's, 'gcx> {
     ctx: &'a LintContext<'s, 'a>,
-    passes: &'a mut [Box<dyn LateLintPass<'hir> + 's>],
-    gcx: Gcx<'hir>,
-    hir: &'hir hir::Hir<'hir>,
+    passes: &'a mut [Box<dyn LateLintPass<'gcx> + 's>],
+    gcx: Gcx<'gcx>,
 }
 
-impl<'a, 's, 'hir> LateLintVisitor<'a, 's, 'hir>
+impl<'a, 's, 'gcx> LateLintVisitor<'a, 's, 'gcx>
 where
-    's: 'hir,
+    's: 'gcx,
 {
     pub fn new(
         ctx: &'a LintContext<'s, 'a>,
-        passes: &'a mut [Box<dyn LateLintPass<'hir> + 's>],
-        gcx: Gcx<'hir>,
-        hir: &'hir hir::Hir<'hir>,
+        passes: &'a mut [Box<dyn LateLintPass<'gcx> + 's>],
+        gcx: Gcx<'gcx>,
     ) -> Self {
-        Self { ctx, passes, gcx, hir }
+        Self { ctx, passes, gcx }
     }
 }
 
-impl<'s, 'hir> hir::Visit<'hir> for LateLintVisitor<'_, 's, 'hir>
+impl<'s, 'gcx> hir::Visit<'gcx> for LateLintVisitor<'_, 's, 'gcx>
 where
-    's: 'hir,
+    's: 'gcx,
 {
     type BreakValue = Never;
 
-    fn hir(&self) -> &'hir hir::Hir<'hir> {
-        self.hir
+    fn hir(&self) -> &'gcx hir::Hir<'gcx> {
+        &self.gcx.hir
     }
 
     fn visit_nested_source(&mut self, id: hir::SourceId) -> ControlFlow<Self::BreakValue> {
         for pass in self.passes.iter_mut() {
-            pass.check_nested_source(self.ctx, self.gcx, self.hir, id);
+            pass.check_nested_source(self.ctx, self.gcx, id);
         }
         self.walk_nested_source(id)
     }
 
     fn visit_nested_item(&mut self, id: hir::ItemId) -> ControlFlow<Self::BreakValue> {
         for pass in self.passes.iter_mut() {
-            pass.check_nested_item(self.ctx, self.hir, id);
+            pass.check_nested_item(self.ctx, self.gcx, id);
         }
         self.walk_nested_item(id)
     }
 
     fn visit_nested_contract(&mut self, id: hir::ContractId) -> ControlFlow<Self::BreakValue> {
         for pass in self.passes.iter_mut() {
-            pass.check_nested_contract(self.ctx, self.gcx, self.hir, id);
+            pass.check_nested_contract(self.ctx, self.gcx, id);
         }
         self.walk_nested_contract(id)
     }
 
     fn visit_nested_function(&mut self, id: hir::FunctionId) -> ControlFlow<Self::BreakValue> {
         for pass in self.passes.iter_mut() {
-            pass.check_nested_function(self.ctx, self.hir, id);
+            pass.check_nested_function(self.ctx, self.gcx, id);
         }
         self.walk_nested_function(id)
     }
 
     fn visit_nested_var(&mut self, id: hir::VariableId) -> ControlFlow<Self::BreakValue> {
         for pass in self.passes.iter_mut() {
-            pass.check_nested_var(self.ctx, self.hir, id);
+            pass.check_nested_var(self.ctx, self.gcx, id);
         }
         self.walk_nested_var(id)
     }
 
     fn visit_contract(
         &mut self,
-        contract: &'hir hir::Contract<'hir>,
+        contract: &'gcx hir::Contract<'gcx>,
     ) -> ControlFlow<Self::BreakValue> {
         for pass in self.passes.iter_mut() {
-            pass.check_contract(self.ctx, self.gcx, self.hir, contract);
+            pass.check_contract(self.ctx, self.gcx, contract);
         }
         self.walk_contract(contract)
     }
 
     fn visit_function(
         &mut self,
-        function: &'hir hir::Function<'hir>,
+        function: &'gcx hir::Function<'gcx>,
     ) -> ControlFlow<Self::BreakValue> {
         for pass in self.passes.iter_mut() {
-            pass.check_function(self.ctx, self.gcx, self.hir, function);
+            pass.check_function(self.ctx, self.gcx, function);
         }
         self.walk_function(function)
     }
 
     fn visit_modifier(
         &mut self,
-        modifier: &'hir hir::Modifier<'hir>,
+        modifier: &'gcx hir::Modifier<'gcx>,
     ) -> ControlFlow<Self::BreakValue> {
         for pass in self.passes.iter_mut() {
-            pass.check_modifier(self.ctx, self.hir, modifier);
+            pass.check_modifier(self.ctx, self.gcx, modifier);
         }
         self.walk_modifier(modifier)
     }
 
-    fn visit_item(&mut self, item: hir::Item<'hir, 'hir>) -> ControlFlow<Self::BreakValue> {
+    fn visit_item(&mut self, item: hir::Item<'gcx, 'gcx>) -> ControlFlow<Self::BreakValue> {
         for pass in self.passes.iter_mut() {
-            pass.check_item(self.ctx, self.hir, item);
+            pass.check_item(self.ctx, self.gcx, item);
         }
         self.walk_item(item)
     }
 
-    fn visit_var(&mut self, var: &'hir hir::Variable<'hir>) -> ControlFlow<Self::BreakValue> {
+    fn visit_var(&mut self, var: &'gcx hir::Variable<'gcx>) -> ControlFlow<Self::BreakValue> {
         for pass in self.passes.iter_mut() {
-            pass.check_var(self.ctx, self.hir, var);
+            pass.check_var(self.ctx, self.gcx, var);
         }
         self.walk_var(var)
     }
 
-    fn visit_expr(&mut self, expr: &'hir hir::Expr<'hir>) -> ControlFlow<Self::BreakValue> {
+    fn visit_expr(&mut self, expr: &'gcx hir::Expr<'gcx>) -> ControlFlow<Self::BreakValue> {
         for pass in self.passes.iter_mut() {
-            pass.check_expr(self.ctx, self.gcx, self.hir, expr);
+            pass.check_expr(self.ctx, self.gcx, expr);
         }
         self.walk_expr(expr)
     }
 
     fn visit_call_args(
         &mut self,
-        args: &'hir hir::CallArgs<'hir>,
+        args: &'gcx hir::CallArgs<'gcx>,
     ) -> ControlFlow<Self::BreakValue> {
         for pass in self.passes.iter_mut() {
-            pass.check_call_args(self.ctx, self.hir, args);
+            pass.check_call_args(self.ctx, self.gcx, args);
         }
         self.walk_call_args(args)
     }
 
-    fn visit_stmt(&mut self, stmt: &'hir hir::Stmt<'hir>) -> ControlFlow<Self::BreakValue> {
+    fn visit_stmt(&mut self, stmt: &'gcx hir::Stmt<'gcx>) -> ControlFlow<Self::BreakValue> {
         for pass in self.passes.iter_mut() {
-            pass.check_stmt(self.ctx, self.gcx, self.hir, stmt);
+            pass.check_stmt(self.ctx, self.gcx, stmt);
         }
         self.walk_stmt(stmt)
     }
 
-    fn visit_ty(&mut self, ty: &'hir hir::Type<'hir>) -> ControlFlow<Self::BreakValue> {
+    fn visit_ty(&mut self, ty: &'gcx hir::Type<'gcx>) -> ControlFlow<Self::BreakValue> {
         for pass in self.passes.iter_mut() {
-            pass.check_ty(self.ctx, self.hir, ty);
+            pass.check_ty(self.ctx, self.gcx, ty);
         }
         self.walk_ty(ty)
     }

--- a/crates/lint/src/registry.rs
+++ b/crates/lint/src/registry.rs
@@ -7,7 +7,7 @@ pub(crate) type EarlyLintFactory =
 
 /// Factory for a HIR lint pass.
 pub(crate) type LateLintFactory =
-    Arc<dyn for<'hir> Fn(PhantomData<&'hir ()>) -> Box<dyn LateLintPass<'hir>> + Send + Sync>;
+    Arc<dyn for<'gcx> Fn(PhantomData<&'gcx ()>) -> Box<dyn LateLintPass<'gcx>> + Send + Sync>;
 
 /// Factory for a project-wide lint pass.
 pub(crate) type ProjectLintFactory =
@@ -38,7 +38,7 @@ impl LintPassFactory<EarlyLintFactory> {
 }
 
 impl LintPassFactory<LateLintFactory> {
-    pub(crate) fn create_late<'hir>(&self) -> Box<dyn LateLintPass<'hir>> {
+    pub(crate) fn create_late<'gcx>(&self) -> Box<dyn LateLintPass<'gcx>> {
         (self.factory)(PhantomData)
     }
 }
@@ -86,7 +86,7 @@ impl LintRegistry {
     /// Registers a constructor for an owned HIR pass.
     pub fn register_late_pass<P, F>(&mut self, lint_ids: &'static [&'static str], factory: F)
     where
-        P: for<'hir> LateLintPass<'hir> + 'static,
+        P: for<'gcx> LateLintPass<'gcx> + 'static,
         F: Fn() -> P + Send + Sync + 'static,
     {
         self.register_late(lint_ids, Arc::new(move |_| Box::new(factory())));

--- a/crates/lint/src/runner.rs
+++ b/crates/lint/src/runner.rs
@@ -135,8 +135,7 @@ pub fn run_lints(
                     cx.with_ansi_help,
                     Some(file.clone()),
                 );
-                let mut visitor =
-                    LateLintVisitor::new(&lint_context, &mut late_passes, cx.gcx, &cx.gcx.hir);
+                let mut visitor = LateLintVisitor::new(&lint_context, &mut late_passes, cx.gcx);
                 _ = visitor.visit_nested_source(*source_id);
             }
 

--- a/crates/solar/tests/it/lint.rs
+++ b/crates/solar/tests/it/lint.rs
@@ -97,13 +97,12 @@ impl<'ast> EarlyLintPass<'ast> for TestEarlyPass {
 #[derive(Default)]
 struct TestLatePass;
 
-impl<'hir> LateLintPass<'hir> for TestLatePass {
+impl<'gcx> LateLintPass<'gcx> for TestLatePass {
     fn check_contract(
         &mut self,
         ctx: &LintContext<'_, '_>,
-        _gcx: Gcx<'hir>,
-        _hir: &'hir hir::Hir<'hir>,
-        contract: &'hir hir::Contract<'hir>,
+        _gcx: Gcx<'gcx>,
+        contract: &'gcx hir::Contract<'gcx>,
     ) {
         ctx.emit(&LATE, contract.span);
     }
@@ -129,21 +128,15 @@ impl RecordingLatePass {
     }
 }
 
-impl<'hir> LateLintPass<'hir> for RecordingLatePass {
-    fn check_nested_item(
-        &mut self,
-        _ctx: &LintContext<'_, '_>,
-        _hir: &'hir hir::Hir<'hir>,
-        _id: hir::ItemId,
-    ) {
+impl<'gcx> LateLintPass<'gcx> for RecordingLatePass {
+    fn check_nested_item(&mut self, _ctx: &LintContext<'_, '_>, _gcx: Gcx<'gcx>, _id: hir::ItemId) {
         self.record(|counts| counts.nested_item += 1);
     }
 
     fn check_nested_contract(
         &mut self,
         _ctx: &LintContext<'_, '_>,
-        _gcx: Gcx<'hir>,
-        _hir: &'hir hir::Hir<'hir>,
+        _gcx: Gcx<'gcx>,
         _id: hir::ContractId,
     ) {
         self.record(|counts| counts.nested_contract += 1);
@@ -152,7 +145,7 @@ impl<'hir> LateLintPass<'hir> for RecordingLatePass {
     fn check_nested_function(
         &mut self,
         _ctx: &LintContext<'_, '_>,
-        _hir: &'hir hir::Hir<'hir>,
+        _gcx: Gcx<'gcx>,
         _id: hir::FunctionId,
     ) {
         self.record(|counts| counts.nested_function += 1);
@@ -161,7 +154,7 @@ impl<'hir> LateLintPass<'hir> for RecordingLatePass {
     fn check_nested_var(
         &mut self,
         _ctx: &LintContext<'_, '_>,
-        _hir: &'hir hir::Hir<'hir>,
+        _gcx: Gcx<'gcx>,
         _id: hir::VariableId,
     ) {
         self.record(|counts| counts.nested_var += 1);
@@ -170,8 +163,8 @@ impl<'hir> LateLintPass<'hir> for RecordingLatePass {
     fn check_modifier(
         &mut self,
         _ctx: &LintContext<'_, '_>,
-        _hir: &'hir hir::Hir<'hir>,
-        _modifier: &'hir hir::Modifier<'hir>,
+        _gcx: Gcx<'gcx>,
+        _modifier: &'gcx hir::Modifier<'gcx>,
     ) {
         self.record(|counts| counts.modifier += 1);
     }
@@ -179,8 +172,8 @@ impl<'hir> LateLintPass<'hir> for RecordingLatePass {
     fn check_call_args(
         &mut self,
         _ctx: &LintContext<'_, '_>,
-        _hir: &'hir hir::Hir<'hir>,
-        _args: &'hir hir::CallArgs<'hir>,
+        _gcx: Gcx<'gcx>,
+        _args: &'gcx hir::CallArgs<'gcx>,
     ) {
         self.record(|counts| counts.call_args += 1);
     }
@@ -485,7 +478,7 @@ fn calls_late_hooks_for_nested_items_modifiers_and_call_args() {
         let ctx = LintContext::new(gcx.sess, &policy, false, false, None);
         let mut passes: Vec<Box<dyn LateLintPass<'_>>> =
             vec![Box::new(RecordingLatePass { counts: counts.clone() })];
-        let mut visitor = LateLintVisitor::new(&ctx, &mut passes, gcx, &gcx.hir);
+        let mut visitor = LateLintVisitor::new(&ctx, &mut passes, gcx);
         let _ = hir::Visit::visit_nested_source(&mut visitor, source_id);
     });
 


### PR DESCRIPTION
`Gcx<'hir>` already exposes the HIR as `gcx.hir`, so every `LateLintPass` hook now receives only the global context: the hooks that took both `gcx` and `hir` drop the `hir` parameter, and the hooks that took only `hir` take `gcx` instead, giving the whole trait one uniform shape. `LateLintVisitor` no longer stores a separate HIR handle and its constructor loses that argument.

This is a breaking change for downstream lint passes (Foundry's lints are being updated alongside in foundry-rs/foundry#16621). Written with AI assistance (Claude Code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
