### PR TITLE
perf(lsp): reduce query work and index memory

### DIFF
--- a/crates/lsp/benches/lsp.rs
+++ b/crates/lsp/benches/lsp.rs
@@ -127,6 +127,17 @@ fn analysis_build(c: &mut Criterion) {
             },
         );
     }
+    let call = "function_0000(1, 2, address(0));";
+    let source = benchmark_source(1).source.replace(call, &call.repeat(256));
+    assert_clean(&BenchmarkAnalysis::from_source(source.clone()));
+    group.throughput(Throughput::Bytes(source.len() as u64));
+    group.bench_function(BenchmarkId::from_parameter("repeated-calls"), |b| {
+        b.iter_batched(
+            || source.clone(),
+            |source| black_box(BenchmarkAnalysis::from_source(black_box(source))),
+            BatchSize::PerIteration,
+        );
+    });
     group.finish();
 }
 

--- a/crates/lsp/benches/lsp.rs
+++ b/crates/lsp/benches/lsp.rs
@@ -130,6 +130,38 @@ fn analysis_build(c: &mut Criterion) {
     group.finish();
 }
 
+fn completion_queries(c: &mut Criterion) {
+    let fixture = benchmark_source(HOVER_FUNCTION_COUNT);
+    let (uri, position) =
+        fixture.project.unique_anchor("benchmark.sol", "function_0255(1, 2, address(0))").unwrap();
+    let analysis = fixture.project.analyze();
+    assert_clean(&analysis);
+    let mut group = c.benchmark_group("lsp/completion");
+    for (name, prefix) in
+        [("all", ""), ("selective", "function_0255"), ("no-match", "not_a_symbol")]
+    {
+        let items = analysis.completions(&uri, position, prefix);
+        match name {
+            "all" => assert!(items.len() >= HOVER_FUNCTION_COUNT),
+            "selective" => assert_eq!(
+                items.iter().map(|item| item.label.as_str()).collect::<Vec<_>>(),
+                ["function_0255"]
+            ),
+            _ => assert!(items.is_empty()),
+        }
+        group.bench_function(BenchmarkId::from_parameter(name), |b| {
+            b.iter(|| {
+                black_box(analysis.completions(
+                    black_box(&uri),
+                    black_box(position),
+                    black_box(prefix),
+                ))
+            });
+        });
+    }
+    group.finish();
+}
+
 fn bounded_workspace_discovery(c: &mut Criterion) {
     let temp = tempfile::tempdir().expect("benchmark temporary directory");
     let project = temp.path().join("project");
@@ -654,6 +686,7 @@ fn unifap_benches(c: &mut Criterion) {
 criterion_group!(
     benches,
     analysis_build,
+    completion_queries,
     bounded_workspace_discovery,
     symbol_table_aggregation,
     burst_hover,

--- a/crates/lsp/benches/lsp.rs
+++ b/crates/lsp/benches/lsp.rs
@@ -11,7 +11,7 @@ use solar_lsp::{
     BenchmarkOpenDocuments, BenchmarkProject, BenchmarkRepeatedAnalysis, BenchmarkRequest,
     BenchmarkResponse, BenchmarkSelectionRangeRequests, BenchmarkWorkspaceDiscovery,
     BenchmarkWorkspacePathQueries, BenchmarkWorkspaceReports, benchmark_folding_ranges,
-    benchmark_folding_ranges_from_rope, benchmark_selection_ranges,
+    benchmark_folding_ranges_from_rope, benchmark_import_path_at, benchmark_selection_ranges,
 };
 use std::{fs, hint::black_box, path::PathBuf};
 
@@ -127,6 +127,18 @@ fn analysis_build(c: &mut Criterion) {
             },
         );
     }
+    group.finish();
+}
+
+fn import_path_queries(c: &mut Criterion) {
+    let mut group = c.benchmark_group("lsp/import-path");
+    let cursor = OPTIMISM_SOURCE.rfind('}').unwrap();
+    assert!(!benchmark_import_path_at(OPTIMISM_SOURCE, cursor));
+    group.bench_function(BenchmarkId::from_parameter("optimism-code"), |b| {
+        b.iter(|| {
+            black_box(benchmark_import_path_at(black_box(OPTIMISM_SOURCE), black_box(cursor)))
+        });
+    });
     group.finish();
 }
 
@@ -687,6 +699,7 @@ criterion_group!(
     benches,
     analysis_build,
     completion_queries,
+    import_path_queries,
     bounded_workspace_discovery,
     symbol_table_aggregation,
     burst_hover,

--- a/crates/lsp/benches/lsp.rs
+++ b/crates/lsp/benches/lsp.rs
@@ -495,6 +495,12 @@ fn repeated_analysis(c: &mut Criterion) {
     cached.bench_function(BenchmarkId::from_parameter("unchanged"), |b| {
         b.iter(|| black_box(analysis.run()))
     });
+    cached.bench_function(BenchmarkId::from_parameter("reverted-edit"), |b| {
+        b.iter(|| {
+            analysis.edit_and_revert();
+            black_box(analysis.run())
+        });
+    });
     cached.finish();
 }
 

--- a/crates/lsp/src/global_state.rs
+++ b/crates/lsp/src/global_state.rs
@@ -267,6 +267,14 @@ struct CachedAnalysisOutput {
     vfs_content_revision: u64,
     config: Arc<Config>,
     output: AnalysisOutput<Arc<SymbolTables>>,
+    inputs: Vec<AnalysisBatchInputs>,
+}
+
+/// Exact analysis roots and overlays, excluding client document versions.
+#[derive(Clone)]
+struct AnalysisBatchInputs {
+    files: Vec<(PathBuf, Arc<String>)>,
+    preloaded_files: Vec<(PathBuf, Arc<String>)>,
 }
 
 impl AnalysisCommitState {
@@ -1630,6 +1638,44 @@ fn run_analysis(
         return AnalysisTaskOutcome::Superseded;
     }
 
+    if !has_disk_paths && source_files_complete {
+        let cached = {
+            let mut commit = snapshot.analysis_commit.lock();
+            if !commit.cache_invalidated
+                && let Some(cached) = &mut commit.cached_output
+                && Arc::ptr_eq(&cached.config, &config)
+                && cached.inputs.len() == batches.len()
+                && cached.inputs.iter().zip(&batches).all(|(inputs, batch)| {
+                    inputs.files == batch.files && inputs.preloaded_files == batch.preloaded_files
+                })
+            {
+                cached.vfs_content_revision = vfs_content_revision;
+                Some(cached.output.clone())
+            } else {
+                None
+            }
+        };
+        if let Some(output) = cached {
+            progress.report("Reusing workspace index");
+            return if snapshot.publish_analysis_output(version, output) {
+                AnalysisTaskOutcome::Published
+            } else {
+                AnalysisTaskOutcome::Superseded
+            };
+        }
+    }
+
+    let inputs = if has_disk_paths {
+        Vec::new()
+    } else {
+        batches
+            .iter()
+            .map(|batch| AnalysisBatchInputs {
+                files: batch.files.clone(),
+                preloaded_files: batch.preloaded_files.clone(),
+            })
+            .collect::<Vec<_>>()
+    };
     let mut results = AnalysisOutputAccumulator::default();
 
     for batch in batches {
@@ -1653,8 +1699,12 @@ fn run_analysis(
 
     let output = results.finish().into_shared();
     if !has_disk_paths {
-        snapshot.analysis_commit.lock().cached_output =
-            Some(CachedAnalysisOutput { vfs_content_revision, config, output: output.clone() });
+        snapshot.analysis_commit.lock().cached_output = Some(CachedAnalysisOutput {
+            vfs_content_revision,
+            config,
+            output: output.clone(),
+            inputs,
+        });
     }
     progress.report("Publishing workspace index");
     if snapshot.publish_analysis_output(version, output) {

--- a/crates/lsp/src/global_state.rs
+++ b/crates/lsp/src/global_state.rs
@@ -97,6 +97,12 @@ struct AnalysisPathIndex {
 }
 
 impl AnalysisPathIndex {
+    fn is_empty(&self) -> bool {
+        self.resolved_dependencies.is_empty()
+            && self.existing_unresolved_candidates.is_empty()
+            && self.missing_candidates.is_empty()
+    }
+
     fn merge(&mut self, other: Self) {
         self.resolved_dependencies.extend(other.resolved_dependencies);
         self.existing_unresolved_candidates.extend(other.existing_unresolved_candidates);
@@ -1205,6 +1211,8 @@ impl GlobalState {
             let progress = self.analysis_progress.reserve(version);
             if refresh_pull_results {
                 commit.begin_external_refresh();
+                // Keep invalidation even if a later request cancels the debounced worker.
+                commit.cached_output = None;
             }
             self.commit_analysis_epoch(&mut commit, version, changed_paths, rediscover);
             let update =
@@ -1644,6 +1652,8 @@ fn run_analysis(
             if !commit.cache_invalidated
                 && let Some(cached) = &mut commit.cached_output
                 && Arc::ptr_eq(&cached.config, &config)
+                // The compared batches do not include disk-only imports or resolver probes.
+                && cached.output.analysis_paths.is_empty()
                 && cached.inputs.len() == batches.len()
                 && cached.inputs.iter().zip(&batches).all(|(inputs, batch)| {
                     inputs.files == batch.files && inputs.preloaded_files == batch.preloaded_files
@@ -1699,12 +1709,15 @@ fn run_analysis(
 
     let output = results.finish().into_shared();
     if !has_disk_paths {
-        snapshot.analysis_commit.lock().cached_output = Some(CachedAnalysisOutput {
-            vfs_content_revision,
-            config,
-            output: output.clone(),
-            inputs,
-        });
+        let mut commit = snapshot.analysis_commit.lock();
+        if snapshot.is_current(version) && !commit.cache_invalidated {
+            commit.cached_output = Some(CachedAnalysisOutput {
+                vfs_content_revision,
+                config,
+                output: output.clone(),
+                inputs: if output.analysis_paths.is_empty() { inputs } else { Vec::new() },
+            });
+        }
     }
     progress.report("Publishing workspace index");
     if snapshot.publish_analysis_output(version, output) {

--- a/crates/lsp/src/global_state/benchmark.rs
+++ b/crates/lsp/src/global_state/benchmark.rs
@@ -529,6 +529,17 @@ impl BenchmarkRepeatedAnalysis {
         Self { state, version }
     }
 
+    /// Advance the VFS revision through an edit and undo before analysis begins.
+    pub fn edit_and_revert(&mut self) {
+        let mut vfs = self.state.vfs.write();
+        let (path, source) =
+            vfs.iter().next().map(|(path, source)| (path.clone(), source.clone())).unwrap();
+        let mut edited = source.clone();
+        edited.insert(0, " ");
+        vfs.set_file_contents(path.clone(), Some(edited));
+        vfs.set_file_contents(path, Some(source));
+    }
+
     /// Run one production analysis epoch, returning whether it published successfully.
     #[inline(never)]
     pub fn run(&mut self) -> bool {

--- a/crates/lsp/src/global_state/benchmark.rs
+++ b/crates/lsp/src/global_state/benchmark.rs
@@ -9,6 +9,7 @@ use crate::{
     diagnostics::{AnalyzedDocuments, DiagnosticStore, PullReport},
     handlers,
     project_fixture::ProjectFixture,
+    symbols::CompletionContext,
     utils::apply_document_changes,
     vfs::VfsPath,
     workspace::{
@@ -20,9 +21,9 @@ use crate::{
 use async_lsp::ClientSocket;
 use crop::Rope;
 use lsp_types::{
-    Diagnostic, DidChangeTextDocumentParams, GotoDefinitionResponse, Hover, HoverContents,
-    Location, Position, PreviousResultId, Range, TextDocumentContentChangeEvent, Url,
-    VersionedTextDocumentIdentifier, WorkspaceFolder, WorkspaceSymbol,
+    CompletionItem, Diagnostic, DidChangeTextDocumentParams, GotoDefinitionResponse, Hover,
+    HoverContents, Location, Position, PreviousResultId, Range, TextDocumentContentChangeEvent,
+    Url, VersionedTextDocumentIdentifier, WorkspaceFolder, WorkspaceSymbol,
 };
 use normalize_path::NormalizePath;
 use solar_config::{CompileOpts, Threads};
@@ -863,6 +864,12 @@ impl BenchmarkAnalysis {
                 BenchmarkResponse::WorkspaceSymbols(self.symbol_tables.workspace_symbols(query))
             }
         }
+    }
+
+    /// Complete names at a source position without protocol transport or parsing.
+    #[inline(never)]
+    pub fn completions(&self, uri: &Url, position: Position, prefix: &str) -> Vec<CompletionItem> {
+        self.symbol_tables.completion_items(uri, position, CompletionContext::new(prefix, None))
     }
 
     /// Resolve one declaration or reference position synchronously.

--- a/crates/lsp/src/import_resolution.rs
+++ b/crates/lsp/src/import_resolution.rs
@@ -39,6 +39,8 @@ pub(crate) fn import_path_at(source: &str, cursor: usize) -> Option<ImportPathAt
         return None;
     }
 
+    // Import paths are plain strings; code navigation does not need a full-file parse.
+    plain_string_at(source, cursor)?;
     parse_import_path(source, cursor)
 }
 

--- a/crates/lsp/src/import_resolution/tests/path.rs
+++ b/crates/lsp/src/import_resolution/tests/path.rs
@@ -1,4 +1,4 @@
-use super::super::{import_path_at, import_path_at_for_completion};
+use super::super::{import_path_at, import_path_at_for_completion, parse_import_path};
 
 #[test]
 fn completion_recovers_an_unterminated_import_before_an_unrelated_string() {
@@ -40,7 +40,7 @@ fn completion_does_not_recover_past_an_unescaped_line_break() {
 }
 
 #[test]
-fn completion_matches_parser_import_ranges_at_every_boundary() {
+fn valid_import_paths_match_parser_at_every_boundary() {
     for source in [
         r#"import "./Dep.sol"; contract C { string s = "ordinary"; }"#,
         "import {Dep as Alias} from './Dep.sol'; // import './Fake.sol';",
@@ -49,10 +49,25 @@ fn completion_matches_parser_import_ranges_at_every_boundary() {
         r#"contract C { string s = unicode"./Dep.sol"; bytes s2 = hex"abcd"; }"#,
     ] {
         for cursor in (0..=source.len()).filter(|&cursor| source.is_char_boundary(cursor)) {
+            let expected = parse_import_path(source, cursor);
+            assert_eq!(import_path_at(source, cursor), expected, "cursor {cursor} in {source}");
             assert_eq!(
                 import_path_at_for_completion(source, cursor),
-                import_path_at(source, cursor),
+                expected,
                 "cursor {cursor} in {source}",
+            );
+        }
+    }
+}
+
+#[test]
+fn definition_matches_parser_import_ranges_at_every_boundary() {
+    for source in [r#"import "./Dep" "suffix";"#, r#"import "./Dep"#] {
+        for cursor in (0..=source.len()).filter(|&cursor| source.is_char_boundary(cursor)) {
+            assert_eq!(
+                import_path_at(source, cursor),
+                parse_import_path(source, cursor),
+                "cursor {cursor} in {source}"
             );
         }
     }

--- a/crates/lsp/src/lib.rs
+++ b/crates/lsp/src/lib.rs
@@ -357,6 +357,13 @@ pub use global_state::benchmark::{
     BenchmarkWorkspaceReports,
 };
 
+/// Checks whether a source position belongs to a parsed import path.
+#[cfg(feature = "bench")]
+#[doc(hidden)]
+pub fn benchmark_import_path_at(source: &str, cursor: usize) -> bool {
+    import_resolution::import_path_at(source, cursor).is_some()
+}
+
 /// Runs the folding-range kernel for Criterion benchmarks.
 #[cfg(feature = "bench")]
 #[doc(hidden)]

--- a/crates/lsp/src/rename.rs
+++ b/crates/lsp/src/rename.rs
@@ -77,7 +77,7 @@ pub(crate) struct RenameIndex {
     yul_symbol_targets: FxHashSet<SymbolId>,
     occurrences: Vec<RenameOccurrence>,
     file_occurrences: FxHashMap<Url, Vec<usize>>,
-    target_occurrences: FxHashMap<RenameTarget, Vec<Location>>,
+    target_occurrences: FxHashMap<RenameTarget, Vec<usize>>,
     ambiguous_targets: FxHashSet<RenameTarget>,
 }
 
@@ -557,7 +557,7 @@ impl RenameIndex {
             .iter()
             .filter_map(|target| self.target_occurrences.get(target))
             .flatten()
-            .cloned()
+            .map(|&index| self.occurrences[index].location.clone())
             .collect::<Vec<_>>();
         sort_locations(&mut locations);
         locations.dedup_by(|a, b| a.uri == b.uri && a.range == b.range);
@@ -649,16 +649,8 @@ impl RenameIndex {
                 self.ambiguous_targets.extend(occurrence.targets.iter().copied());
             }
             for &target in &occurrence.targets {
-                self.target_occurrences
-                    .entry(target)
-                    .or_default()
-                    .push(occurrence.location.clone());
+                self.target_occurrences.entry(target).or_default().push(index);
             }
-        }
-
-        for locations in self.target_occurrences.values_mut() {
-            sort_locations(locations);
-            locations.dedup_by(|a, b| a.uri == b.uri && a.range == b.range);
         }
     }
 

--- a/crates/lsp/src/signature_help.rs
+++ b/crates/lsp/src/signature_help.rs
@@ -15,9 +15,9 @@ use solar_sema::{
     Gcx,
     builtins::Builtin,
     hir::{self, CallArgs, FunctionKind, ItemId, NatSpecKind, Res, StateMutability, Visit},
-    ty::{CallableParamSource, CallableSignature, TyKind},
+    ty::{CallableParamSource, CallableSignature, Ty, TyKind},
 };
-use std::{fmt::Write, ops::ControlFlow, sync::Arc};
+use std::{borrow::Cow, fmt::Write, ops::ControlFlow, sync::Arc};
 
 #[derive(Clone, Debug, Default)]
 pub(crate) struct SignatureHelpIndex {
@@ -66,9 +66,16 @@ struct ActiveArgument<'a> {
 impl SignatureHelpIndex {
     pub(crate) fn build(gcx: Gcx<'_>, locations: &proto::LocationConverter) -> Self {
         let mut index = Self::default();
-        index.build_callable_catalog(gcx, locations);
-        let mut collector =
-            CallCollector { index: &mut index, locations, gcx, source: None, contract: None };
+        let mut renderer = SignatureRenderer { gcx, signatures: FxHashMap::default() };
+        index.build_callable_catalog(&mut renderer, locations);
+        let mut collector = CallCollector {
+            index: &mut index,
+            renderer: &mut renderer,
+            locations,
+            gcx,
+            source: None,
+            contract: None,
+        };
         for source_id in gcx.hir.source_ids() {
             collector.source = Some(source_id);
             collector.contract = None;
@@ -84,7 +91,7 @@ impl SignatureHelpIndex {
         for (uri, mut calls) in other.calls {
             for call in &mut calls {
                 for signature in &mut call.signatures {
-                    *signature = self.intern_shared_signature(signature.clone());
+                    *signature = self.intern_signature(signature.clone());
                 }
             }
             let destination = self.calls.entry(uri).or_default();
@@ -93,12 +100,7 @@ impl SignatureHelpIndex {
         }
         for (name, entries) in other.callables_by_name {
             for entry in entries {
-                self.push_shared_callable(
-                    name.clone(),
-                    entry.location,
-                    entry.form,
-                    entry.signature,
-                );
+                self.push_callable(name.clone(), entry.location, entry.form, entry.signature);
             }
         }
     }
@@ -185,10 +187,15 @@ impl SignatureHelpIndex {
         Some(SignatureHelp { signatures, active_signature: Some(0), active_parameter })
     }
 
-    fn build_callable_catalog(&mut self, gcx: Gcx<'_>, locations: &proto::LocationConverter) {
+    fn build_callable_catalog(
+        &mut self,
+        renderer: &mut SignatureRenderer<'_>,
+        locations: &proto::LocationConverter,
+    ) {
+        let gcx = renderer.gcx;
         for item_id in gcx.hir.item_ids() {
             if let Some(name) = gcx.hir.item(item_id).name()
-                && let Some(signature) = render_item(gcx, item_id)
+                && let Some(signature) = renderer.render_item(item_id)
             {
                 let Some(location) = locations.location(gcx.hir.item(item_id).span()) else {
                     continue;
@@ -203,7 +210,7 @@ impl SignatureHelpIndex {
             }
         }
         for builtin in Builtin::global() {
-            if let Some(signature) = render_res(gcx, Res::Builtin(builtin)) {
+            if let Some(signature) = renderer.render_res(Res::Builtin(builtin)) {
                 self.push_callable(builtin.name().to_string(), None, CallForm::Regular, signature);
             }
         }
@@ -214,19 +221,9 @@ impl SignatureHelpIndex {
         name: String,
         location: Option<Location>,
         form: CallForm,
-        signature: CallSignature,
-    ) {
-        self.push_shared_callable(name, location, form, Arc::new(signature));
-    }
-
-    fn push_shared_callable(
-        &mut self,
-        name: String,
-        location: Option<Location>,
-        form: CallForm,
         signature: Arc<CallSignature>,
     ) {
-        let signature = self.intern_shared_signature(signature);
+        let signature = self.intern_signature(signature);
         let entries = self.callables_by_name.entry(name).or_default();
         if !entries.iter().any(|entry| {
             entry.location == location && entry.form == form && entry.signature == signature
@@ -242,7 +239,7 @@ impl SignatureHelpIndex {
         args: &CallArgs<'_>,
         callee_span: Span,
         form: CallForm,
-        signatures: Vec<CallSignature>,
+        signatures: Vec<Arc<CallSignature>>,
     ) {
         if args.is_dummy() || signatures.is_empty() {
             return;
@@ -267,11 +264,7 @@ impl SignatureHelpIndex {
         });
     }
 
-    fn intern_signature(&mut self, signature: CallSignature) -> Arc<CallSignature> {
-        self.intern_shared_signature(Arc::new(signature))
-    }
-
-    fn intern_shared_signature(&mut self, signature: Arc<CallSignature>) -> Arc<CallSignature> {
+    fn intern_signature(&mut self, signature: Arc<CallSignature>) -> Arc<CallSignature> {
         let candidates =
             self.signatures_by_label.entry(signature.information.label.clone()).or_default();
         if let Some(existing) =
@@ -344,6 +337,7 @@ impl CallSignature {
 }
 
 struct CallCollector<'a, 'gcx> {
+    renderer: &'a mut SignatureRenderer<'gcx>,
     index: &'a mut SignatureHelpIndex,
     locations: &'a proto::LocationConverter,
     gcx: Gcx<'gcx>,
@@ -376,7 +370,7 @@ impl<'gcx> CallCollector<'_, 'gcx> {
         };
         let callee_span = callee.span.with_hi(args.span.lo());
         let selected = self.gcx.resolved_callee(callee.id);
-        let mut candidates = Vec::<(bool, CallSignature)>::new();
+        let mut candidates = Vec::<(bool, Arc<CallSignature>)>::new();
 
         match callee.kind {
             hir::ExprKind::Ident(resolutions) => {
@@ -384,7 +378,7 @@ impl<'gcx> CallCollector<'_, 'gcx> {
                     if matches!(res, Res::Item(ItemId::Contract(_))) {
                         continue;
                     }
-                    if let Some(signature) = render_res(self.gcx, res) {
+                    if let Some(signature) = self.renderer.render_res(res) {
                         candidates.push((selected.is_some_and(|it| it.res == res), signature));
                     }
                 }
@@ -416,9 +410,11 @@ impl<'gcx> CallCollector<'_, 'gcx> {
                         let is_selected = selected.is_some_and(|selected| {
                             member.res == Some(selected.res) && member.attached == selected.attached
                         });
-                        if let Some(signature) =
-                            render_callable(self.gcx, callable, member.res, Some(name.to_string()))
-                        {
+                        if let Some(signature) = self.renderer.render_callable(
+                            callable,
+                            member.res,
+                            Some(Cow::Borrowed(name.name.as_str_in(self.gcx.sess))),
+                        ) {
                             candidates.push((is_selected, signature));
                         }
                     }
@@ -428,13 +424,13 @@ impl<'gcx> CallCollector<'_, 'gcx> {
                 let signature = if let hir::ExprKind::New(ref ty) = callee.kind
                     && let TyKind::Contract(id) = self.gcx.type_of_hir_ty(ty).kind
                 {
-                    render_item(self.gcx, ItemId::Contract(id))
+                    self.renderer.render_item(ItemId::Contract(id))
                 } else if let Some(ty) = callee_ty
                     && let Some(callable) = self.gcx.callable_signature_of_ty(ty)
                 {
                     let fallback_name =
                         self.gcx.sess.source_map().span_to_snippet(callee.span).ok();
-                    render_callable(self.gcx, callable, None, fallback_name)
+                    self.renderer.render_callable(callable, None, fallback_name.map(Cow::Owned))
                 } else {
                     None
                 };
@@ -447,7 +443,7 @@ impl<'gcx> CallCollector<'_, 'gcx> {
         candidates.sort_by_key(|(selected, _)| !selected);
         let mut signatures = Vec::with_capacity(candidates.len());
         for (_, signature) in candidates {
-            if !signatures.iter().any(|existing: &CallSignature| {
+            if !signatures.iter().any(|existing: &Arc<CallSignature>| {
                 existing.information.label == signature.information.label
             }) {
                 signatures.push(signature);
@@ -457,7 +453,7 @@ impl<'gcx> CallCollector<'_, 'gcx> {
     }
 
     fn collect_modifier(&mut self, modifier: &'gcx hir::Modifier<'gcx>) {
-        let Some(signature) = render_item(self.gcx, modifier.id) else { return };
+        let Some(signature) = self.renderer.render_item(modifier.id) else { return };
         self.index.push(
             self.gcx,
             self.locations,
@@ -499,44 +495,91 @@ impl<'gcx> Visit<'gcx> for CallCollector<'_, 'gcx> {
     }
 }
 
-fn render_res(gcx: Gcx<'_>, res: Res) -> Option<CallSignature> {
-    if let Res::Item(item_id) = res {
-        return render_item(gcx, item_id);
-    }
-    let callable = gcx.callable_signature_of_ty(gcx.type_of_res(res))?;
-    let fallback_name = match res {
-        Res::Builtin(builtin) => Some(builtin.name().to_string()),
-        Res::Item(item_id) => gcx.hir.item(item_id).name().map(|name| name.to_string()),
-        Res::Namespace(_) | Res::Err(_) => None,
-    };
-    render_callable(gcx, callable, Some(res), fallback_name)
+/// Render each compiler signature once per analysis, before interning the owned result.
+struct SignatureRenderer<'gcx> {
+    gcx: Gcx<'gcx>,
+    signatures: FxHashMap<SignatureKey<'gcx>, Option<Arc<CallSignature>>>,
 }
 
-fn render_item(gcx: Gcx<'_>, item_id: ItemId) -> Option<CallSignature> {
-    if let ItemId::Contract(id) = item_id {
-        let contract = gcx.hir.contract(id);
-        if let Some(constructor) = contract.ctor {
-            return render_item(gcx, ItemId::Function(constructor));
+#[derive(PartialEq, Eq, Hash)]
+struct SignatureKey<'gcx> {
+    parameters: &'gcx [Ty<'gcx>],
+    returns: &'gcx [Ty<'gcx>],
+    param_source: Option<CallableParamSource>,
+    res: Option<Res>,
+    fallback_name: Option<Cow<'gcx, str>>,
+}
+
+impl<'gcx> SignatureRenderer<'gcx> {
+    fn render_res(&mut self, res: Res) -> Option<Arc<CallSignature>> {
+        let gcx = self.gcx;
+        if let Res::Item(item_id) = res {
+            return self.render_item(item_id);
         }
-        return Some(CallSignature {
-            information: SignatureInformation {
-                label: "constructor()".into(),
-                documentation: None,
-                parameters: Some(Vec::new()),
-                active_parameter: None,
-            },
-            parameter_names: Vec::new(),
-            variadic: false,
-        });
+        let callable = gcx.callable_signature_of_ty(gcx.type_of_res(res))?;
+        let fallback_name = match res {
+            Res::Builtin(builtin) => Some(Cow::Borrowed(builtin.name().as_str_in(gcx.sess))),
+            Res::Item(item_id) => gcx
+                .hir
+                .item(item_id)
+                .name()
+                .map(|name| Cow::Borrowed(name.name.as_str_in(gcx.sess))),
+            Res::Namespace(_) | Res::Err(_) => None,
+        };
+        self.render_callable(callable, Some(res), fallback_name)
     }
 
-    let res = Res::Item(item_id);
-    let mut callable = gcx.callable_signature_of_ty(gcx.type_of_res(res))?;
-    if let ItemId::Variable(id) = item_id {
-        callable.param_source = Some(CallableParamSource::FunctionType(id));
+    fn render_item(&mut self, item_id: ItemId) -> Option<Arc<CallSignature>> {
+        let gcx = self.gcx;
+        if let ItemId::Contract(id) = item_id {
+            let contract = gcx.hir.contract(id);
+            if let Some(constructor) = contract.ctor {
+                return self.render_item(ItemId::Function(constructor));
+            }
+            return Some(Arc::new(CallSignature {
+                information: SignatureInformation {
+                    label: "constructor()".into(),
+                    documentation: None,
+                    parameters: Some(Vec::new()),
+                    active_parameter: None,
+                },
+                parameter_names: Vec::new(),
+                variadic: false,
+            }));
+        }
+
+        let res = Res::Item(item_id);
+        let mut callable = gcx.callable_signature_of_ty(gcx.type_of_res(res))?;
+        if let ItemId::Variable(id) = item_id {
+            callable.param_source = Some(CallableParamSource::FunctionType(id));
+        }
+        let fallback_name =
+            gcx.hir.item(item_id).name().map(|name| Cow::Borrowed(name.name.as_str_in(gcx.sess)));
+        self.render_callable(callable, Some(res), fallback_name)
     }
-    let fallback_name = gcx.hir.item(item_id).name().map(|name| name.to_string());
-    render_callable(gcx, callable, Some(res), fallback_name)
+
+    fn render_callable(
+        &mut self,
+        callable: CallableSignature<'gcx>,
+        res: Option<Res>,
+        fallback_name: Option<Cow<'gcx, str>>,
+    ) -> Option<Arc<CallSignature>> {
+        let key = SignatureKey {
+            parameters: callable.parameters,
+            returns: callable.returns,
+            param_source: callable.param_source,
+            res,
+            fallback_name,
+        };
+        let gcx = self.gcx;
+        self.signatures
+            .entry(key)
+            .or_insert_with_key(|key| {
+                render_callable(gcx, callable, res, key.fallback_name.clone().map(Cow::into_owned))
+                    .map(Arc::new)
+            })
+            .clone()
+    }
 }
 
 fn render_callable<'gcx>(
@@ -1037,10 +1080,11 @@ mod tests {
     #[test]
     fn extend_reinterns_callsite_signatures() {
         let mut destination = SignatureHelpIndex::default();
-        let canonical =
-            destination.intern_signature(test_signature("function f(uint256)", vec![None]));
+        let canonical = destination
+            .intern_signature(Arc::new(test_signature("function f(uint256)", vec![None])));
         let mut source = SignatureHelpIndex::default();
-        let duplicate = source.intern_signature(test_signature("function f(uint256)", vec![None]));
+        let duplicate =
+            source.intern_signature(Arc::new(test_signature("function f(uint256)", vec![None])));
         let uri = Url::parse("file:///Signature.sol").unwrap();
         source.calls.insert(
             uri.clone(),

--- a/crates/lsp/src/symbols.rs
+++ b/crates/lsp/src/symbols.rs
@@ -981,6 +981,9 @@ impl SymbolTables {
             return Vec::new();
         };
 
+        let prefix = completion_filter_prefix(context.prefix);
+        let matches_prefix =
+            |name: &str| prefix.as_ref().is_none_or(|prefix| fuzzy_completion_match(prefix, name));
         let mut seen = FxHashMap::<&str, SymbolId>::default();
         let mut scope = Some(scope_id);
         while let Some(scope_id) = scope {
@@ -993,17 +996,21 @@ impl SymbolTables {
                     continue;
                 }
                 let symbol = &self.declarations[declaration.symbol_id];
-                seen.entry(symbol.name.as_str()).or_insert(declaration.symbol_id);
+                if matches_prefix(&symbol.name) {
+                    seen.entry(symbol.name.as_str()).or_insert(declaration.symbol_id);
+                }
             }
             scope = current.parent;
         }
 
         let mut items =
             seen.into_values().map(|symbol_id| self.completion_item(symbol_id)).collect::<Vec<_>>();
-        items.extend(self.global_completions.iter().cloned());
+        items.extend(
+            self.global_completions.iter().filter(|item| matches_prefix(&item.label)).cloned(),
+        );
         items.sort_by(|a, b| a.label.cmp(&b.label));
         items.dedup_by(|a, b| a.label == b.label);
-        filter_completion_items(items, context.prefix)
+        items
     }
 
     pub(crate) fn resolve_completion_item(
@@ -2589,12 +2596,6 @@ fn completion_item_for_builtin(builtin: Builtin) -> CompletionItem {
         }),
         ..Default::default()
     }
-}
-
-fn filter_completion_items(mut items: Vec<CompletionItem>, prefix: &str) -> Vec<CompletionItem> {
-    let Some(prefix) = completion_filter_prefix(prefix) else { return items };
-    items.retain(|item| fuzzy_completion_match(&prefix, &item.label));
-    items
 }
 
 fn filtered_completion_items(items: &[CompletionItem], prefix: &str) -> Vec<CompletionItem> {

--- a/crates/lsp/src/tests/completion.rs
+++ b/crates/lsp/src/tests/completion.rs
@@ -1731,3 +1731,34 @@ second Method
     fixture.check_completion("$4", str![[""]]);
     fixture.check_completion("$5", str![[""]]);
 }
+
+#[test]
+fn filters_visible_names_before_building_items() {
+    let fixture = RequestFixture::new_allowing_diagnostics(
+        r#"
+        //- /Completion.sol open
+        contract C {
+            uint256 needleValue;
+            function f() public {
+                uint256 needleValue = 1;
+                nDV$1;
+                noMatchingName$2;
+            }
+        }
+        "#,
+        "/Completion.sol",
+    );
+    fixture.check_completion(
+        "$1",
+        str![[r#"
+needleValue Variable
+
+"#]],
+    );
+    fixture.check_completion(
+        "$2",
+        str![[r#"
+
+"#]],
+    );
+}

--- a/crates/lsp/src/tests/indexing.rs
+++ b/crates/lsp/src/tests/indexing.rs
@@ -9,7 +9,7 @@ async fn opening_identical_source_and_reverted_edits_reuse_analysis() {
     let project = TestProject::from_fixture("//- /Main.sol\ncontract Main {}\n");
     let path = project.path("/Main.sol");
     let uri = Url::from_file_path(&path).unwrap();
-    let source = std::fs::read_to_string(&path).unwrap();
+    let source = project.read_file("/Main.sol");
     let mut state = GlobalState::new(ClientSocket::new_closed());
     state.config = Arc::new(project.config());
     state.recompute_after_opening_source(Vec::new());
@@ -83,7 +83,7 @@ async fn identical_inputs_do_not_hide_disk_dependency_changes() {
     let published = state.symbol_tables.load_full();
     state.vfs.write().set_file_contents_with_version(
         VfsPath::from(main.clone()),
-        Some(Rope::from(std::fs::read_to_string(&main).unwrap().as_str())),
+        Some(Rope::from(project.read_file("/Main.sol").as_str())),
         Some(1),
     );
     std::fs::write(&dep, "contract Dep { uint public changed; }").unwrap();
@@ -121,7 +121,14 @@ async fn cached_and_published_symbol_tables_share_storage() {
     let old = Arc::downgrade(&published);
     drop(published);
     state.clear_analysis_cache();
-    assert!(old.upgrade().is_none());
+    // Publication wakes readers before the worker drops its previous snapshot.
+    tokio::time::timeout(ASYNC_TEST_TIMEOUT, async {
+        while old.upgrade().is_some() {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .unwrap();
 }
 
 #[tokio::test(flavor = "current_thread")]

--- a/crates/lsp/src/tests/indexing.rs
+++ b/crates/lsp/src/tests/indexing.rs
@@ -1,6 +1,97 @@
 use super::*;
+use crate::{handlers, vfs::VfsPath};
 use async_lsp::LanguageServer;
+use crop::Rope;
 use std::sync::atomic::AtomicBool;
+
+#[tokio::test(flavor = "current_thread")]
+async fn opening_identical_source_and_reverted_edits_reuse_analysis() {
+    let project = TestProject::from_fixture("//- /Main.sol\ncontract Main {}\n");
+    let path = project.path("/Main.sol");
+    let uri = Url::from_file_path(&path).unwrap();
+    let source = std::fs::read_to_string(&path).unwrap();
+    let mut state = GlobalState::new(ClientSocket::new_closed());
+    state.config = Arc::new(project.config());
+    state.recompute_after_opening_source(Vec::new());
+    tokio::time::timeout(ASYNC_TEST_TIMEOUT, state.latest_analysis()).await.unwrap().unwrap();
+    let published = state.symbol_tables.load_full();
+
+    let _ = handlers::did_open_text_document(
+        &mut state,
+        DidOpenTextDocumentParams {
+            text_document: TextDocumentItem::new(uri.clone(), "solidity".into(), 7, source.clone()),
+        },
+    );
+    tokio::time::timeout(ASYNC_TEST_TIMEOUT, state.latest_analysis()).await.unwrap().unwrap();
+    assert!(Arc::ptr_eq(&published, &state.symbol_tables.load()));
+    let reports = state.diagnostics.read().workspace_pull_reports(Vec::new());
+    assert_eq!(reports.iter().find(|report| report.uri == uri).unwrap().version, Some(7));
+
+    {
+        let mut vfs = state.vfs.write();
+        vfs.set_file_contents_with_version(
+            VfsPath::from(path.clone()),
+            Some(Rope::from("contract Edited {}")),
+            Some(8),
+        );
+        vfs.set_file_contents_with_version(
+            VfsPath::from(path.clone()),
+            Some(Rope::from(source.as_str())),
+            Some(9),
+        );
+    }
+    state.recompute_after_opening_source(vec![path.clone()]);
+    tokio::time::timeout(ASYNC_TEST_TIMEOUT, state.latest_analysis()).await.unwrap().unwrap();
+    assert!(Arc::ptr_eq(&published, &state.symbol_tables.load()));
+    let reports = state.diagnostics.read().workspace_pull_reports(Vec::new());
+    assert_eq!(reports.iter().find(|report| report.uri == uri).unwrap().version, Some(9));
+
+    state.vfs.write().set_file_contents_with_version(
+        VfsPath::from(path.clone()),
+        Some(Rope::from("contract Edited {}")),
+        Some(10),
+    );
+    state.recompute_after_opening_source(vec![path]);
+    tokio::time::timeout(ASYNC_TEST_TIMEOUT, state.latest_analysis()).await.unwrap().unwrap();
+    assert!(!Arc::ptr_eq(&published, &state.symbol_tables.load()));
+    assert_eq!(state.symbol_tables.load().workspace_symbols("Edited").len(), 1);
+
+    let edited = state.symbol_tables.load_full();
+    state.config = Arc::new((*state.config).clone());
+    state.recompute_after_opening_source(Vec::new());
+    tokio::time::timeout(ASYNC_TEST_TIMEOUT, state.latest_analysis()).await.unwrap().unwrap();
+    assert!(!Arc::ptr_eq(&edited, &state.symbol_tables.load()));
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn identical_inputs_do_not_hide_disk_dependency_changes() {
+    let project = TestProject::from_fixture(
+        r#"
+        //- /Main.sol
+        import "./lib/Dep.sol";
+        contract Main is Dep {}
+        //- /lib/Dep.sol
+        contract Dep {}
+    "#,
+    );
+    let main = project.path("/Main.sol");
+    let dep = project.path("/lib/Dep.sol");
+    let mut state = GlobalState::new(ClientSocket::new_closed());
+    state.config = Arc::new(project.config());
+    state.recompute_after_opening_source(Vec::new());
+    tokio::time::timeout(ASYNC_TEST_TIMEOUT, state.latest_analysis()).await.unwrap().unwrap();
+    let published = state.symbol_tables.load_full();
+    state.vfs.write().set_file_contents_with_version(
+        VfsPath::from(main.clone()),
+        Some(Rope::from(std::fs::read_to_string(&main).unwrap().as_str())),
+        Some(1),
+    );
+    std::fs::write(&dep, "contract Dep { uint public changed; }").unwrap();
+    state.recompute_with_disk_files(vec![dep]);
+    tokio::time::timeout(ASYNC_TEST_TIMEOUT, state.latest_analysis()).await.unwrap().unwrap();
+    assert!(!Arc::ptr_eq(&published, &state.symbol_tables.load()));
+    assert_eq!(state.symbol_tables.load().workspace_symbols("changed").len(), 1);
+}
 
 #[tokio::test(flavor = "current_thread")]
 async fn cached_and_published_symbol_tables_share_storage() {

--- a/crates/lsp/src/tests/indexing.rs
+++ b/crates/lsp/src/tests/indexing.rs
@@ -94,6 +94,57 @@ async fn identical_inputs_do_not_hide_disk_dependency_changes() {
 }
 
 #[tokio::test(flavor = "current_thread")]
+async fn disk_dependency_changes_survive_cache_reuse_attempts() {
+    for notify_change in [false, true] {
+        let project = TestProject::from_fixture(
+            r#"
+            //- /Main.sol
+            import "./lib/Dep.sol";
+            contract Main is Dep {}
+            //- /lib/Dep.sol
+            contract Dep {}
+        "#,
+        );
+        let main = project.path("/Main.sol");
+        let dep = project.path("/lib/Dep.sol");
+        let source = project.read_file("/Main.sol");
+        let mut state = GlobalState::new(ClientSocket::new_closed());
+        state.config = Arc::new(project.config());
+        state.vfs.write().set_file_contents_with_version(
+            VfsPath::from(main.clone()),
+            Some(Rope::from(source.as_str())),
+            Some(1),
+        );
+        state.recompute_after_opening_source(Vec::new());
+        tokio::time::timeout(ASYNC_TEST_TIMEOUT, state.latest_analysis()).await.unwrap().unwrap();
+        let published = state.symbol_tables.load_full();
+
+        std::fs::write(&dep, "contract Dep { uint public changed; }").unwrap();
+        if notify_change {
+            // Supersede the debounced disk request without changing the VFS revision.
+            state.recompute_for_file_changes(vec![dep], Vec::new(), false);
+        } else {
+            // A reverted edit must reload disk imports even without a watcher notification.
+            let mut vfs = state.vfs.write();
+            vfs.set_file_contents_with_version(
+                VfsPath::from(main.clone()),
+                Some(Rope::from("contract Edited {}")),
+                Some(2),
+            );
+            vfs.set_file_contents_with_version(
+                VfsPath::from(main.clone()),
+                Some(Rope::from(source.as_str())),
+                Some(3),
+            );
+        }
+        state.recompute_after_opening_source(vec![main]);
+        tokio::time::timeout(ASYNC_TEST_TIMEOUT, state.latest_analysis()).await.unwrap().unwrap();
+        assert!(!Arc::ptr_eq(&published, &state.symbol_tables.load()));
+        assert_eq!(state.symbol_tables.load().workspace_symbols("changed").len(), 1);
+    }
+}
+
+#[tokio::test(flavor = "current_thread")]
 async fn cached_and_published_symbol_tables_share_storage() {
     let project = TestProject::from_fixture(
         r#"

--- a/crates/lsp/src/tests/signature_help.rs
+++ b/crates/lsp/src/tests/signature_help.rs
@@ -897,7 +897,7 @@ fn hides_the_receiver_for_attached_library_functions() {
             using Math for uint256;
 
             function use(uint256 value) public pure returns (uint256) {
-                return value.bump($1 2);
+                return value.bump($1 Math.bump($2 value, 2));
             }
         }
         "#,
@@ -910,6 +910,16 @@ fn hides_the_receiver_for_attached_library_functions() {
 active signature=Some(0) parameter=Some(0)
 function bump(uint256 amount) internal pure returns (uint256)
   14..28
+
+"#]],
+    );
+    fixture.check_signature_help(
+        "$2",
+        str![[r#"
+active signature=Some(0) parameter=Some(0)
+function bump(uint256 self, uint256 amount) internal pure returns (uint256)
+  14..26
+  28..42
 
 "#]],
     );

--- a/crates/lsp/src/type_hierarchy.rs
+++ b/crates/lsp/src/type_hierarchy.rs
@@ -2,7 +2,8 @@
 //!
 //! The index retains declaration items and direct hierarchy edges as facts that can be merged
 //! across analysis batches. After merging, [`TypeHierarchyIndex::rebuild`] derives the canonical
-//! query indexes that are published to request handlers.
+//! query indexes that are published to request handlers. Adjacency lists use canonical symbol
+//! IDs; URI/range keys are retained only for node identity across batches and protocol requests.
 
 use crate::symbols::{DeclarationSymbol, SymbolId};
 use lsp_types::{Range, TypeHierarchyItem, Url};
@@ -25,9 +26,9 @@ pub(crate) struct TypeHierarchyIndex {
     candidate_key_by_symbol: FxHashMap<SymbolId, NodeKey>,
     direct_edges: Vec<HierarchyEdge>,
     canonical_symbol_by_key: FxHashMap<NodeKey, SymbolId>,
-    key_by_symbol: FxHashMap<SymbolId, NodeKey>,
-    bases_by_key: FxHashMap<NodeKey, Vec<NodeKey>>,
-    children_by_key: FxHashMap<NodeKey, Vec<NodeKey>>,
+    canonical_symbol_by_symbol: FxHashMap<SymbolId, SymbolId>,
+    bases_by_symbol: FxHashMap<SymbolId, Vec<SymbolId>>,
+    children_by_symbol: FxHashMap<SymbolId, Vec<SymbolId>>,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -190,89 +191,82 @@ impl TypeHierarchyIndex {
             .retain(|_, symbol_id| self.items_by_symbol.contains_key(symbol_id));
         for (&symbol_id, key) in &self.candidate_key_by_symbol {
             if self.items_by_symbol.contains_key(&symbol_id)
-                && self.canonical_symbol_by_key.contains_key(key)
+                && let Some(&canonical) = self.canonical_symbol_by_key.get(key)
             {
-                self.key_by_symbol.insert(symbol_id, key.clone());
+                self.canonical_symbol_by_symbol.insert(symbol_id, canonical);
             }
         }
 
         for edge in &self.direct_edges {
-            let (Some(derived), Some(base)) =
-                (self.key_by_symbol.get(&edge.derived), self.key_by_symbol.get(&edge.base))
-            else {
-                continue;
-            };
-            if derived == base {
-                continue;
+            if let (Some(&derived), Some(&base)) = (
+                self.canonical_symbol_by_symbol.get(&edge.derived),
+                self.canonical_symbol_by_symbol.get(&edge.base),
+            ) && derived != base
+            {
+                self.bases_by_symbol.entry(derived).or_default().push(base);
+                self.children_by_symbol.entry(base).or_default().push(derived);
             }
-            self.bases_by_key.entry(derived.clone()).or_default().push(base.clone());
-            self.children_by_key.entry(base.clone()).or_default().push(derived.clone());
         }
 
-        for bases in self.bases_by_key.values_mut() {
-            sort_and_dedup_keys(bases);
-        }
-        for children in self.children_by_key.values_mut() {
-            sort_and_dedup_keys(children);
+        for neighbors in
+            self.bases_by_symbol.values_mut().chain(self.children_by_symbol.values_mut())
+        {
+            sort_and_dedup_symbols(neighbors, &self.items_by_symbol);
         }
     }
 
     pub(crate) fn prepare(&self, symbol_ids: &[SymbolId]) -> Option<Vec<TypeHierarchyItem>> {
-        let mut keys = symbol_ids
+        let mut symbols = symbol_ids
             .iter()
-            .filter_map(|symbol_id| self.key_by_symbol.get(symbol_id))
+            .filter_map(|symbol_id| self.canonical_symbol_by_symbol.get(symbol_id).copied())
             .collect::<Vec<_>>();
-        if keys.is_empty() {
+        if symbols.is_empty() {
             return None;
         }
-        sort_and_dedup_keys(&mut keys);
-        Some(
-            keys.into_iter()
-                .map(|key| self.items_by_symbol[&self.canonical_symbol_by_key[key]].clone())
-                .collect(),
-        )
+        sort_and_dedup_symbols(&mut symbols, &self.items_by_symbol);
+        Some(symbols.into_iter().map(|symbol| self.items_by_symbol[&symbol].clone()).collect())
     }
 
     pub(crate) fn supertypes(&self, item: &TypeHierarchyItem) -> Option<Vec<TypeHierarchyItem>> {
-        self.neighbors(item, &self.bases_by_key)
+        self.neighbors(item, &self.bases_by_symbol)
     }
 
     pub(crate) fn subtypes(&self, item: &TypeHierarchyItem) -> Option<Vec<TypeHierarchyItem>> {
-        self.neighbors(item, &self.children_by_key)
+        self.neighbors(item, &self.children_by_symbol)
     }
 
     pub(crate) fn direct_counts(&self, symbol_ids: &[SymbolId]) -> Option<(usize, usize)> {
-        let key = symbol_ids.iter().find_map(|symbol_id| self.key_by_symbol.get(symbol_id))?;
+        let symbol = symbol_ids
+            .iter()
+            .find_map(|symbol_id| self.canonical_symbol_by_symbol.get(symbol_id))?;
         debug_assert!(
             symbol_ids
                 .iter()
-                .filter_map(|symbol_id| self.key_by_symbol.get(symbol_id))
-                .all(|candidate| candidate == key)
+                .filter_map(|symbol_id| self.canonical_symbol_by_symbol.get(symbol_id))
+                .all(|candidate| candidate == symbol)
         );
-        let bases = self.bases_by_key.get(key).map_or(0, Vec::len);
-        let derived = self.children_by_key.get(key).map_or(0, Vec::len);
+        let bases = self.bases_by_symbol.get(symbol).map_or(0, Vec::len);
+        let derived = self.children_by_symbol.get(symbol).map_or(0, Vec::len);
         Some((bases, derived))
     }
 
     fn neighbors(
         &self,
         item: &TypeHierarchyItem,
-        adjacency: &FxHashMap<NodeKey, Vec<NodeKey>>,
+        adjacency: &FxHashMap<SymbolId, Vec<SymbolId>>,
     ) -> Option<Vec<TypeHierarchyItem>> {
-        let key = self.resolve_item(item)?;
+        let symbol = self.resolve_item(item)?;
         Some(
             adjacency
-                .get(&key)
+                .get(&symbol)
                 .into_iter()
                 .flatten()
-                .map(|neighbor| {
-                    self.items_by_symbol[&self.canonical_symbol_by_key[neighbor]].clone()
-                })
+                .map(|neighbor| self.items_by_symbol[neighbor].clone())
                 .collect(),
         )
     }
 
-    fn resolve_item(&self, item: &TypeHierarchyItem) -> Option<NodeKey> {
+    fn resolve_item(&self, item: &TypeHierarchyItem) -> Option<SymbolId> {
         let data = TypeHierarchyData::deserialize(item.data.as_ref()?).ok()?;
         if data.version != DATA_VERSION {
             return None;
@@ -280,14 +274,14 @@ impl TypeHierarchyIndex {
         let key = NodeKey { uri: data.uri, selection_range: data.selection_range };
         let symbol_id = self.canonical_symbol_by_key.get(&key)?;
         let canonical_item = self.items_by_symbol.get(symbol_id)?;
-        (canonical_item == item).then_some(key)
+        (canonical_item == item).then_some(*symbol_id)
     }
 
     fn invalidate_query_indexes(&mut self) {
         self.canonical_symbol_by_key.clear();
-        self.key_by_symbol.clear();
-        self.bases_by_key.clear();
-        self.children_by_key.clear();
+        self.canonical_symbol_by_symbol.clear();
+        self.bases_by_symbol.clear();
+        self.children_by_symbol.clear();
     }
 }
 
@@ -338,6 +332,17 @@ fn node_name(gcx: Gcx<'_>, item_id: ItemId) -> Option<String> {
         | ItemId::Error(_)
         | ItemId::Event(_) => return None,
     })
+}
+
+fn sort_and_dedup_symbols(
+    symbols: &mut Vec<SymbolId>,
+    items: &FxHashMap<SymbolId, TypeHierarchyItem>,
+) {
+    symbols.sort_unstable_by_key(|symbol| {
+        let item = &items[symbol];
+        (item.uri.as_str(), range_key(item.selection_range))
+    });
+    symbols.dedup();
 }
 
 fn sort_and_dedup_keys<T: Ord>(keys: &mut Vec<T>) {

--- a/crates/sema/src/eval.rs
+++ b/crates/sema/src/eval.rs
@@ -72,6 +72,12 @@ impl<'gcx> Gcx<'gcx> {
         }
     }
 
+    pub(crate) fn eval_const_value_result(self, expr: &hir::Expr<'_>) -> &'gcx EvalResult {
+        // Constant values can own big-integer buffers. Keep them in the cache itself so they
+        // are dropped with the compilation instead of leaking from the dropless HIR arena.
+        self.eval_cache.insert(expr.id, |_| Box::new(eval_const(self, expr)))
+    }
+
     /// Emits a diagnostic for the given constant evaluation error.
     pub fn emit_const_eval_error(self, expr: &hir::Expr<'_>, err: EvalError) -> ErrorGuaranteed {
         match err.kind {

--- a/crates/sema/src/ty/mod.rs
+++ b/crates/sema/src/ty/mod.rs
@@ -352,6 +352,7 @@ pub struct GlobalCtxt<'gcx> {
     pub(crate) hir_arenas: ThreadLocal<hir::Arena>,
     interner: Interner<'gcx>,
     cache: Cache<'gcx>,
+    pub(crate) eval_cache: FxOnceMap<hir::ExprId, Box<crate::eval::EvalResult>>,
     pub(crate) override_index: OnceLock<crate::typeck::override_checker::OverrideIndex<'gcx>>,
 }
 
@@ -387,6 +388,7 @@ impl<'gcx> GlobalCtxt<'gcx> {
             hir_arenas,
             interner,
             cache: Cache::default(),
+            eval_cache: FxOnceMap::default(),
             override_index: OnceLock::new(),
         }
     }
@@ -1942,12 +1944,6 @@ fn internal_function_members_in_context(
 ) -> members::MemberList<'gcx> {
     let (id, current_contract) = key;
     gcx.bump().alloc_vec(members::internal_function_members_in_context(gcx, id, current_contract))
-}
-
-pub(crate) fn eval_const_value_result(gcx: _, expr: &hir::Expr<'_>)
-    cached_by(hir::ExprId, expr.id) -> &'gcx crate::eval::EvalResult
-{
-    gcx.alloc(crate::eval::eval_const(gcx, expr))
 }
 
 } // cached!


### PR DESCRIPTION
Follow up #1393 by reducing interactive query work and avoiding analysis when opening an already indexed file or undoing an edit before analysis starts. Reuse compares exact roots and overlays only when analysis has no additional disk dependencies or resolver probes. Opening 24 additional OpenZeppelin files falls from 90.2 to 6.1 ms median locally, with identical symbols. Other workspaces and actual content changes still rebuild semantic analysis. Accepted external changes invalidate cached output before debounce, and superseded workers cannot refill it.

Filter completion names before constructing items and skip import parsing for navigation outside strings. Selective completion falls from 81.1 to 14.2 us locally, with a small empty-prefix tradeoff of 63.9 to 66.2 us. Definition-query medians fall from 0.358 to 0.072 ms in the Uniswap test file. Cache signature rendering within each analysis; the repeated-call benchmark falls from 1.01 to 0.75 ms.

Store rename occurrence indices and canonical hierarchy IDs instead of duplicate locations and URI keys. Rename storage cuts retained requested allocations by 10–14% across the measured projects; hierarchy edges save another 1.93 MiB in OpenZeppelin. These measurements describe requested allocations, not process RSS.

Move cached constant-evaluation results out of the dropless HIR arena so their big-integer buffers are released with the compilation. A System-allocator Solady run previously retained another 9,104 bytes per analysis; post-drop allocation counts now stay flat, and macOS leaks reports zero leaked blocks for the same run.
