### PR TITLE
fix: correct ABI data locations and lowering

### DIFF
--- a/crates/codegen/src/mir/lower/function/abi_calls.rs
+++ b/crates/codegen/src/mir/lower/function/abi_calls.rs
@@ -281,7 +281,13 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
     ) -> Option<(ValueId, AbiType)> {
         let value = self.lower_typed_expr(argument, parameter_ty)?;
         let abi_type = self.types.abi_type(parameter_ty)?;
-        let abi_type = self.abi_type_for_value(value, abi_type);
+        let abi_type = if self.cx.gcx.type_of_expr(argument.id).is_some_and(|ty| {
+            ty.is_ref_at(DataLocation::Memory) || ty.is_ref_at(DataLocation::Storage)
+        }) {
+            Self::memory_abi_type(abi_type)
+        } else {
+            self.abi_type_for_value(value, abi_type)
+        };
         self.validate_calldata_bytes_argument(value, &abi_type);
         self.prepare_abi_argument(argument, parameter_ty, value, abi_type)
     }

--- a/crates/codegen/src/mir/lower/function/abi_values.rs
+++ b/crates/codegen/src/mir/lower/function/abi_values.rs
@@ -214,8 +214,8 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
                 let ty = parameter_types[index];
                 let memory_ty = ty.with_loc_if_ref(this.cx.gcx, DataLocation::Memory);
                 let value = this.lower_typed_expr(expr, memory_ty)?;
-                let abi_type = this.types.abi_type(ty)?;
-                this.prepare_abi_encode_argument(expr, ty, value, abi_type)
+                let abi_type = this.types.abi_type(memory_ty)?;
+                this.prepare_abi_encode_argument(expr, memory_ty, value, abi_type)
             },
         )?;
         let (values, types): (Vec<_>, Vec<_>) = values_and_types.into_iter().unzip();

--- a/crates/codegen/src/mir/lower/function/memory_values.rs
+++ b/crates/codegen/src/mir/lower/function/memory_values.rs
@@ -103,7 +103,11 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
             args.span,
             "struct constructor argument",
             |this, index, argument| {
-                let field_ty = this.cx.gcx.type_of_item(struct_fields[index].into());
+                let field_ty = this
+                    .cx
+                    .gcx
+                    .type_of_item(struct_fields[index].into())
+                    .with_loc_if_ref(this.cx.gcx, DataLocation::Memory);
                 let value = this.lower_typed_expr(argument, field_ty)?;
                 let value = this.materialize_memory_argument(field_ty, value, argument.span)?;
                 Some(this.encode_memory_scalar(field_ty, value))

--- a/crates/codegen/src/mir/transform/lower_abi.rs
+++ b/crates/codegen/src/mir/transform/lower_abi.rs
@@ -40,6 +40,7 @@ use crate::mir::{
     FrameSlotKind, Function, FunctionBuilder, FunctionId, InstId, InstKind, MangledSymbol,
     MemoryObjectKind, MemoryObjectLayout, MirPhase, MirType, Module, PanicCode, RevertReason,
     SliceLocation, Terminator, Value, ValueId, memory::EvmMemoryLayout, pass::MirPass,
+    transform::cfg_simplify::remove_unreachable_blocks,
 };
 use alloy_primitives::U256;
 use solar_config::{EvmVersion, RevertStrings};
@@ -969,6 +970,7 @@ impl LowerAbiCx {
         else {
             return;
         };
+        // body(args) -> icall body_id, args; return results
         func.blocks[block].instructions.clear();
         func.blocks[block].terminator = None;
         let mut builder = FunctionBuilder::new(func);
@@ -1006,6 +1008,8 @@ impl LowerAbiCx {
             builder.ret(values);
         }
         let _ = crate::mir::utils::repair_reachability_phis(builder.func_mut());
+        // Drop the detached body blocks before lowering their now-orphaned slice projections.
+        let _ = remove_unreachable_blocks(builder.func_mut());
     }
 
     /// Rewrites `fallback(bytes calldata) returns (bytes memory)` into an

--- a/crates/codegen/src/mir/transform/lower_abi_encode.rs
+++ b/crates/codegen/src/mir/transform/lower_abi_encode.rs
@@ -5,12 +5,14 @@
 //! supplied by the lowering plan. Literal objects are kept until their projections
 //! can be folded. Generated stores inherit the encoding operation's source context;
 //! any block split moves the original terminator and its metadata together.
+//! Constructor-reachable encoders stay inline because their output is not reserved
+//! until encoding finishes, and a dynamic call frame would overlap that output.
 
 use crate::mir::{
     AbiEncodeMode, AbiLayout, AbiType, AbiWordValidator, BlockId, Function, FunctionBuilder,
     FunctionId, InstKind, InstructionMetadata, MemoryObjectKind, MemoryObjectLayout, MirType,
-    Module, RevertReason, SliceLocation, Terminator, Value, ValueId, pass::MirPass,
-    transform::utils::redirect_successor_predecessors, utils::resolve_replacement,
+    Module, RevertReason, SliceLocation, Terminator, Value, ValueId, analysis::CallGraphInfo,
+    pass::MirPass, transform::utils::redirect_successor_predecessors, utils::resolve_replacement,
 };
 
 use alloy_primitives::U256;
@@ -39,9 +41,26 @@ impl MirPass for LowerAbiEncode {
     ) -> bool {
         let revert_strings = gcx.sess.opts.revert_strings;
         let helpers = synthesize_array_helpers(module, revert_strings);
+        let call_graph = CallGraphInfo::new(module);
+        let mut constructors = call_graph.reachable_callees_from(
+            module
+                .functions
+                .iter_enumerated()
+                .filter_map(|(id, func)| func.attributes.is_constructor.then_some(id)),
+        );
+        for (id, func) in module.functions.iter_enumerated() {
+            if func.attributes.is_constructor {
+                constructors.insert(id);
+            }
+        }
+        let inline_helpers = EncodeHelpers::default();
         let mut changed = !helpers.arrays.is_empty();
-        for func in module.functions.iter_mut() {
-            changed |= lower_function(func, &helpers, revert_strings);
+        for (id, func) in module.functions.iter_mut_enumerated() {
+            // NOTE: Constructor calls allocate frames at the free-memory pointer. Encoding
+            // writes there before reserving its output, so an outlined call would overwrite it.
+            // abi_encode(args) => inline head stores and tail copies
+            let helpers = if constructors.contains(id) { &inline_helpers } else { &helpers };
+            changed |= lower_function(func, helpers, revert_strings);
         }
         changed
     }

--- a/tests/foundry/abi-encoding/test/AbiEncoding.t.sol
+++ b/tests/foundry/abi-encoding/test/AbiEncoding.t.sol
@@ -3,6 +3,10 @@ pragma solidity ^0.8.0;
 
 import {AbiEncoding} from "../src/AbiEncoding.sol";
 
+interface AbiVm {
+    function assertLt(uint256 a, uint256 b) external pure;
+}
+
 contract AbiEncodingTest {
     AbiEncoding target;
 
@@ -80,5 +84,98 @@ contract AbiEncodingTest {
 
     function testRuntimeCode() public view {
         assert(target.runtimeCodeLength() > 0);
+    }
+
+    function testConstructorReturnedStrings() public {
+        StringConfig config = new StringConfig(this);
+        string[] memory values = abi.decode(config.get(), (string[]));
+        assert(values.length == 2);
+        assert(keccak256(bytes(values[0])) == keccak256("bar"));
+        assert(keccak256(bytes(values[1])) == keccak256("baz"));
+    }
+
+    struct Page {
+        uint256 a;
+    }
+
+    struct Key {
+        uint256 a;
+    }
+
+    function page(Key calldata key, bytes calldata cursor)
+        external
+        pure
+        returns (Page memory result, bytes memory next, bool done)
+    {
+        if (cursor.length == 0) {
+            next = new bytes(480);
+            assembly { mstore(add(next, 32), 1) }
+        } else {
+            uint256 a = abi.decode(cursor, (uint256));
+            assert(a == 1);
+            done = true;
+        }
+        result.a = key.a;
+    }
+
+    function testPagedReturn() public view {
+        Page memory result = getPaged(Key(7));
+        assert(result.a == 7);
+    }
+
+    function getPaged(Key memory key) internal view returns (Page memory result) {
+        bytes memory cursor;
+        bool done;
+        uint256 pages;
+        while (!done) {
+            (result, cursor, done) = this.page(key, cursor);
+            pages++;
+            AbiVm(address(uint160(uint256(keccak256("hevm cheat code"))))).assertLt(pages, 3);
+        }
+        assert(result.a == 7);
+    }
+
+    struct Kind {
+        uint8 tag;
+        bool array;
+    }
+
+    struct Wrapped {
+        Kind kind;
+        bytes data;
+    }
+    mapping(uint256 => Kind) kinds;
+
+    function wrapStoredKind(uint256 key) external view returns (Wrapped memory) {
+        return Wrapped(kinds[key], hex"abcd");
+    }
+
+    function testStorageStructConstructorArgument() public {
+        kinds[7] = Kind(3, true);
+        Wrapped memory result = this.wrapStoredKind(7);
+        assert(result.kind.tag == 3 && result.kind.array);
+        assert(keccak256(result.data) == keccak256(hex"abcd"));
+    }
+
+    function strings() external pure returns (string[] memory values) {
+        values = new string[](2);
+        values[0] = "bar";
+        values[1] = "baz";
+    }
+}
+
+contract StringConfig {
+    mapping(uint256 => mapping(string => bytes)) stored;
+
+    constructor(AbiEncodingTest source) {
+        stored[1]["values"] = abi.encode(source.strings());
+    }
+
+    function reload(string[] memory values) external {
+        stored[1]["values"] = abi.encode(values);
+    }
+
+    function get() external view returns (bytes memory) {
+        return stored[1]["values"];
     }
 }

--- a/tests/foundry/constructor-args/test/ConstructorArgs.t.sol
+++ b/tests/foundry/constructor-args/test/ConstructorArgs.t.sol
@@ -9,6 +9,16 @@ contract ConstructorArgsTest {
     uint256 constant TEST_VALUE = 12345;
     address constant TEST_OWNER = address(0xBEEF);
 
+    function buildString() public returns (ConstructorStringArgs, address) {
+        return (new ConstructorStringArgs("test", address(this)), address(this));
+    }
+
+    function test_InternalStringConstructor() public {
+        (ConstructorStringArgs instance, address owner) = buildString();
+        require(keccak256(bytes(instance.name())) == keccak256("test"));
+        require(instance.owner() == owner);
+    }
+
     function setUp() public {
         c = new ConstructorArgs(TEST_VALUE, TEST_OWNER);
     }
@@ -27,5 +37,22 @@ contract ConstructorArgsTest {
 
     function test_GetOwner() public view {
         assert(c.getOwner() == TEST_OWNER);
+    }
+}
+
+contract ConstructorStringArgs {
+    string public name;
+    address public owner;
+    event NameChanged(string previous, string current);
+
+    constructor(string memory name_, address owner_) {
+        setName(name_);
+        owner = owner_;
+    }
+
+    function setName(string memory name_) internal {
+        string memory previous = name;
+        name = name_;
+        emit NameChanged(previous, name_);
     }
 }

--- a/tests/ui/codegen/lowering/run-call/abi_encode_call_memory_v2.mir.stdout
+++ b/tests/ui/codegen/lowering/run-call/abi_encode_call_memory_v2.mir.stdout
@@ -15,6 +15,139 @@ fn @something() [selector=0xa7a0d537, pure, abi_params=[], abi_returns=[]] {
     stop
 }
 
+fn @accept(arg0: calldataslice, arg1: calldataslice) -> bytes32 [selector=0x1403c78f, pure, abi_params=[bytes, array<_, u256>], abi_returns=[word]] {
+  bb0:
+    v0 = abi_encode [calldata_bytes, calldata_array<word>], scratch, args arg0, arg1
+    v1 = slice_ptr v0
+    v2 = slice_len v0
+    v3 = keccak256 v1, v2
+    ret v3
+}
+
+fn @next() -> memorybytes [selector=0x4c8fe526, pure, abi_params=[], abi_returns=[memory_bytes]] {
+  bb0:
+    v0 = not 31
+    v1 = and 543, v0
+    v2 = alloc memorybytes, exact, zeroed, panic, v1
+    set_memory_object_len memorybytes, v2, 480
+    v3 = add v2, 32
+    mstore v3, 1
+    ret v2
+}
+
+fn @memoryLoop() -> u256 [selector=0x0f61b86c, abi_params=[], abi_returns=[word]] {
+  bb0:
+    v0 = alloc memoryarray<1>, exact, zeroed, panic, 96
+    set_memory_object_len memoryarray, v0, 2
+    v1 = memory_object_len memoryarray, v0
+    v2 = lt 0, v1
+    v3 = iszero v2
+    jumpi v3, bb1, bb2
+  bb2:
+    memory_object_store_element memoryarray<1>, v0, 0, 42
+    v4 = memory_object_len memoryarray, v0
+    v5 = lt 1, v4
+    v6 = iszero v5
+    jumpi v6, bb1, bb3
+  bb3:
+    memory_object_store_element memoryarray<1>, v0, 1, 99
+    jump bb4
+  bb4:
+    v7 = phi [bb3: 0], [bb20: v51]
+    v8 = phi [bb3: 96], [bb20: v46]
+    v9 = phi [bb3: 0], [bb20: v9]
+    v10 = phi [bb3: v0], [bb20: v47]
+    v11 = lt v7, 2
+    jumpi v11, bb7, bb8
+  bb8:
+    jump bb5
+  bb5:
+    ret 1
+  bb7:
+    v12 = abi_encode [memory_bytes, memory_array<word>], object, selector 0x1403c78f00000000000000000000000000000000000000000000000000000000, args v8, v10
+    v13 = address
+    v14 = gas
+    v15 = memory_object_data memorybytes, v12
+    v16 = memory_object_len memorybytes, v12
+    v17 = call v14, v13, 0, v15, v16, 0, 0
+    v18 = returndatasize
+    v19 = add v18, 63
+    v20 = lt v19, v18
+    jumpi v20, bb10, bb11
+  bb11:
+    v21 = not 31
+    v22 = and v19, v21
+    v23 = alloc memorybytes, exact, uninitialized, infallible, v22
+    set_memory_object_len memorybytes, v23, v18
+    v24 = make_returndata_slice 0, v18
+    memory_object_copy_from_slice memorybytes, v23, v24
+    v25 = iszero v17
+    jumpi v25, bb12, bb13
+  bb13:
+    v26 = abi_decode [bytes32], v23
+    v27 = abi_encode [memory_bytes, memory_array<word>], scratch, args v8, v10
+    v28 = slice_ptr v27
+    v29 = slice_len v27
+    v30 = keccak256 v28, v29
+    v31 = eq v26, v30
+    v32 = iszero v31
+    jumpi v32, bb12, bb14
+  bb14:
+    v33 = address
+    v34 = gas
+    v35 = abi_encode [], selector 0x4c8fe52600000000000000000000000000000000000000000000000000000000
+    v36 = slice_ptr v35
+    v37 = slice_len v35
+    v38 = staticcall v34, v33, v36, v37, 0, 0
+    jumpi v38, bb16, bb15
+  bb15:
+    revert_returndata
+  bb16:
+    v39 = returndatasize
+    v40 = add v39, 63
+    v41 = lt v40, v39
+    jumpi v41, bb10, bb17
+  bb17:
+    v42 = not 31
+    v43 = and v40, v42
+    v44 = alloc memorybytes, exact, uninitialized, infallible, v43
+    set_memory_object_len memorybytes, v44, v39
+    v45 = make_returndata_slice 0, v39
+    memory_object_copy_from_slice memorybytes, v44, v45
+    v46 = abi_decode [bytes], v44
+    v47 = alloc memoryarray<1>, exact, zeroed, panic, 128
+    set_memory_object_len memoryarray, v47, 3
+    v48 = memory_object_len memoryarray, v47
+    v49 = lt 2, v48
+    v50 = iszero v49
+    jumpi v50, bb1, bb18
+  bb18:
+    memory_object_store_element memoryarray<1>, v47, 2, 123
+    jump bb9
+  bb9:
+    jump bb6
+  bb6:
+    v51 = add v7, 1
+    v52 = lt v51, v7
+    jumpi v52, bb19, bb20
+  bb20:
+    jump bb4
+  bb19:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 17 !metadata(memory=scratch)
+    revert 0, 36
+  bb12:
+    revert 0, 0
+  bb10:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 65 !metadata(memory=scratch)
+    revert 0, 36
+  bb1:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 50 !metadata(memory=scratch)
+    revert 0, 36
+}
+
 fn @test() -> bytes4 [selector=0xf8a8fd6d, abi_params=[], abi_returns=[word<bytes4>]] {
   bb0:
     v0 = alloc memoryfixedarray<2, 1>, exact, uninitialized, infallible, 64

--- a/tests/ui/codegen/lowering/run-call/abi_encode_call_memory_v2.sol
+++ b/tests/ui/codegen/lowering/run-call/abi_encode_call_memory_v2.sol
@@ -1,6 +1,7 @@
 //@ filecheck:
 // CHECK: @module
 //@ codegen-matrix: standard
+//@ run-call: memoryLoop => 1
 //@ run-call: test => 0xa7a0d537
 // ported-from: test/libsolidity/semanticTests/abicoder/abi_encode_call_memory_v2.sol
 
@@ -10,6 +11,32 @@ contract AbiEncodeCallMemoryTarget {
 
 contract AbiEncodeCallMemory {
     function something() external pure {}
+
+    function accept(bytes calldata data, uint256[] calldata values) external pure returns (bytes32) {
+        return keccak256(abi.encode(data, values));
+    }
+
+    function next() external pure returns (bytes memory data) {
+        data = new bytes(480);
+        assembly { mstore(add(data, 32), 1) }
+    }
+
+    function memoryLoop() external returns (uint256) {
+        bytes memory data;
+        uint256[] memory values = new uint256[](2);
+        values[0] = 42;
+        values[1] = 99;
+        for (uint256 i; i < 2; ++i) {
+            bytes memory encoded = abi.encodeCall(this.accept, (data, values));
+            (bool ok, bytes memory result) = address(this).call(encoded);
+            require(ok);
+            require(abi.decode(result, (bytes32)) == keccak256(abi.encode(data, values)));
+            data = this.next();
+            values = new uint256[](3);
+            values[2] = 123;
+        }
+        return 1;
+    }
 
     function test() external returns (bytes4) {
         function() external[2] memory pointers;

--- a/tests/ui/codegen/mir/lowering/lower_abi_retargets_calls.mir
+++ b/tests/ui/codegen/mir/lowering/lower_abi_retargets_calls.mir
@@ -38,8 +38,24 @@ fn @literal() -> memorybytes [selector=0x0a0a0a03, abi_params=[], abi_returns=[m
 // CHECK: + {{v[0-9]+}} = icall @literal.body
 // CHECK: + fn @pub.body{{[( ]}}
 // CHECK: + fn @literal.body{{[( ]}}
+// CHECK: + fn @sliceBody.body{{[( ]}}
 fn @literalCaller() -> memorybytes [selector=0x0a0a0a04, abi_params=[], abi_returns=[memory_bytes]] {
   bb0:
     v0 = icall fn2, 1
+    ret v0
+}
+
+fn @sliceBody() -> u256 [selector=0x0a0a0a05, abi_params=[], abi_returns=[word]] {
+  bb0:
+    v0 = make_calldata_slice 4, 32
+    jump bb1
+  bb1:
+    v1 = slice_ptr v0
+    ret v1
+}
+
+fn @sliceCaller() -> u256 [selector=0x0a0a0a06, abi_params=[], abi_returns=[word]] {
+  bb0:
+    v0 = icall fn4, 1
     ret v0
 }

--- a/tests/ui/codegen/mir/lowering/lower_abi_retargets_calls.stdout
+++ b/tests/ui/codegen/mir/lowering/lower_abi_retargets_calls.stdout
@@ -25,7 +25,6 @@
 + fn @caller() [selector=0x0a0a0a02] {
     bb0:
 -     v0 = icall @pub, 1, arg0
--     ret v0
 +     v1 = calldatasize
 +     v2 = lt v1, 36
 +     jumpi v2, bb2, bb3
@@ -39,14 +38,10 @@
 +     returndata 128, v4
 +   bb2:
 +     revert 0, 0
-  }
-  
-- fn @literal() -> memorybytes [selector=0x0a0a0a03, abi_params=[], abi_returns=[memory_bytes]] {
++ }
++ 
 + fn @literal() [selector=0x0a0a0a03] {
-    bb0:
--     v0 = alloc memorybytes, exact, uninitialized, infallible, 64
--     set_memory_object_len memorybytes, v0, 1
--     memory_object_store_word memorybytes, v0, 0, 0x31ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
++   bb0:
 +     mstore 128, 32
 +     mstore 160, 1
 +     mstore 192, 0x3100000000000000000000000000000000000000000000000000000000000000
@@ -62,19 +57,58 @@
 +     returndata v2, v3
 + }
 + 
++ fn @sliceBody() [selector=0x0a0a0a05] {
++   bb0:
++     v2 = icall @sliceBody.body, 1
++     mstore 128, v2
++     v3 = add 128, 32
++     v4 = sub v3, 128
++     returndata 128, v4
++ }
++ 
++ fn @sliceCaller() [selector=0x0a0a0a06] {
++   bb0:
++     v0 = icall @sliceBody.body, 1
++     mstore 128, v0
++     v1 = add 128, 32
++     v2 = sub v1, 128
++     returndata 128, v2
++ }
++ 
 + fn @pub.body(arg0: u256) -> u256 {
 +   bb0:
 +     v0 = add arg0, 1
       ret v0
   }
   
-- fn @literalCaller() -> memorybytes [selector=0x0a0a0a04, abi_params=[], abi_returns=[memory_bytes]] {
+- fn @literal() -> memorybytes [selector=0x0a0a0a03, abi_params=[], abi_returns=[memory_bytes]] {
 + fn @literal.body() -> memorybytes {
     bb0:
--     v0 = icall @literal, 1
-+     v0 = alloc memorybytes, exact, uninitialized, infallible, 64
-+     set_memory_object_len memorybytes, v0, 1
-+     memory_object_store_word memorybytes, v0, 0, 0x31ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+      v0 = alloc memorybytes, exact, uninitialized, infallible, 64
+      set_memory_object_len memorybytes, v0, 1
+      memory_object_store_word memorybytes, v0, 0, 0x31ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
       ret v0
+  }
+  
+- fn @literalCaller() -> memorybytes [selector=0x0a0a0a04, abi_params=[], abi_returns=[memory_bytes]] {
++ fn @sliceBody.body() -> u256 {
+    bb0:
+-     v0 = icall @literal, 1
+-     ret v0
+- }
+- 
+- fn @sliceBody() -> u256 [selector=0x0a0a0a05, abi_params=[], abi_returns=[word]] {
+-   bb0:
+      v0 = make_calldata_slice 4, 32
+      jump bb1
+    bb1:
+      v1 = slice_ptr v0
+      ret v1
+- }
+- 
+- fn @sliceCaller() -> u256 [selector=0x0a0a0a06, abi_params=[], abi_returns=[word]] {
+-   bb0:
+-     v0 = icall @sliceBody, 1
+-     ret v0
   }
   


### PR DESCRIPTION
External Foundry suites exposed corrupted ABI values and failures in constructor-reachable lowering. Encode memory arguments using their actual location, including `abi.encodeCall`, and materialize storage structs before placing them in memory structs.

Keep constructor-reachable array encoders inline so call frames cannot overwrite their unfinished output. Remove detached ABI-body blocks before lowering orphaned slice projections. Cover these cases with reduced runtime and MIR regressions.

Downstream tests fixed by these ABI/lowering changes:

| Project | Affected tests |
| --- | --- |
| forge-std, `Config.t.sol` | `test_configExists`, `test_loadConfig`, `test_loadConfigWithoutRpcEndpoint`, `test_writeConfig`, `test_writeUpdatesBackToFile`, `testRevert_ChainNotInitialized`, and `testRevert_WriteToFileInForbiddenCtxt`; constructor string-array encoding previously reverted. |
| v4-periphery, PositionDescriptor | `test_tokenURI_succeeds` and `test_native_tokenURI_succeeds`; generated JSON was corrupt. |
| v4-periphery, ReservesLens | `test_pagedEqualsSingleShot`, `test_pagedMinimumBudgetMakesProgress`, `test_fullRangePositionMaximumTickSpacing`, `test_pagedFinalPageProbesHookStats`, and `test_fuzz_matchesIndependentAggregate`; cursor bytes were encoded from the wrong data location. |
| v4-periphery, Execute | `test_execute_rebalance_perfect`; the call previously reverted with `PoolNotInitialized`. |

Reduced regressions include `testConstructorReturnedStrings`, `testPagedReturn`, `testStorageStructConstructorArgument`, `test_InternalStringConstructor`, and the `abi.encodeCall` memory-layout and detached-ABI-body UI fixtures. The standalone branch passes all 15 abi-encoding and 5 constructor-args tests at `-Onone`, `-Ogas`, and `-Osize`, with and without debug output; debug output leaves bytecode unchanged. The full downstream replay predates the split. Foundry block-number/chain-ID cheatcode differences are outside these fixes.
