### PR TITLE
chore(ci): skip macOS on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,8 @@ jobs:
           - os: "ubuntu-latest"
             rust: "nightly"
         exclude:
+          - os: "macos-latest"
+            rust: ${{ github.event_name == 'push' && 'none' || 'stable' }}
           - os: "windows-latest"
             rust: ${{ github.event_name == 'push' && 'none' || 'stable' }}
     steps:


### PR DESCRIPTION
Run macOS tests only on pushes to `main`, matching the existing Windows matrix exclusion. This skips macOS on pull requests and manual workflow runs while retaining Linux coverage.

Prompted by: @DaniPopes
