### PR TITLE
perf(codegen): skip redundant validation and layout

### DIFF
--- a/crates/codegen/src/analysis/validator.rs
+++ b/crates/codegen/src/analysis/validator.rs
@@ -185,7 +185,7 @@ impl<'a> Validator<'a> {
             });
 
             // ----- Walk instructions in this block -----
-            let block_preds: Vec<BlockId> = block.predecessors.iter().copied().collect();
+            let block_preds = &block.predecessors;
             for &inst_id in &block.instructions {
                 if inst_id.index() >= num_insts {
                     self.emit_at_block(
@@ -288,7 +288,7 @@ impl<'a> Validator<'a> {
                         }
                     }
                     // Every predecessor must appear in the incoming list.
-                    for pred in &block_preds {
+                    for pred in block_preds {
                         if !incoming.iter().any(|(b, _)| b == pred) {
                             self.emit_at_inst(
                                 format_args!(
@@ -633,12 +633,11 @@ impl<'a> Validator<'a> {
             // callee that never returns (an outlined revert stub) delivers
             // nothing, and an external caller's MIR signature does not model
             // its ABI returns, so both are exempt.
-            let callee_can_return = callee.blocks.iter().any(|block| {
-                matches!(block.terminator, Some(crate::mir::Terminator::Return { .. }))
-            });
             if func.selector.is_none()
-                && callee_can_return
                 && func.returns.len() != callee.returns.len()
+                && callee.blocks.iter().any(|block| {
+                    matches!(block.terminator, Some(crate::mir::Terminator::Return { .. }))
+                })
             {
                 self.emit(format_args!(
                     "tail_call to `{}` returns {} value(s), caller signature expects {}",

--- a/crates/codegen/src/backend/evm/ir/assembly/lower.rs
+++ b/crates/codegen/src/backend/evm/ir/assembly/lower.rs
@@ -144,6 +144,10 @@ pub(in crate::backend::evm) fn lower_evm_ir(
             data_layout_is_observable,
             capture_debug_info,
         );
+        // Without indexed tables, only final bytecode emission needs resolved offsets.
+        if tables.is_empty() {
+            return program;
+        }
         let (label_offsets, _) = assembler.resolve_label_offsets(&program);
         if !indexed_jump::refine_indexed_jump_widths(
             module,

--- a/crates/codegen/src/backend/evm/ir/passes/peephole.rs
+++ b/crates/codegen/src/backend/evm/ir/passes/peephole.rs
@@ -484,11 +484,11 @@ fn duplicates_known_zero(instructions: &[Instruction]) -> bool {
         return false;
     };
     let end = instructions.len() - 1;
-    let start = instructions[..end]
+    let floor = end.saturating_sub(MAX_STACK_PEEPHOLE_WINDOW);
+    let start = instructions[floor..end]
         .iter()
         .rposition(|inst| !(inst.is_encoded_push() || inst.as_stack_op().is_some()))
-        .map_or(end.saturating_sub(MAX_STACK_PEEPHOLE_WINDOW), |index| index + 1)
-        .max(end.saturating_sub(MAX_STACK_PEEPHOLE_WINDOW));
+        .map_or(floor, |index| floor + index + 1);
     if !instructions[start..end].iter().any(|inst| inst.concrete_immediate() == Some(U256::ZERO)) {
         return false;
     }


### PR DESCRIPTION
Avoid redundant work in validation and codegen: borrow predecessor lists, inspect tail-call bodies only when result counts disagree, skip preliminary label-offset resolution when no indexed jump tables need refinement, and bound the known-zero DUP scan to its existing 24-instruction window. Validation rules, final PUSH-width resolution, and generated bytecode stay unchanged.

Against 1e6bdb0e, alternating baseline/candidate debug runs across 1,770 matrix invocations reduced aggregate compilation time from 55.53s to 53.77s (3.2%), with identical output hashes. Four larger fixtures with validation disabled improved by 1.2–1.5% in repeated measurements pinned to one CPU. These are local debug-build measurements, not release-build timings.
