### PR TITLE
fix(sema): resolve `length` on calldata slices

### DIFF
--- a/crates/sema/src/builtins/members.rs
+++ b/crates/sema/src/builtins/members.rs
@@ -29,7 +29,14 @@ pub(crate) fn native_members<'gcx>(gcx: Gcx<'gcx>, ty: Ty<'gcx>) -> MemberList<'
         TyKind::Ref(inner, loc) => reference(gcx, ty, inner, loc),
         TyKind::DynArray(_ty) => expected_ref(),
         TyKind::Array(_ty, _len) => expected_ref(),
-        TyKind::Slice(_ty) => Default::default(),
+        // Like solc, calldata slices expose `length` unless they slice a `string`.
+        TyKind::Slice(underlying) => {
+            if matches!(underlying.peel_refs().kind, TyKind::Elementary(ElementaryType::String)) {
+                Default::default()
+            } else {
+                array(gcx)
+            }
+        }
         TyKind::Tuple(_tys) => Default::default(),
         TyKind::Mapping(..) => Default::default(),
         TyKind::Fn(f) => function(gcx, f),

--- a/tests/ui/codegen/lowering/calldata_slice_length.mir.stdout
+++ b/tests/ui/codegen/lowering/calldata_slice_length.mir.stdout
@@ -1,0 +1,185 @@
+// === ROOT/tests/ui/codegen/lowering/calldata_slice_length.sol:CalldataSliceLength ===
+@module CalldataSliceLength
+fn @bytesLength(arg0: calldataslice, arg1: u256, arg2: u256) -> u256 [selector=0xa2918918, pure, abi_params=[bytes, u256, u256], abi_returns=[word]] {
+  bb0:
+    v0 = slice_ptr arg0
+    v1 = slice_len arg0
+    v2 = gt arg2, v1
+    v3 = lt arg2, arg1
+    v4 = or v2, v3
+    jumpi v4, bb1, bb2
+  bb2:
+    v5 = sub arg2, arg1
+    v6 = add v0, arg1
+    v7 = make_calldata_slice v6, v5
+    v8 = slice_len v7
+    ret v8
+  bb1:
+    revert 0, 0
+}
+
+fn @bytesLengthOpenEnd(arg0: calldataslice, arg1: u256) -> u256 [selector=0x3c8aaf2b, pure, abi_params=[bytes, u256], abi_returns=[word]] {
+  bb0:
+    v0 = slice_ptr arg0
+    v1 = slice_len arg0
+    v2 = gt v1, v1
+    v3 = lt v1, arg1
+    v4 = or v2, v3
+    jumpi v4, bb1, bb2
+  bb2:
+    v5 = sub v1, arg1
+    v6 = add v0, arg1
+    v7 = make_calldata_slice v6, v5
+    v8 = slice_len v7
+    ret v8
+  bb1:
+    revert 0, 0
+}
+
+fn @arrayLength(arg0: calldataslice, arg1: u256, arg2: u256) -> u256 [selector=0xb325f995, pure, abi_params=[array<_, u256>, u256, u256], abi_returns=[word]] {
+  bb0:
+    v0 = slice_ptr arg0
+    v1 = slice_len arg0
+    v2 = gt arg2, v1
+    v3 = lt arg2, arg1
+    v4 = or v2, v3
+    jumpi v4, bb1, bb2
+  bb2:
+    v5 = sub arg2, arg1
+    v6 = mul arg1, 32
+    v7 = iszero 32
+    v8 = div v6, 32
+    v9 = eq v8, arg1
+    v10 = or v7, v9
+    v11 = iszero v10
+    jumpi v11, bb3, bb4
+  bb4:
+    v12 = add v0, v6
+    v13 = make_calldata_slice v12, v5
+    v14 = slice_len v13
+    ret v14
+  bb3:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 65 !metadata(memory=scratch)
+    revert 0, 36
+  bb1:
+    revert 0, 0
+}
+
+fn @arrayIndex(arg0: calldataslice, arg1: u256, arg2: u256) -> u256 [selector=0x038766a5, pure, abi_params=[array<_, u256>, u256, u256], abi_returns=[word]] {
+  bb0:
+    v0 = slice_ptr arg0
+    v1 = slice_len arg0
+    v2 = gt arg2, v1
+    v3 = lt arg2, arg1
+    v4 = or v2, v3
+    jumpi v4, bb1, bb2
+  bb2:
+    v5 = sub arg2, arg1
+    v6 = mul arg1, 32
+    v7 = iszero 32
+    v8 = div v6, 32
+    v9 = eq v8, arg1
+    v10 = or v7, v9
+    v11 = iszero v10
+    jumpi v11, bb3, bb4
+  bb4:
+    v12 = add v0, v6
+    v13 = make_calldata_slice v12, v5
+    v14 = slice_len v13
+    v15 = lt 1, v14
+    v16 = iszero v15
+    jumpi v16, bb5, bb6
+  bb6:
+    v17 = slice_ptr v13
+    v18 = add v17, 32
+    v19 = calldataload v18
+    ret v19
+  bb5:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 50 !metadata(memory=scratch)
+    revert 0, 36
+  bb3:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 65 !metadata(memory=scratch)
+    revert 0, 36
+  bb1:
+    revert 0, 0
+}
+
+fn @chainedLength(arg0: calldataslice, arg1: u256, arg2: u256) -> u256 [selector=0xf5905cca, pure, abi_params=[bytes, u256, u256], abi_returns=[word]] {
+  bb0:
+    v0 = slice_ptr arg0
+    v1 = slice_len arg0
+    v2 = gt arg2, v1
+    v3 = lt arg2, arg1
+    v4 = or v2, v3
+    jumpi v4, bb1, bb2
+  bb2:
+    v5 = sub arg2, arg1
+    v6 = add v0, arg1
+    v7 = make_calldata_slice v6, v5
+    v8 = slice_ptr v7
+    v9 = slice_len v7
+    v10 = gt 3, v9
+    v11 = lt 3, 1
+    v12 = or v10, v11
+    jumpi v12, bb1, bb3
+  bb3:
+    v13 = sub 3, 1
+    v14 = add v8, 1
+    v15 = make_calldata_slice v14, v13
+    v16 = slice_len v15
+    ret v16
+  bb1:
+    revert 0, 0
+}
+
+fn @stringSliceInLoop(arg0: calldataslice, arg1: u256, arg2: u256) -> u256 [selector=0x487a8a3e, pure, abi_params=[bytes, u256, u256], abi_returns=[word]] {
+  bb0:
+    v0 = slice_ptr arg0
+    v1 = slice_len arg0
+    v2 = gt arg2, v1
+    v3 = lt arg2, arg1
+    v4 = or v2, v3
+    jumpi v4, bb1, bb2
+  bb2:
+    v5 = sub arg2, arg1
+    v6 = add v0, arg1
+    v7 = make_calldata_slice v6, v5
+    jump bb3
+  bb3:
+    v8 = phi [bb2: arg1], [bb11: v8]
+    v9 = phi [bb2: 0], [bb11: v18]
+    v10 = phi [bb2: 0], [bb11: v16]
+    v11 = phi [bb2: arg0], [bb11: v11]
+    v12 = phi [bb2: arg2], [bb11: v12]
+    v13 = phi [bb2: v7], [bb11: v13]
+    v14 = slice_len v13
+    v15 = lt v9, v14
+    jumpi v15, bb6, bb7
+  bb7:
+    jump bb4
+  bb4:
+    ret v10
+  bb6:
+    v16 = add v10, 1
+    v17 = lt v16, v10
+    jumpi v17, bb9, bb10
+  bb10:
+    jump bb8
+  bb8:
+    jump bb5
+  bb5:
+    v18 = add v9, 1
+    v19 = lt v18, v9
+    jumpi v19, bb9, bb11
+  bb11:
+    jump bb3
+  bb9:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 17 !metadata(memory=scratch)
+    revert 0, 36
+  bb1:
+    revert 0, 0
+}

--- a/tests/ui/codegen/lowering/calldata_slice_length.sol
+++ b/tests/ui/codegen/lowering/calldata_slice_length.sol
@@ -1,0 +1,59 @@
+//@ codegen-matrix: standard
+//@ run-call: bytesLength 0x1122334455, 1, 4 => 3
+//@ run-call: bytesLengthOpenEnd 0x1122334455, 2 => 3
+//@ run-call: arrayLength [7, 8, 9, 10], 1, 3 => 2
+//@ run-call: arrayIndex [7, 8, 9, 10], 1, 3 => 9
+//@ run-call: chainedLength 0x112233445566, 1, 5 => 2
+//@ run-call: stringSliceInLoop "hello", 1, 4 => 3
+
+contract CalldataSliceLength {
+    function bytesLength(bytes calldata data, uint256 start, uint256 end)
+        external
+        pure
+        returns (uint256)
+    {
+        return data[start:end].length;
+    }
+
+    function bytesLengthOpenEnd(bytes calldata data, uint256 start)
+        external
+        pure
+        returns (uint256)
+    {
+        return data[start:].length;
+    }
+
+    function arrayLength(uint256[] calldata a, uint256 start, uint256 end)
+        external
+        pure
+        returns (uint256)
+    {
+        return a[start:end].length;
+    }
+
+    function arrayIndex(uint256[] calldata a, uint256 start, uint256 end)
+        external
+        pure
+        returns (uint256)
+    {
+        return a[start:end][1];
+    }
+
+    function chainedLength(bytes calldata data, uint256 start, uint256 end)
+        external
+        pure
+        returns (uint256)
+    {
+        return data[start:end][1:3].length;
+    }
+
+    function stringSliceInLoop(string calldata s, uint256 start, uint256 end)
+        external
+        pure
+        returns (uint256 n)
+    {
+        // `string` slices have no `length`; count through `bytes`.
+        bytes calldata b = bytes(s)[start:end];
+        for (uint256 i = 0; i < b.length; i++) n++;
+    }
+}

--- a/tests/ui/typeck/calldata_slice_members.sol
+++ b/tests/ui/typeck/calldata_slice_members.sol
@@ -1,0 +1,17 @@
+contract C {
+    function f(bytes calldata data, uint256 start, uint256 end) external pure returns (uint256) {
+        return data[start:end].length;
+    }
+
+    function g(uint256[] calldata a) external pure returns (uint256) {
+        return a[1:].length + a[1:][0];
+    }
+
+    function h(string calldata s) external pure returns (uint256) {
+        return s[1:].length; //~ ERROR: member `length` not found on type `string calldata slice`
+    }
+
+    function i(bytes calldata data) external pure {
+        data[1:].length = 1; //~ ERROR: expression has to be an lvalue
+    }
+}

--- a/tests/ui/typeck/calldata_slice_members.stderr
+++ b/tests/ui/typeck/calldata_slice_members.stderr
@@ -1,0 +1,14 @@
+error: member `length` not found on type `string calldata slice`
+   ╭▸ ROOT/tests/ui/typeck/calldata_slice_members.sol:LL:CC
+   │
+LL │         return s[1:].length;
+   ╰╴                     ━━━━━━
+
+error: expression has to be an lvalue
+   ╭▸ ROOT/tests/ui/typeck/calldata_slice_members.sol:LL:CC
+   │
+LL │         data[1:].length = 1;
+   ╰╴        ━━━━━━━━━━━━━━━
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
Member lookup returned an empty member list for every slice type, so `data[start:end].length` on a `bytes calldata` or `T[] calldata` parameter was rejected with "member `length` not found on type `bytes calldata slice`", while the same length read through a `bytes calldata` local bound to the slice compiled fine. Solc types index range access on a dynamically sized calldata array as a slice of that array and resolves members against the array itself, which gives `length` to every slice except a slice of a `string`, mirroring `ArrayType::nativeMembers`.

The slice arm of `native_members` now returns the array member list unless the sliced array is a `string`. Indexing into a slice was already accepted by the type checker, and codegen already lowers the length of a slice value through `slice_len`, so the member table was the only missing piece. Assigning to a slice's `length` is still rejected as a non-lvalue, as in solc.

The new lowering test runs `bytes` and `uint256[]` slice lengths, open-ended slices, indexing into a slice, chained slices, and a `string` slice read through `bytes` under the standard codegen matrix, and the typeck test pins the accepted forms alongside the `string` slice and lvalue rejections.
