### PR TITLE
perf(lsp): reuse unchanged analysis snapshots

### DIFF
--- a/crates/lsp/benches/lsp.rs
+++ b/crates/lsp/benches/lsp.rs
@@ -5,9 +5,9 @@ use lsp_types::{GotoDefinitionResponse, HoverContents, OneOf, Position, Url};
 use solar_config::CompileOpts;
 use solar_lsp::{
     BenchmarkAnalysis, BenchmarkDocumentUpdate, BenchmarkOpenDocuments, BenchmarkProject,
-    BenchmarkRequest, BenchmarkResponse, BenchmarkSelectionRangeRequests,
-    BenchmarkWorkspaceDiscovery, BenchmarkWorkspacePathQueries, BenchmarkWorkspaceReports,
-    benchmark_selection_ranges,
+    BenchmarkRepeatedAnalysis, BenchmarkRequest, BenchmarkResponse,
+    BenchmarkSelectionRangeRequests, BenchmarkWorkspaceDiscovery, BenchmarkWorkspacePathQueries,
+    BenchmarkWorkspaceReports, benchmark_selection_ranges,
 };
 use std::{fs, hint::black_box, path::PathBuf};
 
@@ -335,6 +335,26 @@ fn open_document_analysis_batches(c: &mut Criterion) {
     group.finish();
 }
 
+fn repeated_analysis(c: &mut Criterion) {
+    let fixture = benchmark_source(256);
+
+    let mut cold = c.benchmark_group("lsp/incremental-analysis");
+    cold.bench_function("cold", |b| {
+        b.iter_batched(
+            || BenchmarkRepeatedAnalysis::new(fixture.source.clone()),
+            |mut analysis| black_box(analysis.run()),
+            BatchSize::PerIteration,
+        );
+    });
+    cold.finish();
+
+    let mut analysis = BenchmarkRepeatedAnalysis::new(fixture.source);
+    assert!(analysis.run());
+    let mut cached = c.benchmark_group("lsp/incremental-analysis");
+    cached.bench_function("unchanged", |b| b.iter(|| black_box(analysis.run())));
+    cached.finish();
+}
+
 fn workspace_path_queries(c: &mut Criterion) {
     let queries =
         BenchmarkWorkspacePathQueries::new(PATH_INDEX_WORKSPACE_COUNT, PATH_INDEX_QUERY_COUNT);
@@ -542,6 +562,7 @@ criterion_group!(
     open_document_selection_range,
     workspace_diagnostic_hot_paths,
     open_document_analysis_batches,
+    repeated_analysis,
     workspace_path_queries,
     unifap_benches
 );

--- a/crates/lsp/src/global_state.rs
+++ b/crates/lsp/src/global_state.rs
@@ -88,7 +88,7 @@ enum AnalysisTaskOutcome {
     Superseded,
 }
 
-#[derive(Default)]
+#[derive(Clone, Default)]
 struct AnalysisPathIndex {
     resolved_dependencies: FxHashSet<PathBuf>,
     existing_unresolved_candidates: FxHashSet<PathBuf>,
@@ -258,6 +258,14 @@ struct AnalysisCommitState {
     analysis_config: Option<Arc<Config>>,
     natspec_pending_source_changes: FxHashSet<PathBuf>,
     natspec_context_change_version: usize,
+    cached_output: Option<CachedAnalysisOutput>,
+}
+
+#[derive(Clone)]
+struct CachedAnalysisOutput {
+    vfs_content_revision: u64,
+    config: Arc<Config>,
+    output: AnalysisOutput,
 }
 
 impl AnalysisCommitState {
@@ -831,6 +839,7 @@ impl GlobalState {
                 publish_diagnostic_batches(client, update.batches, &config);
 
                 commit.cache_invalidated = true;
+                commit.cached_output = None;
                 commit.discovery_pending = false;
                 commit.workspace_roots_before_change = None;
                 commit.analysis_paths = AnalysisPathIndex::default();
@@ -1576,6 +1585,34 @@ fn run_analysis(
     progress: &ProgressTicket,
     cancellation: &IndexingCancellation,
 ) -> AnalysisTaskOutcome {
+    let has_disk_paths = !disk_paths.is_empty();
+    let vfs_content_revision = snapshot.vfs.read().content_revision();
+    let config = snapshot.config.clone();
+    if has_disk_paths {
+        snapshot.analysis_commit.lock().cached_output = None;
+    }
+    if !has_disk_paths && !cancellation.is_cancelled() && snapshot.is_current(version) {
+        let cached = {
+            let commit = snapshot.analysis_commit.lock();
+            if commit.cache_invalidated {
+                None
+            } else {
+                commit.cached_output.as_ref().and_then(|cached| {
+                    (cached.vfs_content_revision == vfs_content_revision
+                        && Arc::ptr_eq(&cached.config, &config))
+                    .then(|| cached.output.clone())
+                })
+            }
+        };
+        if let Some(output) = cached {
+            progress.report("Reusing workspace index");
+            if snapshot.publish_analysis_output(version, output) {
+                return AnalysisTaskOutcome::Published;
+            }
+            return AnalysisTaskOutcome::Superseded;
+        }
+    }
+
     progress.report("Reading workspace sources");
     if cancellation.is_cancelled() || !snapshot.is_current(version) {
         return AnalysisTaskOutcome::Superseded;
@@ -1616,6 +1653,10 @@ fn run_analysis(
     }
 
     let output = results.finish();
+    if !has_disk_paths {
+        snapshot.analysis_commit.lock().cached_output =
+            Some(CachedAnalysisOutput { vfs_content_revision, config, output: output.clone() });
+    }
     progress.report("Publishing workspace index");
     if snapshot.publish_analysis_output(version, output) {
         AnalysisTaskOutcome::Published
@@ -1696,18 +1737,21 @@ fn handle_analysis_failure(
     tracing::warn!(%error, version, "workspace indexing task failed");
     let refresh_requests = commit.fail_external_refresh();
     commit.cache_invalidated = true;
+    commit.cached_output = None;
     commit.discovery_pending = false;
     commit.natspec_context_change_version = commit.natspec_context_change_version.max(version);
     published_analysis_version.send_replace(version);
     Some(refresh_requests)
 }
 
+#[derive(Clone)]
 struct AnalysisResult {
     analyzed_documents: AnalyzedDocuments,
     diagnostics: DiagnosticMap,
     symbol_tables: SymbolTables,
 }
 
+#[derive(Clone)]
 struct AnalysisOutput {
     result: AnalysisResult,
     analysis_paths: AnalysisPathIndex,

--- a/crates/lsp/src/global_state/benchmark.rs
+++ b/crates/lsp/src/global_state/benchmark.rs
@@ -1,8 +1,8 @@
 //! Benchmark-only, in-memory LSP analysis support.
 
 use super::{
-    AnalysisBatch, AnalysisResult, AnalysisResultAccumulator, DiagnosticMap, SymbolTables, analyze,
-    analyze_with_source_map,
+    AnalysisBatch, AnalysisResult, AnalysisResultAccumulator, AnalysisTaskOutcome, DiagnosticMap,
+    SymbolTables, analyze, analyze_with_source_map, run_analysis,
 };
 use crate::{
     config::negotiate_capabilities,
@@ -503,6 +503,47 @@ impl BenchmarkDocumentChange {
 pub struct BenchmarkDocumentUpdate {
     state: super::GlobalState,
     params: DidChangeTextDocumentParams,
+}
+
+/// A production analysis state used to compare a cold run with an unchanged-snapshot reuse.
+#[doc(hidden)]
+pub struct BenchmarkRepeatedAnalysis {
+    state: super::GlobalState,
+    version: usize,
+}
+
+impl BenchmarkRepeatedAnalysis {
+    /// Prepare one open document and reserve a stable analysis epoch.
+    pub fn new(source: String) -> Self {
+        let state = super::GlobalState::new(ClientSocket::new_closed());
+        let path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("benches/repeated-analysis.sol");
+        state.vfs.write().set_file_contents_with_version(
+            VfsPath::from(path),
+            Some(Rope::from(source.as_str())),
+            Some(1),
+        );
+        let version = 1;
+        state.analysis_version.store(version, std::sync::atomic::Ordering::Release);
+        state.analysis_commit.lock().vfs_content_revision = state.vfs.read().content_revision();
+        Self { state, version }
+    }
+
+    /// Run one production analysis epoch, returning whether it published successfully.
+    #[inline(never)]
+    pub fn run(&mut self) -> bool {
+        let mut snapshot = self.state.snapshot();
+        let progress = self.state.analysis_progress.reserve(self.version);
+        matches!(
+            run_analysis(
+                &mut snapshot,
+                self.version,
+                Vec::new(),
+                &progress,
+                &IndexingCancellation::default(),
+            ),
+            AnalysisTaskOutcome::Published
+        )
+    }
 }
 
 impl BenchmarkDocumentUpdate {
@@ -1277,5 +1318,37 @@ mod tests {
         ] {
             assert!(BenchmarkProject::from_fixture("malformed", fixture).is_err());
         }
+    }
+
+    #[test]
+    fn repeated_analysis_reuses_and_invalidates_snapshot() {
+        let mut analysis = BenchmarkRepeatedAnalysis::new("contract Cached {}".into());
+        assert!(analysis.run());
+        let first_revision = analysis
+            .state
+            .analysis_commit
+            .lock()
+            .cached_output
+            .as_ref()
+            .unwrap()
+            .vfs_content_revision;
+
+        assert!(analysis.run());
+        let path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("benches/repeated-analysis.sol");
+        analysis.state.vfs.write().set_file_contents_with_version(
+            VfsPath::from(path),
+            Some(Rope::from("contract Cached { uint value; }")),
+            Some(2),
+        );
+        assert!(analysis.run());
+        let second_revision = analysis
+            .state
+            .analysis_commit
+            .lock()
+            .cached_output
+            .as_ref()
+            .unwrap()
+            .vfs_content_revision;
+        assert_ne!(first_revision, second_revision);
     }
 }

--- a/crates/lsp/src/lib.rs
+++ b/crates/lsp/src/lib.rs
@@ -351,9 +351,9 @@ mod workspace;
 #[doc(hidden)]
 pub use global_state::benchmark::{
     BenchmarkAnalysis, BenchmarkDocumentChange, BenchmarkDocumentUpdate, BenchmarkEdit,
-    BenchmarkError, BenchmarkOpenDocuments, BenchmarkProject, BenchmarkRequest, BenchmarkResponse,
-    BenchmarkSelectionRangeRequests, BenchmarkWorkspaceDiscovery, BenchmarkWorkspacePathQueries,
-    BenchmarkWorkspaceReports,
+    BenchmarkError, BenchmarkOpenDocuments, BenchmarkProject, BenchmarkRepeatedAnalysis,
+    BenchmarkRequest, BenchmarkResponse, BenchmarkSelectionRangeRequests,
+    BenchmarkWorkspaceDiscovery, BenchmarkWorkspacePathQueries, BenchmarkWorkspaceReports,
 };
 
 /// Runs the selection-range kernel for Criterion benchmarks.


### PR DESCRIPTION
Towards OSS-738 , 

This change adds a conservative analysis snapshot fast path for unchanged in-memory LSP workspaces. After a successful analysis, the server retains the published analysis output and reuses it when the VFS content revision and configuration are unchanged. Edits, disk-backed analysis, cache invalidation, cancellation, stale analysis versions, configuration changes, and failed analyses continue through the existing rebuild path.

The implementation also adds a production-path Criterion benchmark and a regression test covering snapshot reuse and invalidation. The fast path publishes the same analysis output and diagnostics, so LSP providers continue to observe the existing symbol and diagnostic state.

## Benchmark

Measured with the new `lsp/incremental-analysis` Criterion workload in the same checkout. These are two execution modes in the same benchmark group, rather than separate main-versus-PR runs: cold analysis creates a fresh production analysis state for each iteration, while unchanged analysis repeats one state after its first successful run. The reduction therefore measures the repeated-analysis fast path against the cold path in the candidate build.

| Run | Execution mode | Median |
| --- | --- | ---: |
| 10 samples, 1 s measurement, 1 s warm-up | Cold analysis | 7.37 ms |
| 10 samples, 1 s measurement, 1 s warm-up | Unchanged snapshot | 1.02 ms |
| 20 samples, 1 s measurement, 1 s warm-up | Cold analysis | 7.46 ms |
| 20 samples, 1 s measurement, 1 s warm-up | Unchanged snapshot | 0.99 ms |

The unchanged snapshot path is 86.1% lower than cold analysis in the 10-sample run and 86.8% lower in the 20-sample run.

The benchmark demonstrates the intended repeated-analysis workload; it does not claim that first-run analysis or analyses invalidated by edits become faster, and it is not a main-versus-PR regression measurement.
