### PR TITLE
perf(codegen): defer validator cycle checks

### DIFF
--- a/crates/codegen/src/analysis/validator.rs
+++ b/crates/codegen/src/analysis/validator.rs
@@ -372,7 +372,6 @@ impl<'a> Validator<'a> {
             if !cfg.is_reachable(block_id) {
                 continue;
             }
-            let block_in_cycle = reaches(block_id, block_id);
             for (index, &inst_id) in block.instructions.iter().enumerate() {
                 match &func.inst(inst_id).kind {
                     InstKind::Phi(incoming) => {
@@ -405,7 +404,8 @@ impl<'a> Validator<'a> {
                         for &operand in kind.operands().iter() {
                             if let Some((def, def_index)) = def_location_of[operand] {
                                 if def == block_id {
-                                    if !block_in_cycle && def_index >= index {
+                                    // Only a forward use needs the cycle exception.
+                                    if def_index >= index && !reaches(block_id, block_id) {
                                         self.emit_at_inst(
                                             format_args!(
                                                 "use of {operand:?} precedes its definition in \


### PR DESCRIPTION
MIR validation currently computes cycle reachability for every reachable block. Only same-block uses that precede their definitions need the cycle exception, so defer the query until that case occurs. The reachability cache and accepted MIR remain unchanged. This adds the lazy cycle check separately from #1379.

Against main at 1dc22410, alternating baseline/candidate debug runs across 1,770 matrix invocations reduced aggregate compilation time from 53.50s to 51.54s (3.7%), with identical compiler output hashes and exit statuses. These are local debug-build compilation measurements, not release or full-suite wall times.
