### PR TITLE
fix(lsp-bench): quiet and bound PR benchmarks

### DIFF
--- a/.github/workflows/lsp-bench-command.yml
+++ b/.github/workflows/lsp-bench-command.yml
@@ -17,7 +17,7 @@ jobs:
       (github.event_name == 'issue_comment' &&
        github.event.issue.pull_request &&
        github.event.comment.body == '/bench lsp')
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
     timeout-minutes: 5
     permissions:
       contents: read
@@ -276,7 +276,7 @@ jobs:
   arbitrate:
     name: supersede older accepted requests
     needs: resolve
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
     timeout-minutes: 5
     permissions:
       actions: write
@@ -450,7 +450,7 @@ jobs:
       needs.resolve.result == 'success' &&
       needs.arbitrate.result == 'success' &&
       needs.arbitrate.outputs.superseded == 'false'
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
     timeout-minutes: 5
     permissions:
       issues: write
@@ -518,7 +518,7 @@ jobs:
       needs.resolve.result == 'success' &&
       needs.arbitrate.result == 'success' &&
       needs.arbitrate.outputs.superseded == 'false'
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
     timeout-minutes: 90
     permissions:
       contents: read
@@ -565,7 +565,7 @@ jobs:
       needs.resolve.result == 'success' &&
       needs.arbitrate.result == 'success' &&
       needs.arbitrate.outputs.superseded == 'false'
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
     timeout-minutes: 90
     permissions:
       contents: read
@@ -616,7 +616,7 @@ jobs:
       needs.build_candidate.result == 'success' &&
       needs.build_base.outputs.artifact_id != '' &&
       needs.build_candidate.outputs.artifact_id != ''
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
     timeout-minutes: 90
     permissions:
       contents: read
@@ -750,7 +750,7 @@ jobs:
       needs.resolve.result == 'success' &&
       needs.arbitrate.result == 'success' &&
       needs.arbitrate.outputs.superseded == 'false'
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
     timeout-minutes: 10
     permissions:
       actions: read

--- a/.github/workflows/lsp-bench-comment.yml
+++ b/.github/workflows/lsp-bench-comment.yml
@@ -21,7 +21,7 @@ jobs:
     if: >-
       github.event.workflow_run.event == 'pull_request' &&
       github.event.workflow_run.conclusion == 'success'
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
     timeout-minutes: 10
     permissions:
       actions: read

--- a/.github/workflows/lsp-bench-comment.yml
+++ b/.github/workflows/lsp-bench-comment.yml
@@ -144,14 +144,18 @@ jobs:
         run: |
           set -euo pipefail
           summary="$REPORT_ROOT/summary.json"
+          baseline="$REPORT_ROOT/baseline.json"
           provenance="$REPORT_ROOT/provenance.json"
           if [[ ! -f "$summary" || ! -f "$provenance" || \
                 -L "$summary" || -L "$provenance" ]]; then
             echo "Expected regular summary.json and provenance.json at artifact root" >&2
             exit 1
           fi
+          test -f "$baseline" && test ! -L "$baseline"
+          test -s "$baseline"
+          test "$(stat -c %s "$baseline")" -le 1048576
           mapfile -t extra < <(find -P "$REPORT_ROOT" -mindepth 1 -maxdepth 1 \
-            ! -name summary.json ! -name provenance.json -print)
+            ! -name summary.json ! -name baseline.json ! -name provenance.json -print)
           if [[ "${#extra[@]}" -ne 0 ]]; then
             echo "Comment data artifact contains unexpected files" >&2
             exit 1
@@ -160,6 +164,7 @@ jobs:
           test -s "$provenance"
           test "$(stat -c %s "$summary")" -le 1048576
           test "$(stat -c %s "$provenance")" -le 16384
+          echo "baseline=$baseline" >> "$GITHUB_OUTPUT"
           echo "summary=$summary" >> "$GITHUB_OUTPUT"
           echo "provenance=$provenance" >> "$GITHUB_OUTPUT"
 
@@ -171,6 +176,7 @@ jobs:
           EXPECTED_HEAD_REPO: ${{ steps.pr.outputs.head_repo }}
           EXPECTED_HEAD_SHA: ${{ steps.pr.outputs.head_sha }}
           EXPECTED_PR_NUMBER: ${{ steps.pr.outputs.number }}
+          BASELINE_PATH: ${{ steps.data.outputs.baseline }}
           PROVENANCE_PATH: ${{ steps.data.outputs.provenance }}
           SUMMARY_PATH: ${{ steps.data.outputs.summary }}
         with:
@@ -180,7 +186,7 @@ jobs:
             const SHA_RE = /^[0-9a-f]{40}$/;
             const SHA256_RE = /^[0-9a-f]{64}$/;
             const expectedKeys = [
-              "base_ref", "base_sha", "harness_sha256", "head_ref",
+              "base_ref", "base_sha", "baseline_sha256", "harness_sha256", "head_ref",
               "head_repository", "head_sha", "kind", "merge_sha",
               "pr_number", "repository", "run_attempt", "run_id",
               "schema_version", "summary_sha256",
@@ -200,7 +206,7 @@ jobs:
             const repository = context.payload.repository?.full_name;
             const prNumber = Number(process.env.EXPECTED_PR_NUMBER);
             if (
-              provenance.schema_version !== 1 ||
+              provenance.schema_version !== 2 ||
               provenance.kind !== "solar-cross-lsp-comment-data" ||
               provenance.repository !== repository ||
               provenance.pr_number !== prNumber ||
@@ -213,7 +219,8 @@ jobs:
               !SHA_RE.test(provenance.base_sha || "") ||
               !SHA_RE.test(provenance.merge_sha || "") ||
               !SHA256_RE.test(provenance.harness_sha256 || "") ||
-              !SHA256_RE.test(provenance.summary_sha256 || "")
+              !SHA256_RE.test(provenance.summary_sha256 || "") ||
+              !SHA256_RE.test(provenance.baseline_sha256 || "")
             ) {
               throw new Error("Comment provenance does not match the workflow run");
             }
@@ -223,6 +230,17 @@ jobs:
               .digest("hex");
             if (summaryDigest !== provenance.summary_sha256) {
               throw new Error("Summary digest does not match comment provenance");
+            }
+            const baselineBytes = fs.readFileSync(process.env.BASELINE_PATH);
+            if (crypto.createHash("sha256").update(baselineBytes).digest("hex") !== provenance.baseline_sha256) {
+              throw new Error("Baseline digest does not match comment provenance");
+            }
+            const baseline = JSON.parse(baselineBytes);
+            const solar = baseline.servers?.filter((server) => server.id === "solar");
+            if (solar?.length !== 1 || solar[0].source_revision_override !== provenance.base_sha ||
+                baseline.harness_git_revision !== provenance.merge_sha ||
+                baseline.harness_executable_sha256 !== provenance.harness_sha256) {
+              throw new Error("Baseline does not match the tested base and harness");
             }
             const { data: pull } = await github.rest.pulls.get({
               ...context.repo,
@@ -284,6 +302,7 @@ jobs:
           EXPECTED_HARNESS_SHA256: ${{ steps.provenance.outputs.harness_sha256 }}
           EXPECTED_MERGE_SHA: ${{ steps.provenance.outputs.merge_sha }}
           SUMMARY_PATH: ${{ steps.data.outputs.summary }}
+          BASELINE_PATH: ${{ steps.data.outputs.baseline }}
         run: |
           set -euo pipefail
           destination="$RUNNER_TEMP/cross-lsp-comment-final/report.md"
@@ -293,9 +312,13 @@ jobs:
             report --input "$SUMMARY_PATH" --output "$destination" \
             --expected-harness-revision "$EXPECTED_MERGE_SHA" \
             --expected-harness-sha256 "$EXPECTED_HARNESS_SHA256" \
-            --expected-profile pr-smoke
+            --expected-profile pr-smoke \
+            --baseline "$BASELINE_PATH" --comment-output "$destination.changed"
           test -s "$destination"
           test "$(stat -c %s "$destination")" -le 60000
+          changed="$(cat "$destination.changed")"
+          case "$changed" in true|false) ;; *) exit 1 ;; esac
+          echo "changed=$changed" >> "$GITHUB_OUTPUT"
           echo "path=$destination" >> "$GITHUB_OUTPUT"
 
       - name: Recheck pull request identity
@@ -357,7 +380,8 @@ jobs:
           steps.data.outcome == 'success' &&
           steps.provenance.outcome == 'success' &&
           steps.report.outcome == 'success' &&
-          steps.recheck.outcome == 'success'
+          steps.recheck.outcome == 'success' &&
+          steps.report.outputs.changed == 'true'
         uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3.0.5
         with:
           header: cross-lsp-benchmark

--- a/.github/workflows/lsp-bench-cross-server-command.yml
+++ b/.github/workflows/lsp-bench-cross-server-command.yml
@@ -17,7 +17,7 @@ jobs:
       github.event_name == 'issue_comment' &&
       github.event.issue.pull_request &&
       github.event.comment.body == '/bench cross-server'
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
     timeout-minutes: 5
     permissions:
       contents: read
@@ -114,7 +114,7 @@ jobs:
     name: run cross-server PR smoke
     needs: resolve
     if: needs.resolve.result == 'success'
-    runs-on: ubuntu-24.04
+    runs-on: depot-ubuntu-latest
     timeout-minutes: 120
     continue-on-error: true
     permissions:
@@ -255,7 +255,7 @@ jobs:
       needs.resolve.result == 'success' &&
       needs.benchmark.result == 'success' &&
       needs.benchmark.outputs.artifact_id != ''
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
     timeout-minutes: 10
     permissions:
       actions: read

--- a/.github/workflows/lsp-bench.yml
+++ b/.github/workflows/lsp-bench.yml
@@ -14,8 +14,11 @@ jobs:
     name: cross-server PR smoke
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-24.04
-    timeout-minutes: 120
+    timeout-minutes: 30
     continue-on-error: true
+    env:
+      RUSTC_WRAPPER: sccache
+      SCCACHE_GHA_ENABLED: "true"
     permissions:
       contents: read
     concurrency:
@@ -44,6 +47,13 @@ jobs:
         with:
           toolchain: "1.96"
 
+      - uses: Swatinem/rust-cache@f0d9c3887740aee45f6153b24b3a6b815192ec16 # v2
+        with:
+          cache-on-failure: true
+          cache-targets: false
+
+      - uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
+
       - name: Check runner prerequisites
         shell: bash
         run: |
@@ -53,6 +63,18 @@ jobs:
           for command in cargo curl git lscpu node npm rustc sha256sum tar; do
             command -v "$command"
           done
+
+      - name: Build PR base
+        shell: bash
+        run: |
+          set -euo pipefail
+          baseline="$RUNNER_TEMP/solar-base"
+          git worktree add --detach "$baseline" "$(git rev-parse HEAD^1)"
+          CARGO_TARGET_DIR="$GITHUB_WORKSPACE/target" cargo build --locked --release \
+            --manifest-path "$baseline/Cargo.toml" -p solar-compiler --bin solar
+          mkdir -p target/lsp-bench
+          cp target/release/solar target/lsp-bench/solar-base
+          git worktree remove "$baseline"
 
       - name: Build candidate and harness
         env:
@@ -91,7 +113,19 @@ jobs:
           npm --prefix target/lsp-bench/servers/nomic-foundation ls --all --json \
             > target/lsp-bench/provenance/nomic-foundation-npm-tree.json || true
 
+      - name: Run PR base with the same harness and fixtures
+        timeout-minutes: 10
+        shell: bash
+        run: |
+          set -euo pipefail
+          target/release/solar-lsp-bench run \
+            --profile pr-smoke --server solar \
+            --output target/lsp-bench/base-smoke --allow-failures \
+            --solar-binary target/lsp-bench/solar-base \
+            --solar-revision "$(git rev-parse HEAD^1)"
+
       - name: Run PR smoke comparison
+        timeout-minutes: 10
         shell: bash
         env:
           TESTED_MERGE_SHA: ${{ github.sha }}
@@ -115,6 +149,7 @@ jobs:
         with:
           name: cross-lsp-pr-smoke-${{ github.run_id }}-${{ github.run_attempt }}
           path: |
+            target/lsp-bench/base-smoke/
             target/lsp-bench/pr-smoke/summary.md
             target/lsp-bench/pr-smoke/summary.json
             target/lsp-bench/pr-smoke/samples.json
@@ -130,7 +165,8 @@ jobs:
       - name: Stage PR smoke comment data
         if: >-
           always() &&
-          hashFiles('target/lsp-bench/pr-smoke/summary.json') != ''
+          hashFiles('target/lsp-bench/pr-smoke/summary.json') != '' &&
+          hashFiles('target/lsp-bench/base-smoke/summary.json') != ''
         shell: bash
         env:
           BASE_REF: ${{ github.event.pull_request.base.ref }}
@@ -147,13 +183,14 @@ jobs:
           export TESTED_BASE_SHA
           mkdir -p target/lsp-bench/pr-comment
           cp -- target/lsp-bench/pr-smoke/summary.json target/lsp-bench/pr-comment/summary.json
+          cp -- target/lsp-bench/base-smoke/summary.json target/lsp-bench/pr-comment/baseline.json
           node <<'NODE'
           const crypto = require("crypto");
           const fs = require("fs");
           const digest = (path) =>
             crypto.createHash("sha256").update(fs.readFileSync(path)).digest("hex");
           const provenance = {
-            schema_version: 1,
+            schema_version: 2,
             kind: "solar-cross-lsp-comment-data",
             repository: process.env.GITHUB_REPOSITORY,
             pr_number: Number(process.env.PR_NUMBER),
@@ -167,6 +204,7 @@ jobs:
             merge_sha: process.env.TESTED_MERGE_SHA,
             harness_sha256: digest("target/release/solar-lsp-bench"),
             summary_sha256: digest("target/lsp-bench/pr-comment/summary.json"),
+            baseline_sha256: digest("target/lsp-bench/pr-comment/baseline.json"),
           };
           fs.writeFileSync(
             "target/lsp-bench/pr-comment/provenance.json",

--- a/.github/workflows/lsp-bench.yml
+++ b/.github/workflows/lsp-bench.yml
@@ -13,7 +13,7 @@ jobs:
   pr-smoke:
     name: cross-server PR smoke
     if: github.event_name == 'pull_request'
-    runs-on: ubuntu-24.04
+    runs-on: depot-ubuntu-latest
     timeout-minutes: 30
     continue-on-error: true
     env:
@@ -225,7 +225,7 @@ jobs:
   full:
     name: full cross-server comparison
     if: github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main'
-    runs-on: ubuntu-24.04
+    runs-on: depot-ubuntu-latest
     timeout-minutes: 360
     permissions:
       contents: read

--- a/benches/lsp/test_cross_server_workflow.py
+++ b/benches/lsp/test_cross_server_workflow.py
@@ -14,7 +14,6 @@ import tempfile
 import unittest
 from pathlib import Path
 
-
 ROOT = Path(__file__).resolve().parents[2]
 WORKFLOW_PATH = ROOT / ".github/workflows/lsp-bench.yml"
 COMMENT_WORKFLOW_PATH = ROOT / ".github/workflows/lsp-bench-comment.yml"
@@ -27,7 +26,9 @@ UPLOAD_ACTION = "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0
 STICKY_COMMENT_ACTION = (
     "marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88"
 )
-SERVER_ARGS = "--server solar --server asyncswap --server nomic-foundation --server solc"
+SERVER_ARGS = (
+    "--server solar --server asyncswap --server nomic-foundation --server solc"
+)
 
 
 def workflow() -> str:
@@ -171,6 +172,15 @@ const context = {{
     return completed.stderr
 
 
+BASELINE_SUMMARY = json.dumps(
+    {
+        "harness_git_revision": "c" * 40,
+        "harness_executable_sha256": "d" * 64,
+        "servers": [{"id": "solar", "source_revision_override": "a" * 40}],
+    }
+).encode()
+
+
 def run_workflow_comment_validation(
     provenance: dict[str, object],
     summary: bytes,
@@ -179,6 +189,7 @@ def run_workflow_comment_validation(
     merge: dict[str, object],
     *,
     expect_success: bool,
+    baseline: bytes = BASELINE_SUMMARY,
 ) -> str:
     step = step_block(
         comment_job_block("comment"),
@@ -219,6 +230,8 @@ const github = {{
         root = Path(directory)
         summary_path = root / "summary.json"
         provenance_path = root / "provenance.json"
+        baseline_path = root / "baseline.json"
+        baseline_path.write_bytes(baseline)
         summary_path.write_bytes(summary)
         provenance_path.write_text(json.dumps(provenance), encoding="utf-8")
         environment = os.environ.copy()
@@ -230,6 +243,7 @@ const github = {{
                 "EXPECTED_PR_NUMBER": "12",
                 "PROVENANCE_PATH": str(provenance_path),
                 "SUMMARY_PATH": str(summary_path),
+                "BASELINE_PATH": str(baseline_path),
             }
         )
         completed = subprocess.run(
@@ -245,7 +259,9 @@ const github = {{
         completed.check_returncode()
         return completed.stdout
     if completed.returncode == 0:
-        raise AssertionError("workflow comment validation unexpectedly accepted provenance")
+        raise AssertionError(
+            "workflow comment validation unexpectedly accepted provenance"
+        )
     return completed.stderr
 
 
@@ -307,6 +323,33 @@ class CrossServerWorkflowTests(unittest.TestCase):
         self.assertIn('--solar-revision "$TESTED_MERGE_SHA"', run)
         self.assertIn('TESTED_MERGE_SHA: ${{ github.sha }}', run)
         self.assertNotIn("--require-authoritative", pr)
+
+    def test_automatic_comments_require_base_result_changes(self) -> None:
+        pr = job_block("pr-smoke")
+        self.assertIn("git rev-parse HEAD^1", step_block(pr, "Build PR base"))
+        self.assertIn(
+            "--server solar",
+            step_block(pr, "Run PR base with the same harness and fixtures"),
+        )
+        self.assertIn("timeout-minutes: 30", pr)
+        self.assertIn("timeout-minutes: 10", step_block(pr, "Run PR smoke comparison"))
+        self.assertIn("RUSTC_WRAPPER: sccache", pr)
+        self.assertIn('SCCACHE_GHA_ENABLED: "true"', pr)
+        manifest = (ROOT / "tools/lsp-bench/benchmark.yaml").read_text()
+        self.assertIn(
+            "timeout_ms: 5000",
+            manifest.split("  pr-smoke:", 1)[1].split("  full:", 1)[0],
+        )
+        self.assertIn("baseline_sha256:", step_block(pr, "Stage PR smoke comment data"))
+        job = comment_job_block("comment")
+        self.assertIn(
+            '--baseline "$BASELINE_PATH" --comment-output',
+            step_block(job, "Render comment from validated data"),
+        )
+        self.assertIn(
+            "steps.report.outputs.changed == 'true'",
+            step_block(job, "Publish sticky benchmark comment"),
+        )
 
     def test_pr_smoke_uploads_only_validated_comment_data(self) -> None:
         pr = job_block("pr-smoke")
@@ -619,7 +662,7 @@ class CrossServerWorkflowTests(unittest.TestCase):
     ) -> None:
         summary = b'{"schema_version":7}\n'
         provenance: dict[str, object] = {
-            "schema_version": 1,
+            "schema_version": 2,
             "kind": "solar-cross-lsp-comment-data",
             "repository": "target/solar",
             "pr_number": 12,
@@ -633,6 +676,7 @@ class CrossServerWorkflowTests(unittest.TestCase):
             "merge_sha": "c" * 40,
             "harness_sha256": "d" * 64,
             "summary_sha256": hashlib.sha256(summary).hexdigest(),
+            "baseline_sha256": hashlib.sha256(BASELINE_SUMMARY).hexdigest(),
         }
         pull: dict[str, object] = {
             "state": "open",
@@ -662,6 +706,31 @@ class CrossServerWorkflowTests(unittest.TestCase):
         )
         self.assertEqual(outputs["base_sha"], "a" * 40)
         self.assertEqual(outputs["merge_sha"], "c" * 40)
+
+        error = run_workflow_comment_validation(
+            provenance,
+            summary,
+            pull,
+            base,
+            merge,
+            expect_success=False,
+            baseline=BASELINE_SUMMARY + b" ",
+        )
+        self.assertIn("Baseline digest does not match", error)
+
+        wrong_baseline = BASELINE_SUMMARY.replace(b"a" * 40, b"f" * 40)
+        error = run_workflow_comment_validation(
+            dict(
+                provenance, baseline_sha256=hashlib.sha256(wrong_baseline).hexdigest()
+            ),
+            summary,
+            pull,
+            base,
+            merge,
+            expect_success=False,
+            baseline=wrong_baseline,
+        )
+        self.assertIn("Baseline does not match the tested base", error)
 
         stale_base = {"commit": {"sha": "f" * 40}}
         error = run_workflow_comment_validation(

--- a/benches/lsp/test_cross_server_workflow.py
+++ b/benches/lsp/test_cross_server_workflow.py
@@ -281,14 +281,14 @@ class CrossServerWorkflowTests(unittest.TestCase):
 
         self.assertIn("if: github.event_name == 'pull_request'", pr)
         self.assertIn("continue-on-error: true", pr)
-        self.assertIn("runs-on: ubuntu-24.04", pr)
+        self.assertIn("runs-on: depot-ubuntu-latest", pr)
         self.assertIn("contents: read", pr)
         self.assertIn("cancel-in-progress: true", pr)
         self.assertIn(
             "if: github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main'",
             full,
         )
-        self.assertIn("runs-on: ubuntu-24.04", full)
+        self.assertIn("runs-on: depot-ubuntu-latest", full)
         self.assertIn("timeout-minutes: 360", full)
         self.assertIn("contents: read", full)
         self.assertIn("cancel-in-progress: false", full)

--- a/benches/lsp/test_workflow.py
+++ b/benches/lsp/test_workflow.py
@@ -1177,8 +1177,7 @@ class ExecutionAndRemovalTests(unittest.TestCase):
                 1,
             )
             self.assertIn('mkdir -p "$RUNNER_TEMP/lsp-bench-bin"', job)
-            self.assertIn("runs-on: ubuntu-latest", job)
-            self.assertNotIn("depot-ubuntu-latest", job)
+            self.assertIn("runs-on: depot-ubuntu-latest", job)
         self.assertEqual(
             WORKFLOW.count(
                 "cargo build --locked --release -p solar-compiler --bin solar"
@@ -1219,8 +1218,7 @@ class ExecutionAndRemovalTests(unittest.TestCase):
         self.assertIn('patch --batch --forward --directory="$source_dir"', compute)
         self.assertIn('--lsp-bench "$RUNNER_TEMP/lsp-bench-tool/lsp-bench"', compute)
         self.assertNotIn("lsp_filter.py", WORKFLOW)
-        self.assertIn("runs-on: ubuntu-latest", compute)
-        self.assertNotIn("depot-ubuntu-latest", compute)
+        self.assertIn("runs-on: depot-ubuntu-latest", compute)
 
     def test_existing_benchmark_workflow_tracks_tested_merge_base(self) -> None:
         trigger = BENCH_WORKFLOW.split("\nenv:", 1)[0]

--- a/tools/lsp-bench/README.md
+++ b/tools/lsp-bench/README.md
@@ -111,6 +111,22 @@ record provenance, and upload the run's summary and raw samples. The generated
 `summary.md` is appended directly to the GitHub job summary; no second
 validation or rendering phase is required.
 
+Automatic PR comments compare our compiler against the tested merge's first
+parent, using the same harness and fixtures. They post only when workload status
+changes, a workload is added or removed, or latency p50 moves by more than both
+10% and 0.1 ms with non-overlapping p50–p95 intervals. This is a noise filter for
+shared runners, not a statistical significance claim. External-server timing
+changes and provenance-only changes do not trigger comments. Missing or mismatched
+base evidence prevents publication; full reports remain in workflow artifacts.
+Manual `/bench cross-server` requests still produce a report on demand.
+The synthetic PR-smoke profile limits operations to five seconds so unsupported
+or unresponsive external servers do not consume repeated 30-second waits.
+Automatic smoke steps have ten-minute limits; the full profile keeps its original
+timeout and sampling settings.
+
+Reports show workload status counts by server, with full metrics and provenance
+in collapsed details sections.
+
 ## Accounting
 
 Every run is portable by default. Process reports include wall time, CPU, and

--- a/tools/lsp-bench/README.md
+++ b/tools/lsp-bench/README.md
@@ -124,8 +124,11 @@ or unresponsive external servers do not consume repeated 30-second waits.
 Automatic smoke steps have ten-minute limits; the full profile keeps its original
 timeout and sampling settings.
 
-Reports show workload status counts by server, with full metrics and provenance
-in collapsed details sections.
+Reports compare per-workload median latency across servers side by side, in
+milliseconds (lower is better). Failed or unsupported workloads show their status
+instead of a latency. Full metrics and provenance stay in collapsed details
+sections. The separate comparison with the PR base controls automatic publication;
+it does not replace the cross-server timing table.
 
 ## Accounting
 

--- a/tools/lsp-bench/benchmark.yaml
+++ b/tools/lsp-bench/benchmark.yaml
@@ -24,7 +24,7 @@ profiles:
     samples: 20
     cold_samples: 4
     lifecycle_samples: 4
-    timeout_ms: 30000
+    timeout_ms: 5000
     network_isolation: false
     require_authoritative: false
     scenarios:

--- a/tools/lsp-bench/src/main.rs
+++ b/tools/lsp-bench/src/main.rs
@@ -91,6 +91,12 @@ enum Command {
         /// Markdown report destination.
         #[arg(long, default_value = "target/lsp-bench/latest/summary.md")]
         output: PathBuf,
+        /// Base-revision summary for deciding whether an automatic comment is useful.
+        #[arg(long, requires = "comment_output")]
+        baseline: Option<PathBuf>,
+        /// Write whether results changed enough to post a comment.
+        #[arg(long, requires = "baseline")]
+        comment_output: Option<PathBuf>,
         /// Refuse to generate a report from a non-authoritative run.
         #[arg(long)]
         require_authoritative: bool,
@@ -175,6 +181,8 @@ fn main() -> Result<()> {
         Command::Report {
             input,
             output,
+            baseline,
+            comment_output,
             require_authoritative,
             expected_harness_revision,
             expected_harness_sha256,
@@ -187,6 +195,7 @@ fn main() -> Result<()> {
                 expected_harness_revision.as_deref(),
                 expected_harness_sha256.as_deref(),
                 expected_profile.as_deref(),
+                baseline.as_deref().zip(comment_output.as_deref()),
             )?;
             println!("Report: {}", output.display());
         }

--- a/tools/lsp-bench/src/report.rs
+++ b/tools/lsp-bench/src/report.rs
@@ -12,7 +12,7 @@ use anyhow::{Context, Result, bail};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::{
-    collections::BTreeMap,
+    collections::{BTreeMap, BTreeSet},
     fmt::Write as _,
     fs,
     path::{Path, PathBuf},
@@ -586,11 +586,7 @@ fn solar_changes(base: &SummaryReport, candidate: &SummaryReport) -> Result<Stri
             continue;
         }
         for (name, metric) in &group.metrics {
-            if !(name.starts_with("textDocument/") && !name.ends_with("_cpu_ms")
-                || name == "cold_ready_ms"
-                || name.starts_with("edit_to_")
-                || name.starts_with("save_to_"))
-            {
+            if !is_latency_metric(name) {
                 continue;
             }
             if let Some(previous) = old.metrics.get(name)
@@ -676,6 +672,68 @@ pub(crate) fn terminal(summary: &SummaryReport) -> String {
     output
 }
 
+fn is_latency_metric(name: &str) -> bool {
+    name.starts_with("textDocument/") && !name.ends_with("_cpu_ms")
+        || name == "cold_ready_ms"
+        || name.starts_with("edit_to_")
+        || name.starts_with("save_to_")
+}
+
+fn latency_table(summary: &SummaryReport) -> String {
+    let mut servers =
+        summary.summaries.iter().map(|group| group.server.as_str()).collect::<Vec<_>>();
+    servers.sort_unstable_by_key(|&server| (server != "solar", server));
+    servers.dedup();
+    let mut workloads = BTreeMap::<_, BTreeMap<_, _>>::new();
+    for group in &summary.summaries {
+        workloads
+            .entry((group.fixture.as_str(), group.workload.as_str()))
+            .or_default()
+            .insert(group.server.as_str(), group);
+    }
+    let mut output = String::from("| Benchmark | Metric |");
+    for server in &servers {
+        let _ = write!(output, " {} |", markdown_cell(server));
+    }
+    output.push_str("\n|---|---|");
+    for _ in &servers {
+        output.push_str("---:|");
+    }
+    output.push('\n');
+    for ((fixture, workload), groups) in workloads {
+        let mut metrics = groups
+            .values()
+            .flat_map(|group| group.metrics.keys())
+            .map(String::as_str)
+            .filter(|name| is_latency_metric(name))
+            .collect::<BTreeSet<_>>();
+        if metrics.is_empty() {
+            metrics.insert("");
+        }
+        for metric in metrics {
+            let _ = write!(
+                output,
+                "| {} | {} |",
+                markdown_cell(&format!("{fixture}/{workload}")),
+                markdown_cell(if metric.is_empty() { "—" } else { metric })
+            );
+            for server in &servers {
+                let value = match groups.get(server) {
+                    Some(group) if group.status == SummaryStatus::Pass => group
+                        .metrics
+                        .get(metric)
+                        .map_or_else(|| "—".into(), |stats| format!("{:.2}", stats.p50)),
+                    Some(group) => markdown_result(group).into(),
+                    None => "—".into(),
+                };
+                let _ = write!(output, " {value} |");
+            }
+            output.push('\n');
+        }
+    }
+    output
+}
+
 fn markdown(summary: &SummaryReport) -> String {
     let mut output = String::from("# Cross-server Solidity LSP benchmark\n\n");
     if !summary.environment.authoritative {
@@ -683,25 +741,8 @@ fn markdown(summary: &SummaryReport) -> String {
             "> [!WARNING]\n> This run is not an authoritative performance measurement.\n\n",
         );
     }
-    let mut servers = BTreeMap::<&str, [usize; 5]>::new();
-    for group in &summary.summaries {
-        let index = match group.status {
-            SummaryStatus::Pass => 0,
-            SummaryStatus::Partial => 1,
-            SummaryStatus::Unsupported => 2,
-            SummaryStatus::Unavailable => 3,
-            SummaryStatus::Failed => 4,
-        };
-        servers.entry(&group.server).or_default()[index] += 1;
-    }
-    output.push_str("Workload results by server. Latencies are in milliseconds.\n\n| Server | Passed | Partial | Unsupported | Unavailable | Failed |\n|---|---:|---:|---:|---:|---:|\n");
-    for (server, [passed, partial, unsupported, unavailable, failed]) in servers {
-        let _ = writeln!(
-            output,
-            "| {} | {passed} | {partial} | {unsupported} | {unavailable} | {failed} |",
-            markdown_cell(server)
-        );
-    }
+    output.push_str("Median latency (p50), in milliseconds; lower is better. Only correct responses contribute timings.\n\n");
+    output.push_str(&latency_table(summary));
     output.push_str("\n<details>\n<summary>Run metadata and provenance</summary>\n\n## Run metadata\n\n| Field | Value |\n|---|---|\n");
     let metadata = [
         ("Result schema", summary.schema_version.to_string()),
@@ -1268,6 +1309,38 @@ mod tests {
     }
 
     #[test]
+    fn latency_table_compares_servers_without_timing_failed_responses() {
+        let group = SummaryGroup {
+            server: "solar".into(),
+            fixture: "synthetic".into(),
+            workload: "hover".into(),
+            successful_runs: 4,
+            status_counts: BTreeMap::from([("pass".into(), 4)]),
+            status: SummaryStatus::Pass,
+            metrics: BTreeMap::from([
+                ("textDocument/hover".into(), metric_stats(4, 1.0, 1.0, 1.2)),
+                ("session_wall_ms".into(), metric_stats(4, 99.0, 99.0, 99.0)),
+            ]),
+        };
+        let mut other = group.clone();
+        other.server = "asyncswap".into();
+        other.metrics.insert("textDocument/hover".into(), metric_stats(4, 2.0, 2.0, 2.1));
+        let mut failed = group.clone();
+        failed.server = "failed".into();
+        failed.status = SummaryStatus::Failed;
+        let summary = summary_with_groups(vec![other, failed, group]);
+        assert_data_eq!(
+            latency_table(&summary),
+            str![[r#"
+| Benchmark | Metric | ` solar ` | ` asyncswap ` | ` failed ` |
+|---|---|---:|---:|---:|
+| ` synthetic/hover ` | ` textDocument/hover ` | 1.00 | 2.00 | :red_circle: **FAILED** |
+
+"#]]
+        );
+    }
+
+    #[test]
     fn markdown_keeps_failed_groups_visible_without_metrics() {
         let group = SummaryGroup {
             server: "external".into(),
@@ -1292,11 +1365,11 @@ mod tests {
             str![[r#"
 # Cross-server Solidity LSP benchmark
 
-Workload results by server. Latencies are in milliseconds.
+Median latency (p50), in milliseconds; lower is better. Only correct responses contribute timings.
 
-| Server | Passed | Partial | Unsupported | Unavailable | Failed |
-|---|---:|---:|---:|---:|---:|
-| ` external ` | 0 | 0 | 0 | 0 | 1 |
+| Benchmark | Metric | ` external ` |
+|---|---|---:|
+| ` synthetic/correctness ` | ` — ` | :red_circle: **FAILED** |
 
 <details>
 <summary>Run metadata and provenance</summary>

--- a/tools/lsp-bench/src/report.rs
+++ b/tools/lsp-bench/src/report.rs
@@ -524,6 +524,7 @@ pub(crate) fn regenerate_markdown(
     expected_harness_revision: Option<&str>,
     expected_harness_sha256: Option<&str>,
     expected_profile: Option<&str>,
+    comparison: Option<(&Path, &Path)>,
 ) -> Result<()> {
     let summary = read_summary(input)?;
     if require_authoritative && !summary.environment.authoritative {
@@ -545,8 +546,94 @@ pub(crate) fn regenerate_markdown(
     {
         fs::create_dir_all(parent)?;
     }
-    fs::write(output, markdown(&summary))?;
+    let mut rendered = markdown(&summary);
+    if let Some((baseline, decision)) = comparison {
+        let changes = solar_changes(&read_summary(baseline)?, &summary)?;
+        fs::write(decision, if changes.is_empty() { "false\n" } else { "true\n" })?;
+        if !changes.is_empty() {
+            rendered.push_str("\n<details>\n<summary>Changes against the PR base</summary>\n\n| Fixture / workload | Change |\n|---|---|\n");
+            rendered.push_str(&changes);
+            rendered.push_str("\n</details>\n");
+        }
+    }
+    fs::write(output, rendered)?;
     Ok(())
+}
+
+/// Ignore provenance churn and small or overlapping latency distributions on shared runners.
+fn solar_changes(base: &SummaryReport, candidate: &SummaryReport) -> Result<String> {
+    if base.profile != candidate.profile
+        || base.config_sha256 != candidate.config_sha256
+        || base.harness_executable_sha256 != candidate.harness_executable_sha256
+        || base.fixtures.iter().map(|f| (&f.id, &f.content_sha256)).collect::<BTreeMap<_, _>>()
+            != candidate.fixtures.iter().map(|f| (&f.id, &f.content_sha256)).collect()
+    {
+        bail!("baseline and candidate must use the same harness, configuration, and fixtures");
+    }
+    let [mut before, after] = [base, candidate].map(|summary| {
+        summary
+            .summaries
+            .iter()
+            .filter(|group| group.server == "solar")
+            .map(|group| ((group.fixture.as_str(), group.workload.as_str()), group))
+            .collect::<BTreeMap<_, _>>()
+    });
+    if before.is_empty() || after.is_empty() {
+        bail!("baseline and candidate must include solar results");
+    }
+    let mut changes = String::new();
+    for ((fixture, workload), group) in after {
+        let key = markdown_cell(&format!("{fixture}/{workload}"));
+        let Some(old) = before.remove(&(fixture, workload)) else {
+            let _ = writeln!(changes, "| {key} | Added workload |");
+            continue;
+        };
+        if old.status != group.status || old.status_counts != group.status_counts {
+            let counts = |group: &SummaryGroup| {
+                markdown_cell(
+                    &group
+                        .status_counts
+                        .iter()
+                        .map(|(status, count)| format!("{status}:{count}"))
+                        .collect::<Vec<_>>()
+                        .join(", "),
+                )
+            };
+            let _ = writeln!(changes, "| {key} | {} → {} |", counts(old), counts(group));
+        }
+        if old.status != SummaryStatus::Pass || group.status != SummaryStatus::Pass {
+            continue;
+        }
+        for (name, metric) in &group.metrics {
+            if !(name.starts_with("textDocument/") && !name.ends_with("_cpu_ms")
+                || name == "cold_ready_ms"
+                || name.starts_with("edit_to_")
+                || name.starts_with("save_to_"))
+            {
+                continue;
+            }
+            if let Some(previous) = old.metrics.get(name)
+                && (metric.p50 - previous.p50).abs() > (previous.p50 * 0.1).max(0.1)
+                && (metric.p50 > previous.p95 || previous.p50 > metric.p95)
+            {
+                let _ = writeln!(
+                    changes,
+                    "| {key} | {} p50: {:.2} → {:.2} ms |",
+                    markdown_cell(name),
+                    previous.p50,
+                    metric.p50
+                );
+            }
+        }
+    }
+    for ((fixture, workload), _) in before {
+        let _ = writeln!(
+            changes,
+            "| {} | Removed workload |",
+            markdown_cell(&format!("{fixture}/{workload}"))
+        );
+    }
+    Ok(changes)
 }
 
 fn validate_expected(label: &str, actual: Option<&str>, expected: Option<&str>) -> Result<()> {
@@ -615,7 +702,26 @@ fn markdown(summary: &SummaryReport) -> String {
             "> [!WARNING]\n> This run is not an authoritative performance measurement.\n\n",
         );
     }
-    output.push_str("## Run metadata\n\n| Field | Value |\n|---|---|\n");
+    let mut servers = BTreeMap::<&str, [usize; 5]>::new();
+    for group in &summary.summaries {
+        let index = match group.status {
+            SummaryStatus::Pass => 0,
+            SummaryStatus::Partial => 1,
+            SummaryStatus::Unsupported => 2,
+            SummaryStatus::Unavailable => 3,
+            SummaryStatus::Failed => 4,
+        };
+        servers.entry(&group.server).or_default()[index] += 1;
+    }
+    output.push_str("Workload results by server. Latencies are in milliseconds.\n\n| Server | Passed | Partial | Unsupported | Unavailable | Failed |\n|---|---:|---:|---:|---:|---:|\n");
+    for (server, [passed, partial, unsupported, unavailable, failed]) in servers {
+        let _ = writeln!(
+            output,
+            "| {} | {passed} | {partial} | {unsupported} | {unavailable} | {failed} |",
+            markdown_cell(server)
+        );
+    }
+    output.push_str("\n<details>\n<summary>Run metadata and provenance</summary>\n\n## Run metadata\n\n| Field | Value |\n|---|---|\n");
     let metadata = [
         ("Result schema", summary.schema_version.to_string()),
         ("Config schema", summary.config_schema_version.to_string()),
@@ -714,6 +820,7 @@ fn markdown(summary: &SummaryReport) -> String {
             let _ = writeln!(output, "| {} |", values.join(" | "));
         }
     }
+    output.push_str("\n</details>\n\n<details>\n<summary>Detailed results</summary>\n\n");
     let capabilities = summary
         .workloads
         .iter()
@@ -770,6 +877,7 @@ fn markdown(summary: &SummaryReport) -> String {
             );
         }
     }
+    output.push_str("\n</details>\n");
     output
 }
 
@@ -983,6 +1091,7 @@ mod tests {
             Some(&"1".repeat(40)),
             Some(&"2".repeat(64)),
             Some("pr-smoke"),
+            None,
         )
         .unwrap();
         assert!(output.is_file());
@@ -1000,6 +1109,7 @@ mod tests {
                     revision.as_deref(),
                     digest.as_deref(),
                     profile,
+                    None,
                 )
                 .is_err()
             );
@@ -1031,6 +1141,67 @@ mod tests {
             command_output_with_timeout("sh", &["-c", "exec sleep 30"], Duration::from_millis(50));
         assert!(value.is_none(), "timed-out metadata must be unavailable");
         assert!(started.elapsed() < Duration::from_secs(3));
+    }
+
+    #[test]
+    fn comment_gate_ignores_noise_and_provenance_but_reports_result_changes() {
+        let base = summary_with_groups(vec![SummaryGroup {
+            server: "solar".into(),
+            fixture: "synthetic".into(),
+            workload: "hover".into(),
+            successful_runs: 4,
+            status_counts: BTreeMap::from([("pass".into(), 4)]),
+            status: SummaryStatus::Pass,
+            metrics: BTreeMap::from([(
+                "textDocument/hover".into(),
+                metric_stats(4, 1.0, 1.0, 1.2),
+            )]),
+        }]);
+        let mut candidate = base.clone();
+        candidate.harness_git_revision = Some("different revision".into());
+        candidate.summaries[0].metrics.get_mut("textDocument/hover").unwrap().p50 = 1.05;
+        assert_eq!(solar_changes(&base, &candidate).unwrap(), "");
+        candidate.summaries[0].metrics.get_mut("textDocument/hover").unwrap().p50 = 1.15;
+        assert_eq!(solar_changes(&base, &candidate).unwrap(), "");
+        candidate.summaries[0]
+            .metrics
+            .insert("textDocument/hover".into(), metric_stats(4, 2.0, 2.0, 2.2));
+        assert_data_eq!(
+            solar_changes(&base, &candidate).unwrap(),
+            str![[r#"
+| ` synthetic/hover ` | ` textDocument/hover ` p50: 1.00 → 2.00 ms |
+
+"#]]
+        );
+        assert_data_eq!(
+            solar_changes(&candidate, &base).unwrap(),
+            str![[r#"
+| ` synthetic/hover ` | ` textDocument/hover ` p50: 2.00 → 1.00 ms |
+
+"#]]
+        );
+        candidate.summaries[0].status = SummaryStatus::Failed;
+        candidate.summaries[0].status_counts = BTreeMap::from([("incorrect".into(), 4)]);
+        candidate.summaries[0].metrics.clear();
+        assert_data_eq!(
+            solar_changes(&base, &candidate).unwrap(),
+            str![[r#"
+| ` synthetic/hover ` | ` pass:4 ` → ` incorrect:4 ` |
+
+"#]]
+        );
+        let mut different_failure = candidate.clone();
+        different_failure.summaries[0].status_counts = BTreeMap::from([("crash".into(), 4)]);
+        assert_data_eq!(
+            solar_changes(&candidate, &different_failure).unwrap(),
+            str![[r#"
+| ` synthetic/hover ` | ` incorrect:4 ` → ` crash:4 ` |
+
+"#]]
+        );
+        candidate.config_sha256 = "mismatched config".into();
+        assert!(solar_changes(&base, &candidate).is_err());
+        assert!(solar_changes(&summary_with_groups(Vec::new()), &base).is_err());
     }
 
     #[test]
@@ -1147,10 +1318,20 @@ mod tests {
             output,
             str![[r#"
 # Cross-server Solidity LSP benchmark
+
+Workload results by server. Latencies are in milliseconds.
+
+| Server | Passed | Partial | Unsupported | Unavailable | Failed |
+|---|---:|---:|---:|---:|---:|
+| ` external ` | 0 | 0 | 0 | 0 | 1 |
+
+<details>
+<summary>Run metadata and provenance</summary>
 ...
-## Run metadata
-...
-## Results
+</details>
+
+<details>
+<summary>Detailed results</summary>
 ...
 | ` external ` | ` synthetic ` | ` correctness ` | ` textDocument/didChange, textDocument/didSave ` | 0 | ` incorrect:1 ` | :red_circle: **FAILED** | - | - | - | - | - |
 ...


### PR DESCRIPTION
Show per-workload median latency side by side for each server, with failed or unsupported results in place of timings. Keep detailed metrics and provenance collapsed. Compare our compiler with the tested PR base using the same harness and fixtures, and post automatic comments only for status changes or latency changes that exceed the noise filter. Keep full reports in workflow artifacts and preserve reports requested with `/bench cross-server`.

A recent smoke job spent 17m22s benchmarking, mostly in repeated 30-second waits on external servers. Limit synthetic smoke operations to five seconds, cap smoke steps at ten minutes, and enable persistent compiler caching. All LSP benchmark, command, and comment jobs use `depot-ubuntu-latest`. The full profile keeps its existing limits.

Addresses the [oversized benchmark comment](https://github.com/paradigmxyz/solar/pull/1403#issuecomment-5572118658).
