### PR TITLE
perf: skip IR validation after unchanged passes

### DIFF
--- a/crates/codegen/src/backend/evm/ir/passes/mod.rs
+++ b/crates/codegen/src/backend/evm/ir/passes/mod.rs
@@ -197,7 +197,7 @@ fn run_passes_inner(
             if gcx.dcx().err_count() != errors_before {
                 return changed;
             }
-            if validate_each && should_validate_ir(gcx) {
+            if pass_changed && validate_each && should_validate_ir(gcx) {
                 validate_module_after_pass(module, pass_name);
             }
             assert_debug_info_handled(module, pass_name, "after");

--- a/crates/codegen/src/pass_manager.rs
+++ b/crates/codegen/src/pass_manager.rs
@@ -169,7 +169,7 @@ fn run_passes_inner(
             changed |= pass_changed;
             assert_debug_info_handled(module, pass_name, "after");
 
-            if validate_each && should_validate_ir(gcx) {
+            if pass_changed && validate_each && should_validate_ir(gcx) {
                 validate_module_after_pass(module, pass_name);
             }
         }
@@ -192,7 +192,7 @@ fn run_passes_inner(
         let phase_changed = module.phase != new_phase;
         module.advance_phase(new_phase);
         changed |= phase_changed;
-        if validate_each && should_validate_ir(gcx) {
+        if phase_changed && validate_each && should_validate_ir(gcx) {
             validate_module_after_pass(module, new_phase.name());
         }
     }


### PR DESCRIPTION
Skip MIR and EVM IR validation when a pass reports no change. Also skip MIR phase validation when the requested phase is already current. Changed passes and actual phase transitions still validate under the existing validation setting.

Three warm runs of `cargo nextest run --workspace` per version gave these means. GNU time measures the full command and child processes, using debug builds in the same checkout with compilation excluded. Each run passed all 1,546 tests, with two skipped. The MIR comparison starts at `b7fb239a5`; the EVM IR comparison uses a fresh baseline at `14aa0d142`, which already includes the MIR check.

| Change | Metric | Before | After | Change |
| --- | --- | ---: | ---: | ---: |
| MIR | Wall | 35.79s | 35.32s | 🟢 −1.3% |
| MIR | Total CPU | 304.53s | 295.27s | 🟢 −3.0% |
| EVM IR, on top of MIR | Wall | 35.98s | 35.86s | 🟢 −0.3% |
| EVM IR, on top of MIR | Total CPU | 296.33s | 293.81s | 🟢 −0.9% |

Wall-time ranges overlap in both comparisons. The Foundry comparison test takes about 33 seconds while the UI suite takes about 10 seconds alongside it. Foundry includes solc compilation and EVM execution, which these checks cannot speed up. The baseline also includes #1380's cheaper MIR cycle checks.

Excluding Foundry with `-E 'not test(foundry::)'`, three warm runs per version compare the original baseline (`b7fb239a5`) against both changes (`7c4812f2a`). All 1,537 selected tests passed in every run, with 11 skipped.

| Time without Foundry | Before | After | Change |
| --- | ---: | ---: | ---: |
| Wall | 10.49s | 9.78s | 🟢 -6.7% |
| User CPU | 168.19s | 152.62s | 🟢 -9.3% |
| System CPU | 93.89s | 96.25s | 🔴 +2.5% |
| Total CPU | 262.09s | 248.87s | 🟢 -5.0% |
