### PR TITLE
perf(lsp): cache source file URLs

### DIFF
--- a/crates/lsp/src/call_hierarchy.rs
+++ b/crates/lsp/src/call_hierarchy.rs
@@ -122,6 +122,7 @@ impl CallHierarchyIndex {
 
     pub(crate) fn build(
         gcx: Gcx<'_>,
+        locations: &proto::LocationConverter,
         item_symbols: &FxHashMap<ItemId, SymbolId>,
         declarations: &IndexVec<SymbolId, DeclarationSymbol>,
     ) -> Self {
@@ -135,8 +136,7 @@ impl CallHierarchyIndex {
                 continue;
             };
             let body_range = if function.body.is_some() {
-                proto::span_to_location(gcx.sess.source_map(), function.body_span)
-                    .map(|location| location.range)
+                locations.location(function.body_span).map(|location| location.range)
             } else {
                 None
             };
@@ -144,7 +144,7 @@ impl CallHierarchyIndex {
         }
 
         if gcx.has_typeck_results() {
-            collect_direct_calls(&mut index.facts, gcx, item_symbols, declarations);
+            collect_direct_calls(&mut index.facts, gcx, locations, item_symbols, declarations);
         }
         index
     }
@@ -464,6 +464,7 @@ impl QueryIndex {
 fn collect_direct_calls<'gcx>(
     facts: &mut CallHierarchyFacts,
     gcx: Gcx<'gcx>,
+    locations: &proto::LocationConverter,
     item_symbols: &FxHashMap<ItemId, SymbolId>,
     declarations: &IndexVec<SymbolId, DeclarationSymbol>,
 ) {
@@ -476,7 +477,8 @@ fn collect_direct_calls<'gcx>(
             continue;
         };
 
-        let mut collector = CallCollector { gcx, item_symbols, declarations, facts, caller };
+        let mut collector =
+            CallCollector { gcx, locations, item_symbols, declarations, facts, caller };
         if function.is_constructor()
             && let Some(contract_id) = function.contract
         {
@@ -499,6 +501,7 @@ fn collect_direct_calls<'gcx>(
 
 struct CallCollector<'a, 'gcx> {
     gcx: Gcx<'gcx>,
+    locations: &'a proto::LocationConverter,
     item_symbols: &'a FxHashMap<ItemId, SymbolId>,
     declarations: &'a IndexVec<SymbolId, DeclarationSymbol>,
     facts: &'a mut CallHierarchyFacts,
@@ -558,9 +561,7 @@ impl CallCollector<'_, '_> {
         let Some(&callee) = self.item_symbols.get(&ItemId::Function(callee_id)) else {
             return;
         };
-        let Some(location) = proto::span_to_location(self.gcx.sess.source_map(), span) else {
-            return;
-        };
+        let Some(location) = self.locations.location(span) else { return };
         if self.declarations[self.caller].location.uri != location.uri {
             return;
         }

--- a/crates/lsp/src/document_links/index.rs
+++ b/crates/lsp/src/document_links/index.rs
@@ -15,7 +15,11 @@ use super::{
 use crate::proto;
 
 impl DocumentLinkIndex {
-    pub(crate) fn build(gcx: Gcx<'_>, source_paths: &FxHashSet<PathBuf>) -> Self {
+    pub(crate) fn build(
+        gcx: Gcx<'_>,
+        source_paths: &FxHashSet<PathBuf>,
+        locations: &proto::LocationConverter,
+    ) -> Self {
         let mut index = Self::default();
         let mut file_resolver = FileResolver::new(gcx.sess.source_map());
         file_resolver.configure_from_sess(gcx.sess);
@@ -29,14 +33,10 @@ impl DocumentLinkIndex {
             let Some(ast) = &source.ast else { continue };
             for &(item_id, target_source_id) in &source.imports {
                 let ast::ItemKind::Import(import) = &ast.items[item_id].kind else { continue };
-                let Some(location) =
-                    proto::span_to_location(gcx.sess.source_map(), import.path.span)
-                else {
+                let Some(location) = locations.location(import.path.span) else {
                     continue;
                 };
-                let Some(directive_location) =
-                    proto::span_to_location(gcx.sess.source_map(), ast.items[item_id].span)
-                else {
+                let Some(directive_location) = locations.location(ast.items[item_id].span) else {
                     continue;
                 };
                 let Some(target) = gcx.sources.get(target_source_id) else { continue };

--- a/crates/lsp/src/inlay_hints.rs
+++ b/crates/lsp/src/inlay_hints.rs
@@ -37,8 +37,8 @@ impl InlayHintIndex {
     ///
     /// The compiler's HIR data is scoped to one analysis run. This index copies out the inlay
     /// hints that LSP requests can query after that run has finished.
-    pub(crate) fn build(gcx: Gcx<'_>) -> Self {
-        let mut collector = InlayHintCollector { gcx, index: Self::default() };
+    pub(crate) fn build(gcx: Gcx<'_>, locations: &proto::LocationConverter) -> Self {
+        let mut collector = InlayHintCollector { gcx, locations, index: Self::default() };
         for source_id in gcx.hir.source_ids() {
             let _ = collector.visit_nested_source(source_id);
         }
@@ -121,12 +121,13 @@ impl StoredInlayHintKind {
     }
 }
 
-struct InlayHintCollector<'gcx> {
+struct InlayHintCollector<'a, 'gcx> {
     gcx: Gcx<'gcx>,
+    locations: &'a proto::LocationConverter,
     index: InlayHintIndex,
 }
 
-impl<'gcx> InlayHintCollector<'gcx> {
+impl<'gcx> InlayHintCollector<'_, 'gcx> {
     /// Adds parameter-name hints for positional arguments when parameter names are known.
     ///
     /// Hints are skipped when the argument already carries the same name as the parameter.
@@ -162,8 +163,7 @@ impl<'gcx> InlayHintCollector<'gcx> {
             if self.argument_name_matches_param(arg, param_name) {
                 continue;
             }
-            let Some(location) = proto::span_to_location(self.gcx.sess.source_map(), arg.span)
-            else {
+            let Some(location) = self.locations.location(arg.span) else {
                 continue;
             };
             self.index.push(
@@ -229,7 +229,7 @@ impl<'gcx> InlayHintCollector<'gcx> {
         if ty.is_unit() || ty.references_error() {
             return;
         }
-        let Some(location) = proto::span_to_location(self.gcx.sess.source_map(), expr.span) else {
+        let Some(location) = self.locations.location(expr.span) else {
             return;
         };
         self.index.push(
@@ -264,7 +264,7 @@ impl<'gcx> InlayHintCollector<'gcx> {
     }
 }
 
-impl<'gcx> Visit<'gcx> for InlayHintCollector<'gcx> {
+impl<'gcx> Visit<'gcx> for InlayHintCollector<'_, 'gcx> {
     type BreakValue = Never;
 
     fn hir(&self) -> &'gcx hir::Hir<'gcx> {

--- a/crates/lsp/src/proto.rs
+++ b/crates/lsp/src/proto.rs
@@ -9,11 +9,12 @@ use lsp_types::{
 };
 use solar_config::version::SHORT_VERSION;
 use solar_interface::{
-    CharPos, SourceMap, Span,
+    BytePos, CharPos, SourceMap, Span,
+    data_structures::map::FxHashMap,
     diagnostics::{Diag, Level},
     source_map::SourceFile,
 };
-use std::borrow::Borrow;
+use std::{borrow::Borrow, sync::Arc};
 
 #[derive(Debug)]
 pub(crate) enum Initialize {}
@@ -334,7 +335,50 @@ fn diagnostic_data(
     Some(DiagnosticData::new(uri.clone(), &file.src, suggestions).to_value())
 }
 
+/// Converts compiler spans to LSP locations while caching each source file URI.
+///
+/// The cache is local to one source map and must not outlive its analysis build. Construct it
+/// after source loading is complete so every source file is included in the eager snapshot.
+pub(crate) struct LocationConverter {
+    source_map: Arc<SourceMap>,
+    uris: FxHashMap<BytePos, lsp_types::Url>,
+}
+
+impl LocationConverter {
+    pub(crate) fn new(source_map: Arc<SourceMap>) -> Self {
+        let files = source_map.files();
+        let mut uris = FxHashMap::with_capacity_and_hasher(files.len(), Default::default());
+        for file in files.iter() {
+            if let Some(path) = file.name.as_real()
+                && let Ok(uri) = lsp_types::Url::from_file_path(path)
+            {
+                uris.insert(file.start_pos, uri);
+            }
+        }
+        drop(files);
+        Self { source_map, uris }
+    }
+
+    pub(crate) fn file_uri(&self, file: &SourceFile) -> Option<&lsp_types::Url> {
+        self.uris.get(&file.start_pos)
+    }
+
+    pub(crate) fn location(&self, span: Span) -> Option<lsp_types::Location> {
+        span_to_location_with(&self.source_map, span, |file| self.file_uri(file).cloned())
+    }
+}
+
 pub(crate) fn span_to_location(source_map: &SourceMap, span: Span) -> Option<lsp_types::Location> {
+    span_to_location_with(source_map, span, |file| {
+        lsp_types::Url::from_file_path(file.name.as_real().unwrap()).ok()
+    })
+}
+
+fn span_to_location_with(
+    source_map: &SourceMap,
+    span: Span,
+    uri: impl FnOnce(&SourceFile) -> Option<lsp_types::Url>,
+) -> Option<lsp_types::Location> {
     if source_map.is_empty() || span.is_dummy() {
         return None;
     }
@@ -348,7 +392,7 @@ pub(crate) fn span_to_location(source_map: &SourceMap, span: Span) -> Option<lsp
     let hi = file.lookup_file_pos(file.relative_position(span.hi()));
 
     Some(lsp_types::Location {
-        uri: lsp_types::Url::from_file_path(file.name.as_real().unwrap()).ok()?,
+        uri: uri(&file)?,
         range: lsp_types::Range {
             start: lsp_position(&file, lo.0, lo.1)?,
             end: lsp_position(&file, hi.0, hi.1)?,

--- a/crates/lsp/src/rename.rs
+++ b/crates/lsp/src/rename.rs
@@ -122,10 +122,13 @@ pub(crate) struct RenameReferenceContext<'a> {
 }
 
 impl RenameIndex {
-    pub(crate) fn record_source_contents(&mut self, gcx: Gcx<'_>) {
+    pub(crate) fn record_source_contents(
+        &mut self,
+        gcx: Gcx<'_>,
+        locations: &proto::LocationConverter,
+    ) {
         for file in gcx.sess.source_map().files().iter() {
-            let Some(path) = file.name.as_real() else { continue };
-            let Ok(uri) = Url::from_file_path(path) else { continue };
+            let Some(uri) = locations.file_uri(file).cloned() else { continue };
             self.analyzed_contents.insert(uri, file.src.clone());
         }
     }
@@ -150,6 +153,7 @@ impl RenameIndex {
     pub(crate) fn build_imports(
         &mut self,
         gcx: Gcx<'_>,
+        locations: &proto::LocationConverter,
         item_symbols: &FxHashMap<ItemId, SymbolId>,
     ) -> ImportBindings {
         let mut bindings = ImportBindings::default();
@@ -168,7 +172,7 @@ impl RenameIndex {
                     ast::ImportItems::Plain(alias) => {
                         if let Some(alias) = alias {
                             self.add_namespace_alias(
-                                gcx,
+                                locations,
                                 &mut bindings,
                                 source_id,
                                 imported_source_id,
@@ -177,7 +181,7 @@ impl RenameIndex {
                         }
                     }
                     ast::ImportItems::Glob(alias) => self.add_namespace_alias(
-                        gcx,
+                        locations,
                         &mut bindings,
                         source_id,
                         imported_source_id,
@@ -196,10 +200,10 @@ impl RenameIndex {
                                 continue;
                             }
 
-                            self.push_symbol_occurrence(gcx, imported.span, &symbols);
+                            self.push_symbol_occurrence(locations, imported.span, &symbols);
                             bindings.references.push((imported.span, symbols.clone()));
                             if let Some(alias) = alias
-                                && let Some(alias_id) = self.add_alias(gcx, alias)
+                                && let Some(alias_id) = self.add_alias(locations, alias)
                             {
                                 bindings.references.push((alias.span, symbols.clone()));
                                 for &symbol_id in &symbols {
@@ -223,7 +227,11 @@ impl RenameIndex {
         bindings
     }
 
-    pub(crate) fn build_mapping_names(&mut self, gcx: Gcx<'_>) -> MappingBindings {
+    pub(crate) fn build_mapping_names(
+        &mut self,
+        gcx: Gcx<'_>,
+        locations: &proto::LocationConverter,
+    ) -> MappingBindings {
         let mut bindings = MappingBindings::default();
         for variable_id in gcx.hir.variable_ids() {
             let variable = gcx.hir.variable(variable_id);
@@ -236,7 +244,7 @@ impl RenameIndex {
                 match ty.kind {
                     hir::TypeKind::Mapping(mapping) => {
                         if let Some(name) = mapping.key_name
-                            && let Some(name_id) = self.add_mapping_name(gcx, name)
+                            && let Some(name_id) = self.add_mapping_name(locations, name)
                         {
                             bindings.params.insert(param, name_id);
                         }
@@ -251,7 +259,7 @@ impl RenameIndex {
             if !matches!(ty.kind, hir::TypeKind::Custom(ItemId::Struct(_)))
                 && let Some(name) = return_name
             {
-                let _ = self.add_mapping_name(gcx, name);
+                let _ = self.add_mapping_name(locations, name);
             }
         }
         bindings
@@ -260,6 +268,7 @@ impl RenameIndex {
     pub(crate) fn build_natspec(
         &mut self,
         gcx: Gcx<'_>,
+        locations: &proto::LocationConverter,
         bindings: &ImportBindings,
         item_symbols: &FxHashMap<ItemId, SymbolId>,
         declarations: &IndexVec<SymbolId, DeclarationSymbol>,
@@ -283,12 +292,19 @@ impl RenameIndex {
                 match natspec.kind {
                     hir::NatSpecKind::Param { name } => {
                         let Some(parameters) = item.parameters() else { continue };
-                        self.push_natspec_variable_reference(gcx, parameters, name, item_symbols);
+                        self.push_natspec_variable_reference(
+                            gcx,
+                            locations,
+                            parameters,
+                            name,
+                            item_symbols,
+                        );
                     }
                     hir::NatSpecKind::Return { name: Some(name) } => {
                         let Some(function_id) = item_id.as_function() else { continue };
                         self.push_natspec_variable_reference(
                             gcx,
+                            locations,
                             gcx.hir.function(function_id).returns,
                             name,
                             item_symbols,
@@ -305,6 +321,7 @@ impl RenameIndex {
                         };
                         self.push_path_occurrences(
                             gcx,
+                            locations,
                             RenameReferenceContext {
                                 bindings,
                                 source: item.source(),
@@ -325,6 +342,7 @@ impl RenameIndex {
     fn push_natspec_variable_reference(
         &mut self,
         gcx: Gcx<'_>,
+        locations: &proto::LocationConverter,
         variables: &[VariableId],
         name: Ident,
         item_symbols: &FxHashMap<ItemId, SymbolId>,
@@ -335,24 +353,25 @@ impl RenameIndex {
             return;
         };
         let Some(&symbol_id) = item_symbols.get(&ItemId::Variable(variable_id)) else { return };
-        self.push_symbol_occurrence(gcx, name.span, &[symbol_id]);
+        self.push_symbol_occurrence(locations, name.span, &[symbol_id]);
     }
 
     pub(crate) fn push_mapping_reference(
         &mut self,
-        gcx: Gcx<'_>,
+        locations: &proto::LocationConverter,
         bindings: &MappingBindings,
         param: VariableId,
         span: Span,
     ) -> bool {
         let Some(&name_id) = bindings.params.get(&param) else { return false };
-        self.push_span_occurrence(gcx, span, vec![RenameTarget::MappingName(name_id)]);
+        self.push_span_occurrence(locations, span, vec![RenameTarget::MappingName(name_id)]);
         true
     }
 
     pub(crate) fn push_symbol_reference(
         &mut self,
         gcx: Gcx<'_>,
+        locations: &proto::LocationConverter,
         context: RenameReferenceContext<'_>,
         span: Span,
         symbols: &[SymbolId],
@@ -365,7 +384,7 @@ impl RenameIndex {
         if symbols.is_empty() {
             return;
         }
-        self.push_path_occurrences(gcx, context, span, &symbols);
+        self.push_path_occurrences(gcx, locations, context, span, &symbols);
     }
 
     pub(crate) fn mark_yul_symbols(&mut self, symbols: &[SymbolId]) {
@@ -376,6 +395,7 @@ impl RenameIndex {
     pub(crate) fn build_overrides(
         &mut self,
         gcx: Gcx<'_>,
+        locations: &proto::LocationConverter,
         bindings: &ImportBindings,
         item_symbols: &FxHashMap<ItemId, SymbolId>,
         declarations: &IndexVec<SymbolId, DeclarationSymbol>,
@@ -406,6 +426,7 @@ impl RenameIndex {
                 };
                 self.push_path_occurrences(
                     gcx,
+                    locations,
                     RenameReferenceContext {
                         bindings,
                         source: function.source,
@@ -433,6 +454,7 @@ impl RenameIndex {
                 };
                 self.push_path_occurrences(
                     gcx,
+                    locations,
                     RenameReferenceContext {
                         bindings,
                         source: variable.source,
@@ -464,6 +486,7 @@ impl RenameIndex {
     pub(crate) fn push_namespace_reference(
         &mut self,
         gcx: Gcx<'_>,
+        locations: &proto::LocationConverter,
         bindings: &ImportBindings,
         source: hir::SourceId,
         span: Span,
@@ -484,7 +507,7 @@ impl RenameIndex {
             .collect::<Vec<_>>();
         targets.sort_unstable();
         targets.dedup();
-        self.push_span_occurrence(gcx, ident.span, targets);
+        self.push_span_occurrence(locations, ident.span, targets);
     }
 
     pub(crate) fn candidate(
@@ -671,13 +694,13 @@ impl RenameIndex {
 
     fn add_namespace_alias(
         &mut self,
-        gcx: Gcx<'_>,
+        locations: &proto::LocationConverter,
         bindings: &mut ImportBindings,
         source: hir::SourceId,
         imported_source: hir::SourceId,
         alias: Ident,
     ) {
-        let Some(alias_id) = self.add_alias(gcx, alias) else { return };
+        let Some(alias_id) = self.add_alias(locations, alias) else { return };
         bindings.aliases.insert(
             ImportBindingKey {
                 source,
@@ -688,16 +711,24 @@ impl RenameIndex {
         );
     }
 
-    fn add_alias(&mut self, gcx: Gcx<'_>, alias: Ident) -> Option<ImportAliasId> {
-        let location = proto::span_to_location(gcx.sess.source_map(), alias.span)?;
+    fn add_alias(
+        &mut self,
+        locations: &proto::LocationConverter,
+        alias: Ident,
+    ) -> Option<ImportAliasId> {
+        let location = locations.location(alias.span)?;
         let alias_id =
             self.aliases.push(ImportAlias { name: alias.to_string(), location: location.clone() });
         self.push_occurrence(location, vec![RenameTarget::ImportAlias(alias_id)]);
         Some(alias_id)
     }
 
-    fn add_mapping_name(&mut self, gcx: Gcx<'_>, name: Ident) -> Option<MappingNameId> {
-        let location = proto::span_to_location(gcx.sess.source_map(), name.span)?;
+    fn add_mapping_name(
+        &mut self,
+        locations: &proto::LocationConverter,
+        name: Ident,
+    ) -> Option<MappingNameId> {
+        let location = locations.location(name.span)?;
         let name_id = self
             .mapping_names
             .push(MappingName { name: name.to_string(), location: location.clone() });
@@ -705,9 +736,14 @@ impl RenameIndex {
         Some(name_id)
     }
 
-    fn push_symbol_occurrence(&mut self, gcx: Gcx<'_>, span: Span, symbols: &[SymbolId]) {
+    fn push_symbol_occurrence(
+        &mut self,
+        locations: &proto::LocationConverter,
+        span: Span,
+        symbols: &[SymbolId],
+    ) {
         self.push_span_occurrence(
-            gcx,
+            locations,
             span,
             symbols.iter().copied().map(RenameTarget::Symbol).collect(),
         );
@@ -716,6 +752,7 @@ impl RenameIndex {
     fn push_path_occurrences(
         &mut self,
         gcx: Gcx<'_>,
+        locations: &proto::LocationConverter,
         context: RenameReferenceContext<'_>,
         span: Span,
         symbols: &[SymbolId],
@@ -737,7 +774,7 @@ impl RenameIndex {
         if final_targets.is_empty() {
             return;
         }
-        self.push_span_occurrence(gcx, final_ident.span, final_targets);
+        self.push_span_occurrence(locations, final_ident.span, final_targets);
         if qualifiers.is_empty() {
             return;
         }
@@ -778,17 +815,22 @@ impl RenameIndex {
                     hir::Res::Builtin(_) | hir::Res::Err(_) => None,
                 })
                 .collect();
-            self.push_span_occurrence(gcx, ident.span, targets);
+            self.push_span_occurrence(locations, ident.span, targets);
         }
     }
 
-    fn push_span_occurrence(&mut self, gcx: Gcx<'_>, span: Span, mut targets: Vec<RenameTarget>) {
+    fn push_span_occurrence(
+        &mut self,
+        locations: &proto::LocationConverter,
+        span: Span,
+        mut targets: Vec<RenameTarget>,
+    ) {
         targets.sort_unstable();
         targets.dedup();
         if targets.is_empty() {
             return;
         }
-        let Some(location) = proto::span_to_location(gcx.sess.source_map(), span) else { return };
+        let Some(location) = locations.location(span) else { return };
         self.push_occurrence(location, targets);
     }
 

--- a/crates/lsp/src/signature_help.rs
+++ b/crates/lsp/src/signature_help.rs
@@ -64,10 +64,11 @@ struct ActiveArgument<'a> {
 }
 
 impl SignatureHelpIndex {
-    pub(crate) fn build(gcx: Gcx<'_>) -> Self {
+    pub(crate) fn build(gcx: Gcx<'_>, locations: &proto::LocationConverter) -> Self {
         let mut index = Self::default();
-        index.build_callable_catalog(gcx);
-        let mut collector = CallCollector { index: &mut index, gcx, source: None, contract: None };
+        index.build_callable_catalog(gcx, locations);
+        let mut collector =
+            CallCollector { index: &mut index, locations, gcx, source: None, contract: None };
         for source_id in gcx.hir.source_ids() {
             collector.source = Some(source_id);
             collector.contract = None;
@@ -184,14 +185,12 @@ impl SignatureHelpIndex {
         Some(SignatureHelp { signatures, active_signature: Some(0), active_parameter })
     }
 
-    fn build_callable_catalog(&mut self, gcx: Gcx<'_>) {
+    fn build_callable_catalog(&mut self, gcx: Gcx<'_>, locations: &proto::LocationConverter) {
         for item_id in gcx.hir.item_ids() {
             if let Some(name) = gcx.hir.item(item_id).name()
                 && let Some(signature) = render_item(gcx, item_id)
             {
-                let Some(location) =
-                    proto::span_to_location(gcx.sess.source_map(), gcx.hir.item(item_id).span())
-                else {
+                let Some(location) = locations.location(gcx.hir.item(item_id).span()) else {
                     continue;
                 };
                 let form = match item_id {
@@ -239,6 +238,7 @@ impl SignatureHelpIndex {
     fn push(
         &mut self,
         gcx: Gcx<'_>,
+        locations: &proto::LocationConverter,
         args: &CallArgs<'_>,
         callee_span: Span,
         form: CallForm,
@@ -247,11 +247,8 @@ impl SignatureHelpIndex {
         if args.is_dummy() || signatures.is_empty() {
             return;
         }
-        let Some(location) = proto::span_to_location(gcx.sess.source_map(), args.span) else {
-            return;
-        };
-        let Some(callee_location) = proto::span_to_location(gcx.sess.source_map(), callee_span)
-        else {
+        let Some(location) = locations.location(args.span) else { return };
+        let Some(callee_location) = locations.location(callee_span) else {
             return;
         };
         if callee_location.uri != location.uri {
@@ -348,6 +345,7 @@ impl CallSignature {
 
 struct CallCollector<'a, 'gcx> {
     index: &'a mut SignatureHelpIndex,
+    locations: &'a proto::LocationConverter,
     gcx: Gcx<'gcx>,
     source: Option<hir::SourceId>,
     contract: Option<hir::ContractId>,
@@ -455,13 +453,14 @@ impl<'gcx> CallCollector<'_, 'gcx> {
                 signatures.push(signature);
             }
         }
-        self.index.push(self.gcx, args, callee_span, form, signatures);
+        self.index.push(self.gcx, self.locations, args, callee_span, form, signatures);
     }
 
     fn collect_modifier(&mut self, modifier: &'gcx hir::Modifier<'gcx>) {
         let Some(signature) = render_item(self.gcx, modifier.id) else { return };
         self.index.push(
             self.gcx,
+            self.locations,
             &modifier.args,
             modifier.span.with_hi(modifier.args.span.lo()),
             CallForm::Regular,

--- a/crates/lsp/src/symbols.rs
+++ b/crates/lsp/src/symbols.rs
@@ -303,7 +303,8 @@ impl SymbolTables {
     /// every other table still includes transitive dependencies.
     pub(crate) fn build(gcx: Gcx<'_>, document_link_sources: &FxHashSet<PathBuf>) -> Self {
         let mut tables = Self::default();
-        tables.rename.record_source_contents(gcx);
+        let locations = proto::LocationConverter::new(gcx.sess.clone_source_map());
+        tables.rename.record_source_contents(gcx, &locations);
         tables.build_builtin_completions();
         let item_ids = gcx.hir.item_ids();
         let yul_variables = YulVariableCollector::collect(gcx);
@@ -322,11 +323,10 @@ impl SymbolTables {
             let Some((name, name_span)) = declaration_name(gcx, item_id) else {
                 continue;
             };
-            let Some(location) = proto::span_to_location(gcx.sess.source_map(), item.span()) else {
+            let Some(location) = locations.location(item.span()) else {
                 continue;
             };
-            let Some(name_location) = proto::span_to_location(gcx.sess.source_map(), name_span)
-            else {
+            let Some(name_location) = locations.location(name_span) else {
                 continue;
             };
 
@@ -367,7 +367,8 @@ impl SymbolTables {
         }
 
         tables.build_type_definitions(gcx, &item_symbols);
-        tables.call_hierarchy = CallHierarchyIndex::build(gcx, &item_symbols, &tables.declarations);
+        tables.call_hierarchy =
+            CallHierarchyIndex::build(gcx, &locations, &item_symbols, &tables.declarations);
         tables.code_lens = CodeLensIndex::build(gcx, &item_symbols);
 
         // Public state-variable getters are compiler-generated functions, but source member calls
@@ -380,16 +381,16 @@ impl SymbolTables {
             }
         }
         tables.type_hierarchy = TypeHierarchyIndex::build(gcx, &item_symbols, &tables.declarations);
-        tables.build_scopes(gcx);
+        tables.build_scopes(gcx, &locations);
         tables.build_receiver_member_completions(gcx);
-        tables.build_member_completions(gcx);
-        tables.build_references(gcx, &item_symbols);
+        tables.build_member_completions(gcx, &locations);
+        tables.build_references(gcx, &locations, &item_symbols);
         // HIR IDs are scoped to this compiler run and cannot back published LSP queries.
         tables.symbols_by_key = FxHashMap::default();
-        tables.document_links = DocumentLinkIndex::build(gcx, document_link_sources);
-        tables.inlay_hints = InlayHintIndex::build(gcx);
+        tables.document_links = DocumentLinkIndex::build(gcx, document_link_sources, &locations);
+        tables.inlay_hints = InlayHintIndex::build(gcx, &locations);
         tables.natspec_completion = NatSpecCompletionIndex::build(gcx);
-        tables.signature_help = SignatureHelpIndex::build(gcx);
+        tables.signature_help = SignatureHelpIndex::build(gcx, &locations);
         tables.rebuild_indexes();
         tables
     }
@@ -1115,7 +1116,7 @@ impl SymbolTables {
 
     fn push_reference_entry(
         &mut self,
-        gcx: Gcx<'_>,
+        locations: &proto::LocationConverter,
         span: Span,
         targets: ReferenceTargets,
         kind: DocumentHighlightKind,
@@ -1123,9 +1124,7 @@ impl SymbolTables {
         if targets.is_empty() {
             return;
         }
-        let Some(location) = proto::span_to_location(gcx.sess.source_map(), span) else {
-            return;
-        };
+        let Some(location) = locations.location(span) else { return };
         self.references.push(SymbolReference { location, targets, kind });
     }
 
@@ -1138,16 +1137,21 @@ impl SymbolTables {
         id
     }
 
-    fn build_scopes(&mut self, gcx: Gcx<'_>) {
-        let mut builder = ScopeBuilder { tables: self, gcx, scope: None };
+    fn build_scopes(&mut self, gcx: Gcx<'_>, locations: &proto::LocationConverter) {
+        let mut builder = ScopeBuilder { tables: self, locations, gcx, scope: None };
         for source_id in gcx.hir.source_ids() {
             builder.visit_source_scope(source_id);
         }
     }
 
-    fn build_member_completions(&mut self, gcx: Gcx<'_>) {
-        let mut collector =
-            MemberCompletionCollector { tables: self, gcx, source: None, contract: None };
+    fn build_member_completions(&mut self, gcx: Gcx<'_>, locations: &proto::LocationConverter) {
+        let mut collector = MemberCompletionCollector {
+            tables: self,
+            locations,
+            gcx,
+            source: None,
+            contract: None,
+        };
         for source_id in gcx.hir.source_ids() {
             collector.source = Some(source_id);
             collector.contract = None;
@@ -1156,8 +1160,13 @@ impl SymbolTables {
         }
     }
 
-    fn scope_for_span(&mut self, gcx: Gcx<'_>, span: Span, parent: ScopeId) -> Option<ScopeId> {
-        let location = proto::span_to_location(gcx.sess.source_map(), span)?;
+    fn scope_for_span(
+        &mut self,
+        locations: &proto::LocationConverter,
+        span: Span,
+        parent: ScopeId,
+    ) -> Option<ScopeId> {
+        let location = locations.location(span)?;
         Some(self.push_scope(location.uri, location.range, Some(parent)))
     }
 
@@ -1173,13 +1182,13 @@ impl SymbolTables {
 
     fn add_local_scope_declaration(
         &mut self,
-        gcx: Gcx<'_>,
+        locations: &proto::LocationConverter,
         scope: ScopeId,
         item_id: ItemId,
         span: Span,
     ) {
         if let Some(&symbol_id) = self.symbols_by_key.get(&SymbolKey::Item(item_id)) {
-            self.add_local_symbol_to_scope(gcx, scope, symbol_id, span);
+            self.add_local_symbol_to_scope(locations, scope, symbol_id, span);
         }
     }
 
@@ -1189,12 +1198,13 @@ impl SymbolTables {
 
     fn add_local_symbol_to_scope(
         &mut self,
-        gcx: Gcx<'_>,
+        locations: &proto::LocationConverter,
         scope: ScopeId,
         symbol_id: SymbolId,
         span: Span,
     ) {
-        let available_from = proto::span_to_location(gcx.sess.source_map(), span)
+        let available_from = locations
+            .location(span)
             .map(|location| location.range.end)
             .unwrap_or(self.declarations[symbol_id].location.range.end);
         self.scopes[scope]
@@ -1202,20 +1212,26 @@ impl SymbolTables {
             .push(ScopedDeclaration { symbol_id, available_from: Some(available_from) });
     }
 
-    fn build_references(&mut self, gcx: Gcx<'_>, item_symbols: &FxHashMap<ItemId, SymbolId>) {
-        let bindings = self.rename.build_imports(gcx, item_symbols);
+    fn build_references(
+        &mut self,
+        gcx: Gcx<'_>,
+        locations: &proto::LocationConverter,
+        item_symbols: &FxHashMap<ItemId, SymbolId>,
+    ) {
+        let bindings = self.rename.build_imports(gcx, locations, item_symbols);
         for (span, targets) in bindings.references() {
             self.push_reference_entry(
-                gcx,
+                locations,
                 span,
                 targets.iter().copied().collect(),
                 DocumentHighlightKind::READ,
             );
         }
-        let mapping_bindings = self.rename.build_mapping_names(gcx);
-        self.rename.build_natspec(gcx, &bindings, item_symbols, &self.declarations);
+        let mapping_bindings = self.rename.build_mapping_names(gcx, locations);
+        self.rename.build_natspec(gcx, locations, &bindings, item_symbols, &self.declarations);
         self.rename.build_overrides(
             gcx,
+            locations,
             &bindings,
             item_symbols,
             &self.declarations,
@@ -1223,6 +1239,7 @@ impl SymbolTables {
         );
         let mut collector = ReferenceCollector {
             tables: self,
+            locations,
             gcx,
             item_symbols,
             bindings: &bindings,
@@ -1727,6 +1744,7 @@ impl<'gcx> hir::Visit<'gcx> for YulVariableCollector<'gcx> {
 
 struct ScopeBuilder<'a, 'gcx> {
     tables: &'a mut SymbolTables,
+    locations: &'a proto::LocationConverter,
     gcx: Gcx<'gcx>,
     scope: Option<ScopeId>,
 }
@@ -1734,21 +1752,14 @@ struct ScopeBuilder<'a, 'gcx> {
 impl<'gcx> ScopeBuilder<'_, 'gcx> {
     fn visit_source_scope(&mut self, source_id: hir::SourceId) {
         let source = self.gcx.hir.source(source_id);
-        let Some(path) = source.file.name.as_real() else {
-            return;
-        };
-        let Some(uri) = Url::from_file_path(path).ok() else {
-            return;
-        };
-        let Some(range) = proto::span_to_location(
-            self.gcx.sess.source_map(),
-            Span::new(source.file.start_pos, source.file.end_position()),
-        )
-        .map(|location| location.range) else {
+        let Some(_) = source.file.name.as_real() else { return };
+        let Some(location) =
+            self.locations.location(Span::new(source.file.start_pos, source.file.end_position()))
+        else {
             return;
         };
 
-        let root = self.tables.push_scope(uri, range, None);
+        let root = self.tables.push_scope(location.uri, location.range, None);
         self.with_scope(root, |this| {
             for &item_id in source.items {
                 this.tables.add_scope_declaration(root, item_id);
@@ -1759,7 +1770,7 @@ impl<'gcx> ScopeBuilder<'_, 'gcx> {
 
     fn push_child_scope(&mut self, span: Span) -> Option<ScopeId> {
         let parent = self.scope?;
-        self.tables.scope_for_span(self.gcx, span, parent)
+        self.tables.scope_for_span(self.locations, span, parent)
     }
 
     fn with_scope(&mut self, scope: ScopeId, f: impl FnOnce(&mut Self)) {
@@ -1898,7 +1909,7 @@ impl<'gcx> hir::Visit<'gcx> for ScopeBuilder<'_, 'gcx> {
         match stmt.kind {
             StmtKind::DeclSingle(var) => {
                 self.tables.add_local_scope_declaration(
-                    self.gcx,
+                    self.locations,
                     scope,
                     ItemId::Variable(var),
                     stmt.span,
@@ -1907,7 +1918,7 @@ impl<'gcx> hir::Visit<'gcx> for ScopeBuilder<'_, 'gcx> {
             StmtKind::DeclMulti(vars, _) => {
                 for var in vars.iter().copied().flatten() {
                     self.tables.add_local_scope_declaration(
-                        self.gcx,
+                        self.locations,
                         scope,
                         ItemId::Variable(var),
                         stmt.span,
@@ -1957,6 +1968,7 @@ impl<'gcx> hir::Visit<'gcx> for ScopeBuilder<'_, 'gcx> {
 
 struct MemberCompletionCollector<'a, 'gcx> {
     tables: &'a mut SymbolTables,
+    locations: &'a proto::LocationConverter,
     gcx: Gcx<'gcx>,
     source: Option<hir::SourceId>,
     contract: Option<hir::ContractId>,
@@ -1974,8 +1986,7 @@ impl<'gcx> MemberCompletionCollector<'_, 'gcx> {
         let Some(receiver_ty) = self.gcx.type_of_expr(receiver.id) else {
             return;
         };
-        let Some(location) = proto::span_to_location(self.gcx.sess.source_map(), member.span)
-        else {
+        let Some(location) = self.locations.location(member.span) else {
             return;
         };
 
@@ -2027,6 +2038,7 @@ impl<'gcx> hir::Visit<'gcx> for MemberCompletionCollector<'_, 'gcx> {
 
 struct ReferenceCollector<'a, 'gcx> {
     tables: &'a mut SymbolTables,
+    locations: &'a proto::LocationConverter,
     gcx: Gcx<'gcx>,
     item_symbols: &'a FxHashMap<ItemId, SymbolId>,
     bindings: &'a ImportBindings,
@@ -2053,6 +2065,7 @@ impl<'gcx> ReferenceCollector<'_, 'gcx> {
             }
             self.tables.rename.push_symbol_reference(
                 self.gcx,
+                self.locations,
                 RenameReferenceContext {
                     bindings: self.bindings,
                     source,
@@ -2064,7 +2077,7 @@ impl<'gcx> ReferenceCollector<'_, 'gcx> {
                 &targets,
             );
         }
-        self.tables.push_reference_entry(self.gcx, span, targets, kind);
+        self.tables.push_reference_entry(self.locations, span, targets, kind);
     }
 
     fn visit_ident_reference(
@@ -2117,6 +2130,7 @@ impl<'gcx> ReferenceCollector<'_, 'gcx> {
         let Some(source) = self.source else { return };
         self.tables.rename.push_namespace_reference(
             self.gcx,
+            self.locations,
             self.bindings,
             source,
             span,
@@ -2168,7 +2182,7 @@ impl<'gcx> ReferenceCollector<'_, 'gcx> {
                 continue;
             };
             if self.tables.rename.push_mapping_reference(
-                self.gcx,
+                self.locations,
                 self.mapping_bindings,
                 param,
                 arg.name.span,


### PR DESCRIPTION
Towards OSS-738 , 

Repeated `Url::from_file_path` calls and percent-encoding showed up in LSP symbol-table construction. This caches each source file's URI for one analysis and reuses it across symbol, rename, signature-help, inlay-hint, call-hierarchy, and document-link indexes.

| Benchmark | main | Optimization3 | Change |
| --- | ---: | ---: | ---: |
| `analysis-build/256` | 6.685 ms | 4.782 ms | −28.5% |
| `project-analysis-batched/4` | 7.78 ms | 5.91 ms | −24.0% |
| `project-analysis/unifap-v2` | 34.347 ms | 25.708 ms | −25.2% |
| `project-analysis-after-edit/unifap-v2` | 35.281 ms | 26.402 ms | −25.2% |

Criterion benchmarks used the current `main` baseline. The LSP test suite passes 1,049 tests with one skipped test.
