### PR TITLE
fix(benches): update Solar perf permalinks

### DIFF
--- a/benches/runtime/benchmark-compare.py
+++ b/benches/runtime/benchmark-compare.py
@@ -24,7 +24,7 @@ from urllib.parse import urlencode
 
 from benchmark import workload_signature
 
-PERF_SITE_URL = "https://getfoundry.sh/perf/"
+PERF_SITE_URL = "https://getfoundry.sh/perf/solar/"
 
 METRICS = {
     "total_gas": "runtime gas",

--- a/benches/runtime/test_report.py
+++ b/benches/runtime/test_report.py
@@ -44,11 +44,11 @@ class ReportFormattingTests(unittest.TestCase):
         ):
             self.assertEqual(
                 benchmark.perf_link("Results"),
-                "[Results](https://getfoundry.sh/perf/?base=01234567&head=fedcba98#benchmarks)",
+                "[Results](https://getfoundry.sh/perf/solar/?base=01234567&head=fedcba98#benchmarks)",
             )
             self.assertEqual(
                 benchmark.perf_link("factorial", "factorial"),
-                "[factorial](https://getfoundry.sh/perf/?base=01234567&head=fedcba98&benchmark=factorial#artifacts)",
+                "[factorial](https://getfoundry.sh/perf/solar/?base=01234567&head=fedcba98&benchmark=factorial#artifacts)",
             )
 
     def test_perf_link_targets_artifact(self):


### PR DESCRIPTION
Point benchmark report permalinks at `https://getfoundry.sh/perf/solar/` to match the site move in https://github.com/foundry-rs/book/pull/2056. Update the existing results and per-benchmark link expectations; custom `BENCHMARK_SITE_URL` overrides remain unchanged.

Land after the Book route is deployed to production.

AI assistance: implementation and testing with Codex.
