### PR TITLE
fix: stabilize benchmark artifacts and hide stale summaries

### DIFF
--- a/benches/runtime/benchmark-compare.py
+++ b/benches/runtime/benchmark-compare.py
@@ -1401,10 +1401,10 @@ def format_report(
     details = (
         "<details>\n"
         "<summary>Codegen benchmark output</summary>\n\n"
-        f"{markdown}\n\n"
+        f"{summary}{markdown}\n\n"
         "</details>\n"
     )
-    return notices + summary + details
+    return notices + details
 
 
 def metric(value: float, unit: str, statistic: str) -> dict[str, Any]:

--- a/benches/runtime/test_report.py
+++ b/benches/runtime/test_report.py
@@ -81,7 +81,10 @@ class ReportFormattingTests(unittest.TestCase):
 
     def test_changed_report_has_no_details(self):
         self.assertEqual(
-            benchmark.format_report("## Results", True, False), "## Results"
+            benchmark.format_report(
+                "## Results", True, False, comparison="### Run comparison"
+            ),
+            "### Run comparison\n\n## Results",
         )
 
     def test_notices_precede_comparison_and_details(self):
@@ -92,8 +95,8 @@ class ReportFormattingTests(unittest.TestCase):
             "> [!WARNING]\n"
             "> This branch is behind `main`, so these benchmark results may be incorrect.\n\n"
             "> [!NOTE]\n> Codegen benchmark output is unchanged from `main`.\n\n"
-            "### Run comparison\n\n"
             "<details>\n<summary>Codegen benchmark output</summary>\n\n"
+            "### Run comparison\n\n"
             "## Results\n\n</details>\n",
         )
 
@@ -110,13 +113,16 @@ class ReportFormattingTests(unittest.TestCase):
         )
 
     def test_behind_main_report_has_warning(self):
-        report = benchmark.format_report("## Results", True, True)
+        report = benchmark.format_report(
+            "## Results", True, True, comparison="### Run comparison"
+        )
         self.assertEqual(
             report,
             "> [!WARNING]\n"
             "> This branch is behind `main`, so these benchmark results may be incorrect.\n\n"
             "<details>\n"
             "<summary>Codegen benchmark output</summary>\n\n"
+            "### Run comparison\n\n"
             "## Results\n\n"
             "</details>\n",
         )

--- a/crates/codegen/src/lower/contract.rs
+++ b/crates/codegen/src/lower/contract.rs
@@ -3,7 +3,7 @@
 use super::{ContractBytecodes, function, storage::StorageLayout, types::TypeLowerer};
 use solar_data_structures::{
     Never,
-    map::{FxHashMap, FxHashSet},
+    map::{FxHashMap, FxHashSet, FxIndexSet},
 };
 use solar_interface::{ByteSymbol, Ident, kw, sym};
 use solar_sema::{
@@ -296,7 +296,7 @@ pub(super) fn lower(
 fn shared_string_literals(
     gcx: Gcx<'_>,
     function_ids: &[(hir::FunctionId, bool)],
-) -> (FxHashMap<ByteSymbol, usize>, FxHashSet<ByteSymbol>) {
+) -> (FxIndexSet<ByteSymbol>, FxHashSet<ByteSymbol>) {
     struct Counter<'hir> {
         hir: &'hir hir::Hir<'hir>,
         counts: FxHashMap<ByteSymbol, usize>,
@@ -331,20 +331,20 @@ fn shared_string_literals(
     for &(function_id, _) in function_ids {
         let _ = counter.visit_function(gcx.hir.function(function_id));
     }
-    let mut shared = Vec::new();
+    let mut shared = FxIndexSet::default();
     let mut shared_word = FxHashSet::default();
     for (bytes, count) in counter.counts {
         if count < 3 || bytes.as_byte_str().is_empty() {
             continue;
         }
         if count >= 4 {
-            shared.push(bytes);
+            shared.insert(bytes);
         }
         shared_word.insert(bytes);
     }
     // Symbol IDs depend on parallel parsing order; name helpers by sorted bytes.
     shared.sort_unstable_by(|a, b| a.as_byte_str().cmp(b.as_byte_str()));
-    (shared.into_iter().enumerate().map(|(index, bytes)| (bytes, index)).collect(), shared_word)
+    (shared, shared_word)
 }
 
 /// Creates the MIR declaration for a HIR function.

--- a/crates/codegen/src/lower/contract.rs
+++ b/crates/codegen/src/lower/contract.rs
@@ -296,7 +296,7 @@ pub(super) fn lower(
 fn shared_string_literals(
     gcx: Gcx<'_>,
     function_ids: &[(hir::FunctionId, bool)],
-) -> (FxHashSet<ByteSymbol>, FxHashSet<ByteSymbol>) {
+) -> (FxHashMap<ByteSymbol, usize>, FxHashSet<ByteSymbol>) {
     struct Counter<'hir> {
         hir: &'hir hir::Hir<'hir>,
         counts: FxHashMap<ByteSymbol, usize>,
@@ -331,18 +331,20 @@ fn shared_string_literals(
     for &(function_id, _) in function_ids {
         let _ = counter.visit_function(gcx.hir.function(function_id));
     }
-    let mut shared = FxHashSet::default();
+    let mut shared = Vec::new();
     let mut shared_word = FxHashSet::default();
     for (bytes, count) in counter.counts {
         if count < 3 || bytes.as_byte_str().is_empty() {
             continue;
         }
         if count >= 4 {
-            shared.insert(bytes);
+            shared.push(bytes);
         }
         shared_word.insert(bytes);
     }
-    (shared, shared_word)
+    // Symbol IDs depend on parallel parsing order; name helpers by sorted bytes.
+    shared.sort_unstable_by(|a, b| a.as_byte_str().cmp(b.as_byte_str()));
+    (shared.into_iter().enumerate().map(|(index, bytes)| (bytes, index)).collect(), shared_word)
 }
 
 /// Creates the MIR declaration for a HIR function.

--- a/crates/codegen/src/lower/function.rs
+++ b/crates/codegen/src/lower/function.rs
@@ -54,7 +54,7 @@ pub(super) struct LoweringContext<'gcx, 'ctx> {
     pub(super) immutable_ids: &'ctx FxHashMap<VariableId, ImmutableId>,
     pub(super) child_bytecodes: &'ctx FxHashMap<hir::ContractId, ContractBytecodes>,
     pub(super) state: &'ctx mut LoweringState,
-    pub(super) shared_literals: &'ctx FxHashSet<ByteSymbol>,
+    pub(super) shared_literals: &'ctx FxHashMap<ByteSymbol, usize>,
     pub(super) shared_word_literals: &'ctx FxHashSet<ByteSymbol>,
     pub(super) share_storage_bytes: bool,
     /// Whether the compilation had already failed when the code generation

--- a/crates/codegen/src/lower/function.rs
+++ b/crates/codegen/src/lower/function.rs
@@ -17,7 +17,7 @@ use crate::{
 };
 use alloy_primitives::{U256, keccak256};
 use solar_ast::{BinOpKind, DataLocation, LitKind, StateMutability, StrKind, TypeSize, UnOpKind};
-use solar_data_structures::map::{FxHashMap, FxHashSet, StdEntry};
+use solar_data_structures::map::{FxHashMap, FxHashSet, FxIndexSet, StdEntry};
 use solar_interface::{ByteSymbol, Ident, Span, Symbol, kw, sym};
 use solar_sema::{
     Gcx,
@@ -54,7 +54,7 @@ pub(super) struct LoweringContext<'gcx, 'ctx> {
     pub(super) immutable_ids: &'ctx FxHashMap<VariableId, ImmutableId>,
     pub(super) child_bytecodes: &'ctx FxHashMap<hir::ContractId, ContractBytecodes>,
     pub(super) state: &'ctx mut LoweringState,
-    pub(super) shared_literals: &'ctx FxHashMap<ByteSymbol, usize>,
+    pub(super) shared_literals: &'ctx FxIndexSet<ByteSymbol>,
     pub(super) shared_word_literals: &'ctx FxHashSet<ByteSymbol>,
     pub(super) share_storage_bytes: bool,
     /// Whether the compilation had already failed when the code generation

--- a/crates/codegen/src/lower/function/memory_values.rs
+++ b/crates/codegen/src/lower/function/memory_values.rs
@@ -170,8 +170,8 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
                 MirType::MemoryObject(MemoryObjectKind::Bytes),
                 1,
             )
-        } else if self.cx.shared_literals.contains(&symbol) {
-            let helper = self.ensure_bytes_literal_helper(symbol);
+        } else if let Some(&index) = self.cx.shared_literals.get(&symbol) {
+            let helper = self.ensure_bytes_literal_helper(symbol, index);
             self.builder.icall(
                 helper,
                 Vec::new(),
@@ -235,9 +235,9 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
         Some(object)
     }
 
-    fn ensure_bytes_literal_helper(&mut self, symbol: ByteSymbol) -> FunctionId {
+    fn ensure_bytes_literal_helper(&mut self, symbol: ByteSymbol, index: usize) -> FunctionId {
         // literal_bytes() -> bytes
-        self.lazy_helper(helper_name(sym::literal_bytes, symbol.as_u32()), |this, function| {
+        self.lazy_helper(helper_name(sym::literal_bytes, index), |this, function| {
             let mut builder = FunctionBuilder::new(function);
             builder.add_return(MirType::MemoryObject(MemoryObjectKind::Bytes));
             let object = Self::build_bytes_literal(

--- a/crates/codegen/src/lower/function/memory_values.rs
+++ b/crates/codegen/src/lower/function/memory_values.rs
@@ -170,7 +170,7 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
                 MirType::MemoryObject(MemoryObjectKind::Bytes),
                 1,
             )
-        } else if let Some(&index) = self.cx.shared_literals.get(&symbol) {
+        } else if let Some(index) = self.cx.shared_literals.get_index_of(&symbol) {
             let helper = self.ensure_bytes_literal_helper(symbol, index);
             self.builder.icall(
                 helper,

--- a/tests/ui/codegen/lowering/run-call/string_literal_internal_args.mir.stdout
+++ b/tests/ui/codegen/lowering/run-call/string_literal_internal_args.mir.stdout
@@ -40,14 +40,38 @@ fn @libHex() -> u256 [selector=0xed6b01e9, pure, abi_params=[], abi_returns=[wor
 
 fn @libLong() -> u256 [selector=0x7a8edc4e, pure, abi_params=[], abi_returns=[word]] {
   bb0:
-    v0 = alloc memorybytes, exact, uninitialized, infallible, 96
-    set_memory_object_len memorybytes, v0, 40
-    v1 = memory_object_data memorybytes, v0
-    mstore v1, 0x3031323334353637383930313233343536373839303132333435363738393031
-    v2 = add v1, 32
-    mstore v2, 0x3233343536373839000000000000000000000000000000000000000000000000
-    v3 = icall @lenPlus, 1, v0, 0
-    ret v3
+    v0 = icall @literal_bytes_0, 1
+    v1 = icall @lenPlus, 1, v0, 0
+    ret v1
+}
+
+fn @sharedLong() -> u256 [selector=0xd83f9e13, pure, abi_params=[], abi_returns=[word]] {
+  bb0:
+    v0 = icall @literal_bytes_0, 1
+    v1 = icall @lenPlus, 1, v0, 0
+    v2 = icall @literal_bytes_0, 1
+    v3 = icall @lenPlus, 1, v2, 0
+    v4 = add v1, v3
+    v5 = lt v4, v1
+    jumpi v5, bb1, bb2
+  bb2:
+    v6 = icall @literal_bytes_0, 1
+    v7 = icall @lenPlus, 1, v6, 0
+    v8 = add v4, v7
+    v9 = lt v8, v4
+    jumpi v9, bb1, bb3
+  bb3:
+    v10 = icall @literal_bytes_0, 1
+    v11 = icall @lenPlus, 1, v10, 0
+    v12 = add v8, v11
+    v13 = lt v12, v8
+    jumpi v13, bb1, bb4
+  bb4:
+    ret v12
+  bb1:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 17 !metadata(memory=scratch)
+    revert 0, 36
 }
 
 fn @literalContent() -> bytes32 [selector=0x4ab72711, pure, abi_params=[], abi_returns=[word]] {
@@ -107,4 +131,15 @@ fn @firstWord(arg0: memorybytes) -> bytes32 [pure] {
     v0 = add arg0, 32
     v1 = mload v0
     ret v1
+}
+
+fn @literal_bytes_0() -> memorybytes {
+  bb0:
+    v0 = alloc memorybytes, exact, uninitialized, infallible, 96
+    set_memory_object_len memorybytes, v0, 40
+    v1 = memory_object_data memorybytes, v0
+    mstore v1, 0x3031323334353637383930313233343536373839303132333435363738393031
+    v2 = add v1, 32
+    mstore v2, 0x3233343536373839000000000000000000000000000000000000000000000000
+    ret v0
 }

--- a/tests/ui/codegen/lowering/run-call/string_literal_internal_args.sol
+++ b/tests/ui/codegen/lowering/run-call/string_literal_internal_args.sol
@@ -3,6 +3,7 @@
 //@ run-call: libConstant => 20
 //@ run-call: libHex => 2
 //@ run-call: libLong => 40
+//@ run-call: sharedLong => 160
 //@ run-call: literalContent => 0x6869000000000000000000000000000000000000000000000000000000000000
 //@ run-call: encodeConstant => 132
 //@ run-call: encodeConstantCast => 100
@@ -48,6 +49,13 @@ contract StringLiteralInternalArgs {
 
     function libLong() external pure returns (uint256) {
         return L.lenPlus("0123456789012345678901234567890123456789", 0);
+    }
+
+    function sharedLong() external pure returns (uint256) {
+        return L.lenPlus("0123456789012345678901234567890123456789", 0)
+            + L.lenPlus("0123456789012345678901234567890123456789", 0)
+            + L.lenPlus("0123456789012345678901234567890123456789", 0)
+            + L.lenPlus("0123456789012345678901234567890123456789", 0);
     }
 
     function literalContent() external pure returns (bytes32) {


### PR DESCRIPTION
Shared literal helper names used interned symbol IDs, which depend on parallel parsing order. Assign their suffixes by sorted byte content so identical inputs produce identical MIR artifacts and avoid spurious benchmark comments like https://github.com/paradigmxyz/solar/pull/1402#issuecomment-5571680060. Also collapse the run comparison summary with the rest of the report when results are outdated or unchanged.