### PR TITLE
perf(lsp): optimize folding range

### DIFF
--- a/crates/lsp/benches/lsp.rs
+++ b/crates/lsp/benches/lsp.rs
@@ -1,17 +1,20 @@
 #![allow(unused_crate_dependencies)]
 
 use criterion::{BatchSize, BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use crop::Rope;
 use lsp_types::{GotoDefinitionResponse, HoverContents, OneOf, Position, Url};
 use solar_config::CompileOpts;
 use solar_lsp::{
     BenchmarkAnalysis, BenchmarkDocumentUpdate, BenchmarkOpenDocuments, BenchmarkProject,
     BenchmarkRequest, BenchmarkResponse, BenchmarkSelectionRangeRequests,
     BenchmarkWorkspaceDiscovery, BenchmarkWorkspacePathQueries, BenchmarkWorkspaceReports,
-    benchmark_selection_ranges,
+    benchmark_folding_ranges, benchmark_folding_ranges_from_rope, benchmark_selection_ranges,
 };
 use std::{fs, hint::black_box, path::PathBuf};
 
 const ANALYSIS_FUNCTION_COUNTS: [usize; 2] = [64, 256];
+const INCOMPLETE_FOLDING_CONTRACT_COUNT: usize = 256;
+const MINIFIED_FOLDING_FUNCTION_COUNT: usize = 1_024;
 const HOVER_FUNCTION_COUNT: usize = 256;
 const AGGREGATION_BATCH_COUNT: usize = 4;
 const AGGREGATION_FUNCTION_COUNT: usize = 64;
@@ -261,6 +264,87 @@ fn selection_range(c: &mut Criterion) {
             |source| {
                 black_box(benchmark_selection_ranges(black_box(source), black_box(&positions)))
             },
+            BatchSize::PerIteration,
+        );
+    });
+    group.finish();
+}
+
+fn incomplete_folding_source(contract_count: usize) -> String {
+    let mut source = String::new();
+    for prefix in ["before", "after"] {
+        if prefix == "after" {
+            source.push_str("@ incomplete edit\n");
+        }
+        for index in 0..contract_count {
+            source.push_str(&format!(
+                "contract {prefix}_{index:04} {{\n    function f() external {{\n        if (true) {{\n        }}\n    }}\n}}\n"
+            ));
+            if prefix == "after" && index % 16 == 15 {
+                source.push_str("@ incomplete edit\n");
+            }
+        }
+    }
+    source
+}
+
+fn minified_folding_source(function_count: usize) -> String {
+    let mut source = String::from("contract Minified{");
+    for index in 0..function_count {
+        source.push_str(&format!("function f{index}() external{{if(true){{}}}}"));
+    }
+    source.push('}');
+    source
+}
+
+fn rope_to_string(rope: &Rope) -> String {
+    let mut source = String::with_capacity(rope.byte_len());
+    for chunk in rope.chunks() {
+        source.push_str(chunk);
+    }
+    source
+}
+
+fn folding_range(c: &mut Criterion) {
+    let clean = OPTIMISM_SOURCE.to_owned();
+    let incomplete = incomplete_folding_source(INCOMPLETE_FOLDING_CONTRACT_COUNT);
+    let minified = minified_folding_source(MINIFIED_FOLDING_FUNCTION_COUNT);
+    let open_rope = Rope::from(clean.as_str());
+
+    let clean_ranges = benchmark_folding_ranges(clean.clone());
+    let incomplete_ranges = benchmark_folding_ranges(incomplete.clone());
+    let minified_ranges = benchmark_folding_ranges(minified.clone());
+    assert!(!clean_ranges.is_empty());
+    assert_eq!(incomplete_ranges.len(), INCOMPLETE_FOLDING_CONTRACT_COUNT * 2 * 3);
+    assert!(minified_ranges.is_empty());
+    assert_eq!(benchmark_folding_ranges_from_rope(open_rope.clone()), clean_ranges);
+
+    let mut group = c.benchmark_group("lsp/folding-range");
+    for (name, source) in [("clean", clean), ("incomplete", incomplete), ("minified", minified)] {
+        group.throughput(Throughput::Bytes(source.len() as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(name), &source, |b, source| {
+            b.iter_batched(
+                || source.clone(),
+                |source| black_box(benchmark_folding_ranges(black_box(source))),
+                BatchSize::PerIteration,
+            );
+        });
+    }
+    group.throughput(Throughput::Bytes(OPTIMISM_SOURCE.len() as u64));
+    group.bench_function("open-clean-legacy", |b| {
+        b.iter_batched(
+            || open_rope.clone(),
+            |rope| {
+                let source = rope_to_string(&rope);
+                black_box(benchmark_folding_ranges(black_box(source)))
+            },
+            BatchSize::PerIteration,
+        );
+    });
+    group.bench_function("open-clean-snapshot", |b| {
+        b.iter_batched(
+            || open_rope.clone(),
+            |rope| black_box(benchmark_folding_ranges_from_rope(black_box(rope))),
             BatchSize::PerIteration,
         );
     });
@@ -538,6 +622,7 @@ criterion_group!(
     bounded_workspace_discovery,
     symbol_table_aggregation,
     burst_hover,
+    folding_range,
     selection_range,
     open_document_selection_range,
     workspace_diagnostic_hot_paths,

--- a/crates/lsp/benches/lsp.rs
+++ b/crates/lsp/benches/lsp.rs
@@ -5,11 +5,11 @@ use crop::Rope;
 use lsp_types::{GotoDefinitionResponse, HoverContents, OneOf, Position, Url};
 use solar_config::CompileOpts;
 use solar_lsp::{
-    BenchmarkAnalysis, BenchmarkDocumentUpdate, BenchmarkOpenDocuments, BenchmarkProject,
-    BenchmarkRepeatedAnalysis, BenchmarkRequest, BenchmarkResponse,
-    BenchmarkSelectionRangeRequests, BenchmarkWorkspaceDiscovery, BenchmarkWorkspacePathQueries,
-    BenchmarkWorkspaceReports, benchmark_folding_ranges, benchmark_folding_ranges_from_rope,
-    benchmark_selection_ranges,
+    BenchmarkAnalysis, BenchmarkDocumentUpdate, BenchmarkFoldingRangeRequests,
+    BenchmarkOpenDocuments, BenchmarkProject, BenchmarkRepeatedAnalysis, BenchmarkRequest,
+    BenchmarkResponse, BenchmarkSelectionRangeRequests, BenchmarkWorkspaceDiscovery,
+    BenchmarkWorkspacePathQueries, BenchmarkWorkspaceReports, benchmark_folding_ranges,
+    benchmark_folding_ranges_from_rope, benchmark_selection_ranges,
 };
 use std::{fs, hint::black_box, path::PathBuf};
 
@@ -350,6 +350,15 @@ fn folding_range(c: &mut Criterion) {
         );
     });
     group.finish();
+
+    let requests = BenchmarkFoldingRangeRequests::new(OPTIMISM_SOURCE.to_owned());
+    assert_eq!(requests.run(), clean_ranges);
+    let mut cached = c.benchmark_group("lsp/open-document-folding-range");
+    cached.throughput(Throughput::Bytes(OPTIMISM_SOURCE.len() as u64));
+    cached.bench_function("optimism-unchanged", |b| {
+        b.iter(|| black_box(requests.run()));
+    });
+    cached.finish();
 }
 
 fn open_document_selection_range(c: &mut Criterion) {

--- a/crates/lsp/src/folding_range.rs
+++ b/crates/lsp/src/folding_range.rs
@@ -4,7 +4,11 @@ use crate::proto;
 use crop::Rope;
 use lsp_types::{FoldingRange, FoldingRangeKind};
 use solar_config::CompileOpts;
-use solar_interface::{Session, SourceMap, Span, data_structures::Never, source_map::FileName};
+use solar_interface::{
+    Session, SourceMap, Span,
+    data_structures::{Never, map::FxHashMap},
+    source_map::FileName,
+};
 use solar_parse::{
     Cursor, Parser,
     ast::{self, token::Delimiter, visit::Visit},
@@ -17,24 +21,28 @@ use std::{
 
 pub(crate) fn folding_ranges(source: String) -> Vec<FoldingRange> {
     let rope = Rope::from(source.as_str());
-    let index = proto::LspPositionIndex::new(&rope);
-    let LexicalInfo { mut ranges, fallback_ranges, unclosed_braces } =
-        collect_lexical_info(&source);
-    match collect_ast_ranges(source, &rope, &unclosed_braces) {
-        Some(info) => {
-            if info.has_errors {
-                ranges.extend(fallback_ranges.into_iter().filter(|candidate| {
-                    !info.ranges.iter().any(|ast| {
-                        ast.kind == candidate.kind
-                            && ast.range.start == candidate.range.start
-                            && candidate.range.end <= ast.range.end
-                    })
-                }));
-            }
-            ranges.extend(info.ranges);
-        }
-        None => ranges.extend(fallback_ranges),
+    folding_ranges_with_rope(source, &rope)
+}
+
+pub(crate) fn folding_ranges_from_rope(rope: Rope) -> Vec<FoldingRange> {
+    if is_single_line(&rope) {
+        return Vec::new();
     }
+    let source = rope_to_string(&rope);
+    folding_ranges_with_rope(source, &rope)
+}
+
+fn folding_ranges_with_rope(source: String, rope: &Rope) -> Vec<FoldingRange> {
+    if is_single_line(rope) {
+        return Vec::new();
+    }
+    let index = proto::LspPositionIndex::new(rope);
+    let ranges = collect_ranges(source, rope).unwrap_or_else(|| {
+        let source = rope_to_string(rope);
+        let LexicalInfo { mut ranges, fallback_ranges, .. } = collect_lexical_info(&source, true);
+        ranges.extend(fallback_ranges);
+        ranges
+    });
     let mut ranges = ranges
         .into_iter()
         .filter_map(|candidate| folding_range(&index, candidate))
@@ -44,7 +52,20 @@ pub(crate) fn folding_ranges(source: String) -> Vec<FoldingRange> {
     ranges
 }
 
-fn collect_lexical_info(source: &str) -> LexicalInfo {
+fn is_single_line(rope: &Rope) -> bool {
+    // LSP counts lone CRs and a trailing empty line, unlike Rope's line metric.
+    rope.line_len() <= 1 && rope.chunks().all(|chunk| !chunk.contains(['\r', '\n']))
+}
+
+fn rope_to_string(rope: &Rope) -> String {
+    let mut source = String::with_capacity(rope.byte_len());
+    for chunk in rope.chunks() {
+        source.push_str(chunk);
+    }
+    source
+}
+
+fn collect_lexical_info(source: &str, include_fallback: bool) -> LexicalInfo {
     let mut ranges = Vec::new();
     let mut fallback_ranges = Vec::new();
     let mut line_group = None::<ByteRange<usize>>;
@@ -53,6 +74,9 @@ fn collect_lexical_info(source: &str) -> LexicalInfo {
 
     for (start, token) in Cursor::new(source).with_position() {
         let end = start + token.len as usize;
+        if !matches!(token.kind, RawTokenKind::LineComment { .. } | RawTokenKind::Whitespace) {
+            flush_line_comment_group(&mut ranges, &mut line_group);
+        }
         match token.kind {
             RawTokenKind::LineComment { .. } => {
                 if let Some(group) = &mut line_group
@@ -60,35 +84,24 @@ fn collect_lexical_info(source: &str) -> LexicalInfo {
                 {
                     group.end = end;
                 } else {
-                    if let Some(range) = line_group.take() {
-                        ranges.push(Candidate { range, kind: Some(FoldingRangeKind::Comment) });
-                    }
+                    flush_line_comment_group(&mut ranges, &mut line_group);
                     line_group = Some(start..end);
                 }
             }
             RawTokenKind::Whitespace => {}
             RawTokenKind::BlockComment { .. } => {
-                if let Some(range) = line_group.take() {
-                    ranges.push(Candidate { range, kind: Some(FoldingRangeKind::Comment) });
-                }
                 ranges.push(Candidate { range: start..end, kind: Some(FoldingRangeKind::Comment) });
             }
-            RawTokenKind::OpenDelim(Delimiter::Brace) => {
-                if let Some(range) = line_group.take() {
-                    ranges.push(Candidate { range, kind: Some(FoldingRangeKind::Comment) });
-                }
+            RawTokenKind::OpenDelim(Delimiter::Brace) if include_fallback => {
                 let class = classify_fallback_block(source, &syntax_tokens, &brace_stack);
                 brace_stack.push(OpenBrace { start, class });
                 syntax_tokens.push(SyntaxToken {
                     kind: token.kind,
                     range: start..end,
-                    closed_block: None,
+                    closes_yul_for_init: false,
                 });
             }
-            RawTokenKind::CloseDelim(Delimiter::Brace) => {
-                if let Some(range) = line_group.take() {
-                    ranges.push(Candidate { range, kind: Some(FoldingRangeKind::Comment) });
-                }
+            RawTokenKind::CloseDelim(Delimiter::Brace) if include_fallback => {
                 let closed_block = brace_stack.pop().and_then(|open| {
                     if let Some(class) = open.class {
                         fallback_ranges.push(class.candidate(open.start, end));
@@ -98,39 +111,52 @@ fn collect_lexical_info(source: &str) -> LexicalInfo {
                 syntax_tokens.push(SyntaxToken {
                     kind: token.kind,
                     range: start..end,
-                    closed_block,
+                    closes_yul_for_init: closed_block
+                        .is_some_and(|block| matches!(block.kind, FallbackBlockKind::YulForInit)),
                 });
             }
-            _ => {
-                if let Some(range) = line_group.take() {
-                    ranges.push(Candidate { range, kind: Some(FoldingRangeKind::Comment) });
-                }
+            _ if include_fallback => {
                 syntax_tokens.push(SyntaxToken {
                     kind: token.kind,
                     range: start..end,
-                    closed_block: None,
+                    closes_yul_for_init: false,
                 });
             }
+            _ => {}
         }
     }
-    if let Some(range) = line_group {
-        ranges.push(Candidate { range, kind: Some(FoldingRangeKind::Comment) });
-    }
-    fallback_ranges.extend(collect_fallback_import_ranges(source, &syntax_tokens));
-    let unclosed_braces = brace_stack.iter().map(|brace| brace.start).collect();
-    for open in brace_stack {
-        if let Some(class) = open.class {
-            fallback_ranges.push(class.candidate(open.start, source.len()));
+    flush_line_comment_group(&mut ranges, &mut line_group);
+    let unclosed_braces = if include_fallback {
+        fallback_ranges.extend(collect_fallback_import_ranges(source, &syntax_tokens));
+        let unclosed_braces = brace_stack.iter().map(|brace| brace.start).collect();
+        for open in brace_stack {
+            if let Some(class) = open.class {
+                fallback_ranges.push(class.candidate(open.start, source.len()));
+            }
         }
-    }
-    fallback_ranges
-        .sort_unstable_by_key(|candidate| (candidate.range.start, Reverse(candidate.range.end)));
-    fallback_ranges.dedup_by_key(|candidate| candidate.range.start);
+        fallback_ranges.sort_unstable_by_key(|candidate| {
+            (candidate.range.start, Reverse(candidate.range.end))
+        });
+        fallback_ranges.dedup_by_key(|candidate| candidate.range.start);
+        unclosed_braces
+    } else {
+        Vec::new()
+    };
     LexicalInfo { ranges, fallback_ranges, unclosed_braces }
 }
 
+fn flush_line_comment_group(
+    ranges: &mut Vec<Candidate>,
+    line_group: &mut Option<ByteRange<usize>>,
+) {
+    if let Some(range) = line_group.take() {
+        ranges.push(Candidate { range, kind: Some(FoldingRangeKind::Comment) });
+    }
+}
+
 fn collect_fallback_import_ranges(source: &str, tokens: &[SyntaxToken]) -> Vec<Candidate> {
-    let mut imports = Vec::new();
+    let mut ranges = Vec::new();
+    let mut current = None::<ByteRange<usize>>;
     let mut start = None;
     let mut brace_depth = 0usize;
 
@@ -151,30 +177,26 @@ fn collect_fallback_import_ranges(source: &str, tokens: &[SyntaxToken]) -> Vec<C
             }
             RawTokenKind::Semi if brace_depth == 0 => {
                 if let Some(start) = start.take() {
-                    imports.push(start..token.range.end);
+                    let import = start..token.range.end;
+                    let split = current.as_ref().is_some_and(|group| {
+                        let between = &source[group.end..import.start];
+                        has_blank_line_between(between.bytes())
+                            || Cursor::new(between).any(|token| !token.kind.is_trivial())
+                    });
+                    if split && let Some(range) = current.take() {
+                        ranges.push(Candidate { range, kind: Some(FoldingRangeKind::Imports) });
+                    }
+                    if let Some(group) = &mut current {
+                        group.end = import.end;
+                    } else {
+                        current = Some(import);
+                    }
                 }
             }
             _ => {}
         }
     }
 
-    let mut ranges = Vec::new();
-    let mut current = None::<ByteRange<usize>>;
-    for import in imports {
-        let split = current.as_ref().is_some_and(|group| {
-            let between = &source[group.end..import.start];
-            has_blank_line_between(between.bytes())
-                || Cursor::new(between).any(|token| !token.kind.is_trivial())
-        });
-        if split && let Some(range) = current.take() {
-            ranges.push(Candidate { range, kind: Some(FoldingRangeKind::Imports) });
-        }
-        if let Some(group) = &mut current {
-            group.end = import.end;
-        } else {
-            current = Some(import);
-        }
-    }
     if let Some(range) = current {
         ranges.push(Candidate { range, kind: Some(FoldingRangeKind::Imports) });
     }
@@ -344,12 +366,7 @@ fn classify_yul_for_continuation(tokens: &[SyntaxToken]) -> Option<FallbackBlock
         match token.kind {
             RawTokenKind::Semi | RawTokenKind::OpenDelim(Delimiter::Brace) => return None,
             RawTokenKind::CloseDelim(Delimiter::Brace) => {
-                return match token.closed_block.map(|block| block.kind) {
-                    Some(FallbackBlockKind::YulForInit) => {
-                        Some(FallbackBlock::body(BlockLanguage::Yul))
-                    }
-                    _ => None,
-                };
+                return token.closes_yul_for_init.then(|| FallbackBlock::body(BlockLanguage::Yul));
             }
             _ => {}
         }
@@ -394,8 +411,16 @@ fn has_one_line_break(text: &str) -> bool {
                     bytes.next();
                 }
                 line_breaks += 1;
+                if line_breaks > 1 {
+                    return false;
+                }
             }
-            b'\n' => line_breaks += 1,
+            b'\n' => {
+                line_breaks += 1;
+                if line_breaks > 1 {
+                    return false;
+                }
+            }
             b' ' | b'\t' | 0x0b | 0x0c => {}
             _ => return false,
         }
@@ -403,35 +428,57 @@ fn has_one_line_break(text: &str) -> bool {
     line_breaks == 1
 }
 
-fn collect_ast_ranges(source: String, rope: &Rope, unclosed_braces: &[usize]) -> Option<AstInfo> {
+fn collect_ranges(source: String, rope: &Rope) -> Option<Vec<Candidate>> {
     let mut opts = CompileOpts::default();
     opts.unstable.recover_incomplete_input = true;
     let sess = Session::builder().opts(opts).with_silent_emitter(None).single_threaded().build();
 
     sess.enter_sequential(|| {
         let arena = ast::Arena::new();
-        let Ok(mut parser) = Parser::from_source_code(
-            &sess,
-            &arena,
-            FileName::Custom("lsp-folding-range.sol".into()),
-            source,
-        ) else {
-            return None;
-        };
+        let file = sess
+            .source_map()
+            .new_source_file(FileName::Custom("lsp-folding-range.sol".into()), source)
+            .ok()?;
+        let mut parser = Parser::from_source_file(&sess, &arena, &file);
         let source_unit = match parser.parse_file() {
-            Ok(source_unit) => source_unit,
+            Ok(source_unit) => Some(source_unit),
             Err(error) => {
                 error.emit();
-                return None;
+                None
             }
         };
         drop(parser);
 
-        let mut collector = AstRangeCollector::new(sess.source_map(), rope, unclosed_braces);
+        let has_errors = sess.dcx.has_errors().is_err();
+        let include_fallback = has_errors || source_unit.is_none();
+        let LexicalInfo { mut ranges, fallback_ranges, unclosed_braces } =
+            collect_lexical_info(&file.src, include_fallback);
+        let Some(source_unit) = source_unit else {
+            ranges.extend(fallback_ranges);
+            return Some(ranges);
+        };
+
+        let mut collector = AstRangeCollector::new(sess.source_map(), rope, &unclosed_braces);
         let _ = collector.visit_source_unit(&source_unit);
-        let mut ranges = collect_import_ranges(&source_unit, sess.source_map(), rope);
-        ranges.extend(collector.ranges);
-        Some(AstInfo { ranges, has_errors: sess.dcx.has_errors().is_err() })
+        let mut ast_ranges = collect_import_ranges(&source_unit, sess.source_map(), rope);
+        ast_ranges.extend(collector.ranges);
+
+        if has_errors {
+            let mut ast_ends = FxHashMap::<(u8, usize), usize>::default();
+            for ast in &ast_ranges {
+                ast_ends
+                    .entry((folding_range_kind_rank(ast.kind.as_ref()), ast.range.start))
+                    .and_modify(|end| *end = (*end).max(ast.range.end))
+                    .or_insert(ast.range.end);
+            }
+            ranges.extend(fallback_ranges.into_iter().filter(|candidate| {
+                ast_ends
+                    .get(&(folding_range_kind_rank(candidate.kind.as_ref()), candidate.range.start))
+                    .is_none_or(|&end| candidate.range.end > end)
+            }));
+        }
+        ranges.extend(ast_ranges);
+        Some(ranges)
     })
 }
 
@@ -509,11 +556,11 @@ fn folding_range(
     index: &proto::LspPositionIndex<&Rope>,
     candidate: Candidate,
 ) -> Option<FoldingRange> {
-    let start = index.position_at_byte(candidate.range.start)?;
-    let end = index.position_at_byte(candidate.range.end)?;
-    if start.line >= end.line {
+    if index.line_at_byte(candidate.range.start)? >= index.line_at_byte(candidate.range.end)? {
         return None;
     }
+    let start = index.position_at_byte(candidate.range.start)?;
+    let end = index.position_at_byte(candidate.range.end)?;
     Some(FoldingRange {
         start_line: start.line,
         start_character: Some(start.character),
@@ -530,13 +577,17 @@ fn folding_range_sort_key(range: &FoldingRange) -> (u32, u32, u32, u32, u8) {
         range.start_character.unwrap_or_default(),
         range.end_line,
         range.end_character.unwrap_or_default(),
-        match range.kind {
-            None => 0,
-            Some(FoldingRangeKind::Comment) => 1,
-            Some(FoldingRangeKind::Imports) => 2,
-            Some(FoldingRangeKind::Region) => 3,
-        },
+        folding_range_kind_rank(range.kind.as_ref()),
     )
+}
+
+fn folding_range_kind_rank(kind: Option<&FoldingRangeKind>) -> u8 {
+    match kind {
+        None => 0,
+        Some(FoldingRangeKind::Comment) => 1,
+        Some(FoldingRangeKind::Imports) => 2,
+        Some(FoldingRangeKind::Region) => 3,
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -551,11 +602,6 @@ struct LexicalInfo {
     unclosed_braces: Vec<usize>,
 }
 
-struct AstInfo {
-    ranges: Vec<Candidate>,
-    has_errors: bool,
-}
-
 #[derive(Clone, Copy)]
 struct OpenBrace {
     start: usize,
@@ -566,7 +612,7 @@ struct OpenBrace {
 struct SyntaxToken {
     kind: RawTokenKind,
     range: ByteRange<usize>,
-    closed_block: Option<FallbackBlock>,
+    closes_yul_for_init: bool,
 }
 
 #[derive(Clone, Copy)]
@@ -614,19 +660,13 @@ struct AstRangeCollector<'a> {
     source_map: &'a SourceMap,
     rope: &'a Rope,
     ranges: Vec<Candidate>,
-    suppressed_blocks: Vec<Span>,
+    suppressed_block: Option<Span>,
     unclosed_braces: &'a [usize],
 }
 
 impl<'a> AstRangeCollector<'a> {
     fn new(source_map: &'a SourceMap, rope: &'a Rope, unclosed_braces: &'a [usize]) -> Self {
-        Self {
-            source_map,
-            rope,
-            ranges: Vec::new(),
-            suppressed_blocks: Vec::new(),
-            unclosed_braces,
-        }
+        Self { source_map, rope, ranges: Vec::new(), suppressed_block: None, unclosed_braces }
     }
 
     fn push(&mut self, span: Span) {
@@ -661,13 +701,13 @@ impl<'a> AstRangeCollector<'a> {
     }
 
     fn suppress_block(&mut self, span: Span, f: impl FnOnce(&mut Self)) {
-        self.suppressed_blocks.push(span);
+        let previous = self.suppressed_block.replace(span);
         f(self);
-        self.suppressed_blocks.pop();
+        self.suppressed_block = previous;
     }
 
     fn block_is_suppressed(&self, span: Span) -> bool {
-        self.suppressed_blocks.last() == Some(&span)
+        self.suppressed_block == Some(span)
     }
 }
 

--- a/crates/lsp/src/global_state/benchmark.rs
+++ b/crates/lsp/src/global_state/benchmark.rs
@@ -591,6 +591,40 @@ pub struct BenchmarkSelectionRangeRequests {
     positions: Vec<Position>,
 }
 
+/// A prepared open-document folding-range request workload.
+#[doc(hidden)]
+pub struct BenchmarkFoldingRangeRequests {
+    state: super::GlobalState,
+    path: VfsPath,
+}
+
+impl BenchmarkFoldingRangeRequests {
+    /// Prepare one immutable open document for repeated folding-range requests.
+    pub fn new(source: String) -> Self {
+        let state = super::GlobalState::new(ClientSocket::new_closed());
+        let path = VfsPath::from(
+            PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("benches/open-folding-range.sol"),
+        );
+        state.vfs.write().set_file_contents_with_version(
+            path.clone(),
+            Some(Rope::from(source.as_str())),
+            Some(1),
+        );
+        Self { state, path }
+    }
+
+    /// Run one folding-range request through the open-document source path.
+    #[inline(never)]
+    pub fn run(&self) -> Vec<lsp_types::FoldingRange> {
+        self.state
+            .vfs
+            .read()
+            .get_file_folding_range_source(&self.path)
+            .expect("the benchmark document should be open")
+            .folding_ranges()
+    }
+}
+
 impl BenchmarkSelectionRangeRequests {
     /// Prepare one immutable open document and the positions queried on every request.
     pub fn new(source: String, positions: impl IntoIterator<Item = Position>) -> Self {

--- a/crates/lsp/src/handlers/reqs.rs
+++ b/crates/lsp/src/handlers/reqs.rs
@@ -110,22 +110,29 @@ pub(crate) fn folding_range(
 
     async move {
         let Some((vfs_path, path)) = request else { return Ok(None) };
-        let contents = { vfs.read().get_file_contents(&vfs_path).cloned() };
-        let task = if let Some(rope) = contents {
-            tokio::task::spawn_blocking(move || {
-                crate::folding_range::folding_ranges_from_rope(rope)
-            })
+        let cached_source = { vfs.read().get_file_folding_range_source(&vfs_path) };
+        let ranges = if let Some(source) = cached_source {
+            tokio::task::spawn_blocking(move || source.folding_ranges())
+                .await
+                .map_err(folding_range_task_failed)?
         } else {
-            let source = match tokio::fs::read_to_string(path).await {
-                Ok(source) => source,
-                Err(error) => {
-                    warn!(%error, "failed to read document");
-                    return Ok(None);
-                }
+            let contents = { vfs.read().get_file_contents(&vfs_path).cloned() };
+            let task = if let Some(rope) = contents {
+                tokio::task::spawn_blocking(move || {
+                    crate::folding_range::folding_ranges_from_rope(rope)
+                })
+            } else {
+                let source = match tokio::fs::read_to_string(path).await {
+                    Ok(source) => source,
+                    Err(error) => {
+                        warn!(%error, "failed to read document");
+                        return Ok(None);
+                    }
+                };
+                tokio::task::spawn_blocking(move || crate::folding_range::folding_ranges(source))
             };
-            tokio::task::spawn_blocking(move || crate::folding_range::folding_ranges(source))
+            task.await.map_err(folding_range_task_failed)?
         };
-        let ranges = task.await.map_err(folding_range_task_failed)?;
         Ok(Some(ranges))
     }
 }

--- a/crates/lsp/src/handlers/reqs.rs
+++ b/crates/lsp/src/handlers/reqs.rs
@@ -110,17 +110,22 @@ pub(crate) fn folding_range(
 
     async move {
         let Some((vfs_path, path)) = request else { return Ok(None) };
-        let source = match document_contents(&vfs, &vfs_path, &path).await {
-            Ok(source) => source,
-            Err(error) => {
-                warn!(%error, "failed to read document");
-                return Ok(None);
-            }
-        };
-        let ranges =
+        let contents = { vfs.read().get_file_contents(&vfs_path).cloned() };
+        let task = if let Some(rope) = contents {
+            tokio::task::spawn_blocking(move || {
+                crate::folding_range::folding_ranges_from_rope(rope)
+            })
+        } else {
+            let source = match tokio::fs::read_to_string(path).await {
+                Ok(source) => source,
+                Err(error) => {
+                    warn!(%error, "failed to read document");
+                    return Ok(None);
+                }
+            };
             tokio::task::spawn_blocking(move || crate::folding_range::folding_ranges(source))
-                .await
-                .map_err(folding_range_task_failed)?;
+        };
+        let ranges = task.await.map_err(folding_range_task_failed)?;
         Ok(Some(ranges))
     }
 }

--- a/crates/lsp/src/lib.rs
+++ b/crates/lsp/src/lib.rs
@@ -356,6 +356,20 @@ pub use global_state::benchmark::{
     BenchmarkWorkspaceReports,
 };
 
+/// Runs the folding-range kernel for Criterion benchmarks.
+#[cfg(feature = "bench")]
+#[doc(hidden)]
+pub fn benchmark_folding_ranges(source: String) -> Vec<lsp_types::FoldingRange> {
+    folding_range::folding_ranges(source)
+}
+
+/// Runs the open-document folding-range kernel for Criterion benchmarks.
+#[cfg(feature = "bench")]
+#[doc(hidden)]
+pub fn benchmark_folding_ranges_from_rope(source: crop::Rope) -> Vec<lsp_types::FoldingRange> {
+    folding_range::folding_ranges_from_rope(source)
+}
+
 /// Runs the selection-range kernel for Criterion benchmarks.
 #[cfg(feature = "bench")]
 #[doc(hidden)]

--- a/crates/lsp/src/lib.rs
+++ b/crates/lsp/src/lib.rs
@@ -351,9 +351,10 @@ mod workspace;
 #[doc(hidden)]
 pub use global_state::benchmark::{
     BenchmarkAnalysis, BenchmarkDocumentChange, BenchmarkDocumentUpdate, BenchmarkEdit,
-    BenchmarkError, BenchmarkOpenDocuments, BenchmarkProject, BenchmarkRepeatedAnalysis,
-    BenchmarkRequest, BenchmarkResponse, BenchmarkSelectionRangeRequests,
-    BenchmarkWorkspaceDiscovery, BenchmarkWorkspacePathQueries, BenchmarkWorkspaceReports,
+    BenchmarkError, BenchmarkFoldingRangeRequests, BenchmarkOpenDocuments, BenchmarkProject,
+    BenchmarkRepeatedAnalysis, BenchmarkRequest, BenchmarkResponse,
+    BenchmarkSelectionRangeRequests, BenchmarkWorkspaceDiscovery, BenchmarkWorkspacePathQueries,
+    BenchmarkWorkspaceReports,
 };
 
 /// Runs the folding-range kernel for Criterion benchmarks.

--- a/crates/lsp/src/proto.rs
+++ b/crates/lsp/src/proto.rs
@@ -187,17 +187,20 @@ impl<R: Borrow<Rope>> LspPositionIndex<R> {
 
     pub(crate) fn position_at_byte(&self, byte: usize) -> Option<lsp_types::Position> {
         let rope = self.rope();
+        let line = self.line_at_byte(byte)?;
+        let start = self.line_starts[line];
+        let character =
+            rope.byte_slice(start..byte).chars().map(|ch| ch.len_utf16()).sum::<usize>();
+        Some(lsp_types::Position::new(u32::try_from(line).ok()?, u32::try_from(character).ok()?))
+    }
+
+    pub(crate) fn line_at_byte(&self, byte: usize) -> Option<usize> {
+        let rope = self.rope();
         if byte > rope.byte_len() || !rope.is_char_boundary(byte) {
             return None;
         }
         let line = self.line_starts.partition_point(|&start| start <= byte).checked_sub(1)?;
-        let start = self.line_starts[line];
-        if byte > self.line_end(line) {
-            return None;
-        }
-        let character =
-            rope.byte_slice(start..byte).chars().map(|ch| ch.len_utf16()).sum::<usize>();
-        Some(lsp_types::Position::new(u32::try_from(line).ok()?, u32::try_from(character).ok()?))
+        (byte <= self.line_end(line)).then_some(line)
     }
 
     pub(crate) fn byte_len(&self) -> usize {

--- a/crates/lsp/src/tests/folding_range.rs
+++ b/crates/lsp/src/tests/folding_range.rs
@@ -1,5 +1,6 @@
 use super::support::RequestFixture;
-use crate::folding_range::folding_ranges;
+use crate::folding_range::{folding_ranges, folding_ranges_from_rope};
+use crop::Rope;
 use lsp_types::{FoldingRange, FoldingRangeKind, Url};
 use snapbox::{assert_data_eq, str};
 use std::fmt::Write as _;
@@ -551,6 +552,35 @@ fn uses_utf16_positions_and_crlf_line_endings() {
 
 "#]],
     );
+}
+
+#[test]
+fn rope_snapshot_matches_string_folding_ranges() {
+    let source = "contract C {\n    function f() external {\n    }\n}\n";
+    assert_eq!(folding_ranges_from_rope(Rope::from(source)), folding_ranges(source.into()));
+}
+
+#[test]
+fn single_line_sources_have_no_folding_ranges() {
+    let source = "contract C { function f() external {} }";
+    assert!(folding_ranges(source.to_owned()).is_empty());
+    assert!(folding_ranges_from_rope(Rope::from(source)).is_empty());
+}
+
+#[test]
+fn folding_respects_lsp_line_breaks() {
+    for newline in ["\n", "\r\n", "\r"] {
+        for (source, expected) in [
+            (format!("contract C {{{newline}"), "0:0-1:0 code\n"),
+            (format!("/*{newline}"), "0:0-1:0 comment\n"),
+            (format!("contract C {{{newline}}}{newline}"), "0:0-1:1 code\n"),
+            (format!("/* first{newline}second */"), "0:0-1:9 comment\n"),
+        ] {
+            let rope = Rope::from(source.as_str());
+            assert_data_eq!(folding_range_output(&folding_ranges(source)), expected);
+            assert_data_eq!(folding_range_output(&folding_ranges_from_rope(rope)), expected);
+        }
+    }
 }
 
 fn folding_range_output(ranges: &[FoldingRange]) -> String {

--- a/crates/lsp/src/vfs/fs.rs
+++ b/crates/lsp/src/vfs/fs.rs
@@ -25,6 +25,7 @@
 use super::VfsPath;
 use crate::{
     file_operations::{FileMoveBatch, FileMoveError},
+    folding_range,
     selection_range::SelectionRangeIndex,
 };
 use crop::Rope;
@@ -41,11 +42,17 @@ struct VfsFile {
     contents: Rope,
     analysis_source: OnceLock<Arc<String>>,
     selection_range_index: OnceLock<SelectionRangeIndex>,
+    folding_ranges: OnceLock<Vec<lsp_types::FoldingRange>>,
 }
 
 impl VfsFile {
     fn new(contents: Rope) -> Self {
-        Self { contents, analysis_source: OnceLock::new(), selection_range_index: OnceLock::new() }
+        Self {
+            contents,
+            analysis_source: OnceLock::new(),
+            selection_range_index: OnceLock::new(),
+            folding_ranges: OnceLock::new(),
+        }
     }
 
     fn analysis_source(&self) -> Arc<String> {
@@ -74,6 +81,19 @@ impl SelectionRangeSource {
 
     pub(crate) fn selection_ranges(&self, positions: &[Position]) -> Option<Vec<SelectionRange>> {
         self.index().selection_ranges(positions)
+    }
+}
+
+/// An exact-content handle whose folding ranges are parsed at most once.
+#[derive(Clone)]
+pub(crate) struct FoldingRangeSource(Arc<VfsFile>);
+
+impl FoldingRangeSource {
+    pub(crate) fn folding_ranges(&self) -> Vec<lsp_types::FoldingRange> {
+        self.0
+            .folding_ranges
+            .get_or_init(|| folding_range::folding_ranges(self.0.contents.to_string()))
+            .clone()
     }
 }
 
@@ -148,6 +168,13 @@ impl Vfs {
         path: &VfsPath,
     ) -> Option<SelectionRangeSource> {
         self.data.get(path).cloned().map(SelectionRangeSource)
+    }
+
+    pub(crate) fn get_file_folding_range_source(
+        &self,
+        path: &VfsPath,
+    ) -> Option<FoldingRangeSource> {
+        self.data.get(path).cloned().map(FoldingRangeSource)
     }
 
     pub(crate) fn get_file_version(&self, path: &VfsPath) -> Option<i32> {
@@ -381,6 +408,37 @@ mod tests {
         ));
         let changed_source = vfs.get_file_selection_range_source(&file).unwrap();
         let changed = changed_source.index();
+        assert!(!std::ptr::eq(first, changed));
+    }
+
+    #[test]
+    fn folding_ranges_are_cached_until_contents_change() {
+        let mut vfs = Vfs::default();
+        let file = path("/workspace/Test.sol");
+        insert(&mut vfs, "/workspace/Test.sol", "contract Test {\n}\n", 1);
+
+        let first_source = vfs.get_file_folding_range_source(&file).unwrap();
+        let first = first_source
+            .0
+            .folding_ranges
+            .get_or_init(|| folding_range::folding_ranges(first_source.0.contents.to_string()));
+        let cached_source = vfs.get_file_folding_range_source(&file).unwrap();
+        let cached = cached_source
+            .0
+            .folding_ranges
+            .get_or_init(|| folding_range::folding_ranges(cached_source.0.contents.to_string()));
+        assert!(std::ptr::eq(first, cached));
+
+        assert!(vfs.set_file_contents_with_version(
+            file.clone(),
+            Some(Rope::from("contract Changed {\n}\n")),
+            Some(2),
+        ));
+        let changed_source = vfs.get_file_folding_range_source(&file).unwrap();
+        let changed = changed_source
+            .0
+            .folding_ranges
+            .get_or_init(|| folding_range::folding_ranges(changed_source.0.contents.to_string()));
         assert!(!std::ptr::eq(first, changed));
     }
 


### PR DESCRIPTION
Towards OSS-738

- Reuse the Rope snapshot held for open documents.
- Skip parsing for single-line sources, while keeping lexical fallback for parse errors, incomplete input, and CR/LF line endings.
- Cache computed folding ranges per immutable VFS snapshot. Content changes replace the snapshot and invalidate the cache; repeated requests reuse the parsed result.
- Add a repeated open-document benchmark and cache invalidation coverage.

Benchmark (Criterion):

The first four rows are cold, one-shot requests and retain the original PR measurements. The last row isolates the cache effect on repeated requests.

| Workload | Baseline | PR | Change |
| --- | ---: | ---: | ---: |
| clean | 66.085 ms | 52.965 ms | -19.85% |
| incomplete | 1.299 ms | 0.986 ms | -24.12% |
| minified (36,797 B) | 96.085 ms | 21.145 µs | -99.978% |
| open-clean-snapshot | 66.551 ms | 52.770 ms | -20.71% |
| unchanged open document | 55.315 ms* | 26.6 µs | -99.952% |

\* The baseline for the last row uses the same PR workload with result caching disabled, so it isolates the cache effect from the other folding-range changes.
