### PR TITLE
perf(lsp): index cached selection ranges

### DIFF
--- a/crates/lsp/README.md
+++ b/crates/lsp/README.md
@@ -48,3 +48,8 @@ The benchmark groups intentionally keep separate timing boundaries:
 - `project-analysis` and `project-analysis-after-edit` measure compiler and symbol-table rebuilds.
 - `project-edit-application` measures UTF-16 document edit application without analysis.
 - `symbol-table-queries` measures synchronous query kernels, not complete LSP request latency.
+- `open-document-selection-range` measures repeated selection queries through the VFS snapshot,
+  including UTF-16 conversion and response construction. It covers start, middle, and end positions
+  in an unchanged document and multiple cursors, excluding transport and blocking-pool scheduling.
+- `open-document-selection-range-cold` includes the first request's parsing and index construction;
+  preparing and destroying the open document stays outside timing.

--- a/crates/lsp/benches/lsp.rs
+++ b/crates/lsp/benches/lsp.rs
@@ -476,22 +476,88 @@ fn folding_range(c: &mut Criterion) {
 }
 
 fn open_document_selection_range(c: &mut Criterion) {
-    let positions = [Position::new(0, 0)];
-    let requests =
-        BenchmarkSelectionRangeRequests::new(OPTIMISM_SOURCE.to_owned(), positions.iter().copied());
-    let expected = benchmark_selection_ranges(OPTIMISM_SOURCE.to_owned(), &positions)
-        .expect("the benchmark position should be valid");
-    let ranges = requests.run().expect("the benchmark position should be valid");
-    assert_eq!(ranges, expected);
-    assert_eq!(ranges.len(), positions.len());
-    assert!(ranges[0].range.start <= positions[0] && positions[0] < ranges[0].range.end);
+    let position_at = |source: &str, offset| {
+        let prefix = &source[..offset];
+        Position::new(
+            prefix.bytes().filter(|&byte| byte == b'\n').count() as u32,
+            prefix.rsplit('\n').next().unwrap().encode_utf16().count() as u32,
+        )
+    };
+    let middle = position_at(
+        OPTIMISM_SOURCE,
+        OPTIMISM_SOURCE
+            .match_indices("return ")
+            .find(|(offset, _)| *offset >= OPTIMISM_SOURCE.len() / 2)
+            .unwrap()
+            .0,
+    );
+    let end = position_at(OPTIMISM_SOURCE, OPTIMISM_SOURCE.rfind("return ").unwrap());
+    let start = Position::new(0, 0);
 
     let mut group = c.benchmark_group("lsp/open-document-selection-range");
     group.throughput(Throughput::Bytes(OPTIMISM_SOURCE.len() as u64));
-    group.bench_function(BenchmarkId::from_parameter("optimism"), |b| {
-        b.iter(|| black_box(black_box(&requests).run()));
-    });
+    for (name, positions) in [
+        ("optimism", vec![start]),
+        ("optimism-middle", vec![middle]),
+        ("optimism-end", vec![end]),
+        ("optimism-multiple", vec![end, start, middle, end]),
+    ] {
+        let requests = BenchmarkSelectionRangeRequests::new(
+            OPTIMISM_SOURCE.to_owned(),
+            positions.iter().copied(),
+        );
+        let expected = benchmark_selection_ranges(OPTIMISM_SOURCE.to_owned(), &positions)
+            .expect("the benchmark positions should be valid");
+        let ranges = requests.run().expect("the benchmark positions should be valid");
+        assert_eq!(ranges, expected);
+        assert_eq!(ranges.len(), positions.len());
+        for (range, position) in ranges.iter().zip(&positions) {
+            assert!(range.range.start <= *position && *position < range.range.end);
+            if *position != start {
+                assert!(range.parent.is_some());
+            }
+        }
+        group.bench_function(BenchmarkId::from_parameter(name), |b| {
+            b.iter(|| black_box(black_box(&requests).run()));
+        });
+    }
+    for (name, source) in [
+        ("uniswap-v3", include_str!("../../../testdata/UniswapV3.sol")),
+        (
+            "unifap-v2-router",
+            include_str!("../../../tests/foundry/unifap-v2/src/UnifapV2Router.sol"),
+        ),
+    ] {
+        let anchor = "\n    function ";
+        let offset = source
+            .match_indices(anchor)
+            .find(|(offset, _)| *offset >= source.len() / 2)
+            .expect("the real source should contain a function declaration")
+            .0
+            + anchor.len();
+        let positions = [position_at(source, offset)];
+        let requests = BenchmarkSelectionRangeRequests::new(source.to_owned(), positions);
+        let expected = benchmark_selection_ranges(source.to_owned(), &positions)
+            .expect("the benchmark position should be valid");
+        assert!(expected[0].parent.is_some());
+        assert_eq!(requests.run(), Some(expected));
+        group.throughput(Throughput::Bytes(source.len() as u64));
+        group.bench_function(BenchmarkId::from_parameter(name), |b| {
+            b.iter(|| black_box(black_box(&requests).run()));
+        });
+    }
     group.finish();
+
+    let mut cold = c.benchmark_group("lsp/open-document-selection-range-cold");
+    cold.throughput(Throughput::Bytes(OPTIMISM_SOURCE.len() as u64));
+    cold.bench_function(BenchmarkId::from_parameter("optimism"), |b| {
+        b.iter_batched_ref(
+            || BenchmarkSelectionRangeRequests::new(OPTIMISM_SOURCE.to_owned(), [middle]),
+            |requests| black_box(requests.run()),
+            BatchSize::PerIteration,
+        );
+    });
+    cold.finish();
 }
 
 fn workspace_diagnostic_hot_paths(c: &mut Criterion) {

--- a/crates/lsp/src/selection_range.rs
+++ b/crates/lsp/src/selection_range.rs
@@ -16,6 +16,9 @@ use std::{
     sync::{Arc, OnceLock},
 };
 
+#[cfg(test)]
+mod tests;
+
 pub(crate) fn selection_ranges(
     source: String,
     positions: &[Position],
@@ -33,7 +36,7 @@ pub(crate) fn selection_ranges(
 pub(crate) struct SelectionRangeIndex {
     source: Arc<String>,
     positions: proto::LspPositionIndex<Rope>,
-    candidates: OnceLock<Vec<ByteRange<usize>>>,
+    candidates: OnceLock<CandidateRanges>,
 }
 
 impl SelectionRangeIndex {
@@ -49,10 +52,53 @@ impl SelectionRangeIndex {
             return Some(Vec::new());
         }
 
-        let candidates = self
-            .candidates
-            .get_or_init(|| collect_ranges(SourceCode::Shared(self.source.clone()), index.rope()));
-        selection_ranges_for_cursors(index, candidates, cursors)
+        let candidates = self.candidates.get_or_init(|| {
+            CandidateRanges::new(collect_ranges(
+                SourceCode::Shared(self.source.clone()),
+                index.rope(),
+            ))
+        });
+        cursors
+            .into_iter()
+            .map(|cursor| selection_range_for_cursor(index, candidates.at(cursor), cursor))
+            .collect()
+    }
+}
+
+/// Syntax ranges grouped by traversal order, with a bounding interval for each block.
+///
+/// AST traversal keeps most neighboring ranges close in the source, so point queries can
+/// skip unrelated blocks. Building bounds requires no sorting and stores only two offsets
+/// per block; individual ranges are still checked for exact containment.
+struct CandidateRanges {
+    ranges: Vec<ByteRange<usize>>,
+    bounds: Vec<ByteRange<usize>>,
+}
+
+impl CandidateRanges {
+    const BLOCK_SIZE: usize = 64;
+
+    fn new(ranges: Vec<ByteRange<usize>>) -> Self {
+        let bounds = ranges
+            .chunks(Self::BLOCK_SIZE)
+            .map(|block| {
+                block.iter().fold(block[0].clone(), |bounds, range| {
+                    bounds.start.min(range.start)..bounds.end.max(range.end)
+                })
+            })
+            .collect();
+        Self { ranges, bounds }
+    }
+
+    fn at(&self, cursor: usize) -> Vec<ByteRange<usize>> {
+        self.ranges
+            .chunks(Self::BLOCK_SIZE)
+            .zip(&self.bounds)
+            .filter(|(_, bounds)| bounds.contains(&cursor))
+            .flat_map(|(block, _)| block)
+            .filter(|range| range.contains(&cursor))
+            .cloned()
+            .collect()
     }
 }
 
@@ -113,20 +159,19 @@ fn selection_ranges_for_cursors<R: Borrow<Rope>>(
 ) -> Option<Vec<SelectionRange>> {
     cursors
         .into_iter()
-        .map(|cursor| selection_range_for_cursor(index, candidates, cursor))
+        .map(|cursor| {
+            let candidates =
+                candidates.iter().filter(|range| range.contains(&cursor)).cloned().collect();
+            selection_range_for_cursor(index, candidates, cursor)
+        })
         .collect()
 }
 
 fn selection_range_for_cursor<R: Borrow<Rope>>(
     index: &proto::LspPositionIndex<R>,
-    candidates: &[ByteRange<usize>],
+    mut candidates: Vec<ByteRange<usize>>,
     cursor: usize,
 ) -> Option<SelectionRange> {
-    let mut candidates = candidates
-        .iter()
-        .filter(|range| range.start <= cursor && cursor < range.end)
-        .cloned()
-        .collect::<Vec<_>>();
     candidates
         .sort_unstable_by_key(|range| (range.end - range.start, Reverse(range.start), range.end));
     candidates.dedup();

--- a/crates/lsp/src/selection_range/tests.rs
+++ b/crates/lsp/src/selection_range/tests.rs
@@ -1,0 +1,68 @@
+use super::CandidateRanges;
+use std::ops::Range;
+
+fn check_queries(ranges: Vec<Range<usize>>, cursors: impl IntoIterator<Item = usize>) {
+    let index = CandidateRanges::new(ranges.clone());
+    for cursor in cursors {
+        let mut expected =
+            ranges.iter().filter(|range| range.contains(&cursor)).cloned().collect::<Vec<_>>();
+        let mut actual = index.at(cursor);
+        expected.sort_unstable_by_key(|range| (range.start, range.end));
+        expected.dedup();
+        actual.sort_unstable_by_key(|range| (range.start, range.end));
+        actual.dedup();
+        assert_eq!(actual, expected, "candidate ranges at byte {cursor}");
+    }
+}
+
+#[test]
+fn queries_preserve_overlaps_and_half_open_boundaries() {
+    check_queries(vec![5..10, 0..5, 5..10, 3..8, 2..8, 2..7, 8..12, 0..12], 0..=13);
+}
+
+#[test]
+fn queries_handle_empty_indexes_and_extreme_offsets() {
+    check_queries(Vec::new(), [0, 1, usize::MAX]);
+    check_queries(
+        vec![0..1, usize::MAX - 1..usize::MAX],
+        [0, 1, usize::MAX - 2, usize::MAX - 1, usize::MAX],
+    );
+}
+
+#[test]
+fn mixed_ranges_match_linear_queries_at_every_byte() {
+    let mut ranges = std::iter::once(0..320).collect::<Vec<_>>();
+    ranges.extend((0..128).map(|index| {
+        let start = index * 37 % 256;
+        let length = index * 17 % 61 + 1;
+        start..start + length
+    }));
+    ranges.extend([0..320, 100..220, 120..240, 100..180]);
+
+    for len in 0..=ranges.len() {
+        check_queries(ranges[..len].to_vec(), 0..=321);
+    }
+    ranges.reverse();
+    check_queries(ranges, 0..=321);
+}
+
+#[test]
+fn disjoint_groups_and_crossing_ranges_match_linear_queries() {
+    let mut ranges = [0, 1000, 2000, 3000]
+        .into_iter()
+        .flat_map(|base| {
+            (0..70).map(move |offset| {
+                let start = base + offset * 4;
+                start..start + 2
+            })
+        })
+        .collect::<Vec<_>>();
+    check_queries(ranges.clone(), 0..=3300);
+
+    ranges[20] = 50..1250;
+    ranges[90] = 850..2400;
+    ranges[200] = 1900..3100;
+    check_queries(ranges.clone(), 0..=3300);
+    ranges.reverse();
+    check_queries(ranges, 0..=3300);
+}


### PR DESCRIPTION
Repeated `textDocument/selectionRange` requests currently scan every cached syntax range.

- Group ranges into blocks of 64 and skip blocks whose bounds exclude the cursor.
- Build bounds once with the existing document cache, without sorting. This adds two offsets per block; exact containment checks and selection-chain construction stay unchanged.
- Add benchmarks for middle/end positions, multiple cursors, Uniswap V3, Unifap V2 and first requests. Compare indexed lookups against a linear scan in regression tests.

The first six rows measure repeated queries on an unchanged, already indexed document:

| Selection-range workload | Main | PR | Latency change |
| --- | ---: | ---: | ---: |
| Optimism, start | 161.496 us | 5.078 us | -96.9% |
| Optimism, middle | 191.257 us | 5.248 us | -97.3% |
| Optimism, end | 236.835 us | 7.025 us | -97.0% |
| Optimism, 4 cursors | 836.162 us | 23.385 us | -97.2% |
| Uniswap V3 | 5.108 us | 1.451 us | -71.6% |
| Unifap V2 router | 1.345 us | 1.286 us | -4.4% |
| Optimism, first open-document request | 48.925 ms | 47.936 ms | -2.0% |
| Optimism, standalone uncached query | 48.825 ms | 50.720 ms | +3.9% |

Follows #1351.
