### PR TITLE
test(codegen): spell `icall` in the debug spans fixture

### DIFF
--- a/tests/ui/codegen/mir/inline/debug_spans.mir
+++ b/tests/ui/codegen/mir/inline/debug_spans.mir
@@ -3,12 +3,12 @@
 @module InlineDebugSpans
 
 // CHECK-LABEL: {{^[ +].*}}fn @caller{{[( ]}}
-// CHECK: - {{.*}}internal_call @callee
+// CHECK: - {{.*}}icall @callee
 // CHECK: + [[INLINED:v[0-9]+]] = add arg0, 1 !metadata(span=100..110)
 // CHECK: + {{v[0-9]+}} = phi [bb2: [[INLINED]]]
 fn @caller(arg0: u256) -> u256 {
   bb0:
-    v0 = internal_call fn1, 1, arg0 !metadata(span=10..20)
+    v0 = icall fn1, 1, arg0 !metadata(span=10..20)
     ret v0
 }
 

--- a/tests/ui/codegen/mir/inline/debug_spans.stdout
+++ b/tests/ui/codegen/mir/inline/debug_spans.stdout
@@ -3,7 +3,7 @@
   @module InlineDebugSpans
   fn @caller(arg0: u256) -> u256 {
     bb0:
--     v0 = internal_call @callee, 1, arg0 !metadata(span=10..20)
+-     v0 = icall @callee, 1, arg0 !metadata(span=10..20)
 -     ret v0
 +     jump bb2
 +   bb2:


### PR DESCRIPTION
The inline debug-spans fixture added in #1325 still spells the MIR instruction `internal_call`, which the text format has since renamed to `icall`, so its first parse fails and the `test` jobs on main are red at efea72de. This renames the instruction in the fixture and its FileCheck line and re-blesses the pass-diff snapshot; only the spelling changes.
