### PR TITLE
perf(lsp): reuse signature-help position index

### DIFF
--- a/crates/lsp/src/proto.rs
+++ b/crates/lsp/src/proto.rs
@@ -147,7 +147,7 @@ impl<R: Borrow<Rope>> LspPositionIndex<R> {
         (start <= end).then_some(start..end)
     }
 
-    fn text_range(&self, range: lsp_types::Range) -> std::ops::Range<usize> {
+    pub(crate) fn text_range(&self, range: lsp_types::Range) -> std::ops::Range<usize> {
         let start = self.byte_position_clamped(range.start);
         let end = self.byte_position_clamped(range.end);
         start..end

--- a/crates/lsp/src/signature_help.rs
+++ b/crates/lsp/src/signature_help.rs
@@ -113,14 +113,14 @@ impl SignatureHelpIndex {
         visible_declarations: impl FnOnce(&str) -> Vec<&'a Location>,
         options: SignatureHelpClientOptions,
     ) -> Option<SignatureHelp> {
-        let cursor = proto::text_range(contents, Range::new(position, position)).start;
+        let positions = proto::LspPositionIndex::new(contents);
+        let cursor = positions.text_range(Range::new(position, position)).start;
         let text = contents.byte_slice(..cursor).to_string();
         let context = call_context(&text)?;
         let call = self.calls.get(uri).and_then(|calls| {
             calls.iter().find(|call| {
                 valid_text_position(contents, call.range.start)
-                    && proto::text_range(contents, Range::new(call.range.start, call.range.start))
-                        .start
+                    && positions.text_range(Range::new(call.range.start, call.range.start)).start
                         == context.open
                     && call
                         .callee_tokens
@@ -129,7 +129,7 @@ impl SignatureHelpIndex {
                         .filter(|token| is_identifier(token))
                         == context.callee_name
                     && call.form == context.form
-                    && call.matches_current_callee(contents)
+                    && call.matches_current_callee(&positions)
             })
         });
         let (mut signatures, fallback): (Vec<&CallSignature>, _) = if let Some(call) = call {
@@ -278,13 +278,14 @@ impl SignatureHelpIndex {
 }
 
 impl CallSite {
-    fn matches_current_callee(&self, contents: &Rope) -> bool {
+    fn matches_current_callee(&self, positions: &proto::LspPositionIndex<&Rope>) -> bool {
+        let contents = positions.rope();
         if !valid_text_position(contents, self.callee_range.start)
             || !valid_text_position(contents, self.callee_range.end)
         {
             return false;
         }
-        let range = proto::text_range(contents, self.callee_range);
+        let range = positions.text_range(self.callee_range);
         if range.start > range.end {
             return false;
         }
@@ -1138,7 +1139,7 @@ mod tests {
             signatures: Vec::new(),
         };
 
-        assert!(!call.matches_current_callee(&Rope::from("😀f")));
+        assert!(!call.matches_current_callee(&proto::LspPositionIndex::new(&Rope::from("😀f"))));
     }
 
     #[test]
@@ -1151,6 +1152,6 @@ mod tests {
             signatures: Vec::new(),
         };
 
-        assert!(!call.matches_current_callee(&Rope::from("f")));
+        assert!(!call.matches_current_callee(&proto::LspPositionIndex::new(&Rope::from("f"))));
     }
 }

--- a/tools/lsp-bench/README.md
+++ b/tools/lsp-bench/README.md
@@ -34,6 +34,11 @@ excluded from performance aggregates. Failed samples remain in the raw output
 and determine the run status; `--allow-failures` lets an exploratory run finish
 successfully while retaining those failures.
 
+Signature-help probes use `kind: signature-help`, a fixture `path` and `anchor`,
+an exact `expected_label`, and a zero-based `expected_active_parameter`. They
+check the active signature, including a per-signature active parameter when
+provided, before accepting a request timing.
+
 ## Requirements
 
 Run commands from the repository root. Preparation requires Git, curl, tar,

--- a/tools/lsp-bench/src/config.rs
+++ b/tools/lsp-bench/src/config.rs
@@ -300,6 +300,12 @@ pub(crate) enum ProbeSpec {
         anchor: String,
         expected_text: String,
     },
+    SignatureHelp {
+        path: PathBuf,
+        anchor: String,
+        expected_label: String,
+        expected_active_parameter: u32,
+    },
     References {
         path: PathBuf,
         anchor: String,
@@ -870,9 +876,9 @@ fn validate_probe_path(probe: &ProbeSpec) -> Result<()> {
             validate_relative_path(path, "scenario path")?;
             validate_relative_path(expected_path, "scenario expected path")
         }
-        ProbeSpec::Completion { path, .. } | ProbeSpec::Hover { path, .. } => {
-            validate_relative_path(path, "scenario path")
-        }
+        ProbeSpec::Completion { path, .. }
+        | ProbeSpec::Hover { path, .. }
+        | ProbeSpec::SignatureHelp { path, .. } => validate_relative_path(path, "scenario path"),
         ProbeSpec::References { path, expected_locations, .. } => {
             validate_relative_path(path, "scenario path")?;
             validate_expected_locations(expected_locations)
@@ -938,7 +944,9 @@ fn validate_probe_anchors(probe: &ProbeSpec, require: &impl Fn(&str) -> Result<(
             require(anchor)?;
             require(expected_anchor)
         }
-        ProbeSpec::Completion { anchor, .. } | ProbeSpec::Hover { anchor, .. } => require(anchor),
+        ProbeSpec::Completion { anchor, .. }
+        | ProbeSpec::Hover { anchor, .. }
+        | ProbeSpec::SignatureHelp { anchor, .. } => require(anchor),
         ProbeSpec::References { anchor, expected_locations, .. } => {
             require(anchor)?;
             for expected in expected_locations {
@@ -1220,6 +1228,51 @@ mod tests {
 
         let error = Config::load(&path).unwrap_err().to_string();
         assert!(error.contains("must be relative and stay in its root"), "{error}");
+    }
+
+    #[test]
+    fn signature_help_requires_valid_paths_anchors_and_expectations() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("benchmark.json");
+        let mut config = serde_json::json!({
+            "version": 1,
+            "servers": [{"id": "server", "command": "server"}],
+            "fixtures": [{
+                "id": "fixture",
+                "root": ".",
+                "anchors": {"call": {"path": "Main.sol", "needle": "add(1, 2)", "offset": 7}}
+            }],
+            "scenarios": [{
+                "id": "signature-help",
+                "fixture": "fixture",
+                "steps": [{
+                    "kind": "warm",
+                    "probe": {
+                        "kind": "signature-help",
+                        "path": "Main.sol",
+                        "anchor": "call",
+                        "expected_label": "add(uint256 a, uint256 b)",
+                        "expected_active_parameter": 1
+                    }
+                }]
+            }]
+        });
+        fs::write(&path, serde_json::to_vec(&config).unwrap()).unwrap();
+        assert!(Config::load(&path).is_ok());
+
+        for (field, invalid) in [
+            ("path", serde_json::json!("../escape.sol")),
+            ("anchor", serde_json::json!("missing")),
+            ("expected_active_parameter", serde_json::json!(-1)),
+            ("expected_label", Value::Null),
+        ] {
+            let probe = &mut config["scenarios"][0]["steps"][0]["probe"];
+            let original = probe[field].clone();
+            probe[field] = invalid;
+            fs::write(&path, serde_json::to_vec(&config).unwrap()).unwrap();
+            assert!(Config::load(&path).is_err(), "accepted invalid {field}");
+            config["scenarios"][0]["steps"][0]["probe"][field] = original;
+        }
     }
 
     #[test]

--- a/tools/lsp-bench/src/process.rs
+++ b/tools/lsp-bench/src/process.rs
@@ -935,6 +935,7 @@ impl LspProcess {
             "textDocument/definition" => "definitionProvider",
             "textDocument/completion" => "completionProvider",
             "textDocument/hover" => "hoverProvider",
+            "textDocument/signatureHelp" => "signatureHelpProvider",
             "textDocument/references" => "referencesProvider",
             "textDocument/documentSymbol" => "documentSymbolProvider",
             "textDocument/rename" => "renameProvider",

--- a/tools/lsp-bench/src/runner.rs
+++ b/tools/lsp-bench/src/runner.rs
@@ -22,7 +22,8 @@ use crate::{
 use anyhow::{Context, Result, anyhow, bail};
 use lsp_types::{
     CompletionResponse, DocumentSymbol, DocumentSymbolResponse, GotoDefinitionResponse, Hover,
-    HoverContents, Location, MarkedString, OneOf, Range, Url, WorkspaceSymbolResponse,
+    HoverContents, Location, MarkedString, OneOf, Range, SignatureHelp, Url,
+    WorkspaceSymbolResponse,
 };
 use serde_json::{Value, json};
 use std::{
@@ -948,6 +949,14 @@ impl<'a> Session<'a> {
                             "contextSupport": true
                         },
                         "hover": {"contentFormat": ["markdown", "plaintext"]},
+                        "signatureHelp": {
+                            "dynamicRegistration": true,
+                            "signatureInformation": {
+                                "documentationFormat": ["markdown", "plaintext"],
+                                "parameterInformation": {"labelOffsetSupport": true},
+                                "activeParameterSupport": true
+                            }
+                        },
                         "rename": {"prepareSupport": true}
                     },
                     "window": {"workDoneProgress": true},
@@ -1535,6 +1544,36 @@ impl<'a> Session<'a> {
                     measured,
                 )?;
                 validate_hover(value, expected_text)
+            }
+            ProbeSpec::SignatureHelp {
+                path,
+                anchor,
+                expected_label,
+                expected_active_parameter,
+            } => {
+                let encoding = self.position_encoding()?;
+                if !allow_unopened_target {
+                    self.require_open_for_probe(path)?;
+                }
+                let source_anchor =
+                    self.anchor_with_encoding(anchor, encoding).map_err(harness_error)?;
+                let uri = file_uri(&source_anchor.path).map_err(harness_error)?;
+                if !self.process.supports_document(
+                    "textDocument/signatureHelp",
+                    &uri,
+                    SOLIDITY_LANGUAGE_ID,
+                ) {
+                    return Err(WorkloadError::new(
+                        FailureKind::Unsupported,
+                        "server does not advertise signature help",
+                    ));
+                }
+                let value = self.request(
+                    "textDocument/signatureHelp",
+                    json!({"textDocument": {"uri": uri}, "position": source_anchor.position}),
+                    measured,
+                )?;
+                validate_signature_help(value, expected_label, *expected_active_parameter)
             }
             ProbeSpec::References { path, anchor, min_count, expected_locations } => {
                 let encoding = self.position_encoding()?;
@@ -2298,6 +2337,39 @@ fn validate_hover(value: Value, expected_text: &str) -> std::result::Result<(), 
     }
 }
 
+fn validate_signature_help(
+    value: Value,
+    expected_label: &str,
+    expected_active_parameter: u32,
+) -> std::result::Result<(), WorkloadError> {
+    let help = serde_json::from_value::<SignatureHelp>(value.clone()).map_err(|_| {
+        WorkloadError::new(
+            FailureKind::Incorrect,
+            format!("signature help returned an invalid result: {value}"),
+        )
+    })?;
+    let signature = help.signatures.get(help.active_signature.unwrap_or(0) as usize);
+    if let Some(signature) = signature {
+        let active_parameter = signature.active_parameter.or(help.active_parameter).unwrap_or(0);
+        if !signature.label.is_empty()
+            && signature.label == expected_label
+            && active_parameter == expected_active_parameter
+            && signature
+                .parameters
+                .as_ref()
+                .is_none_or(|parameters| (active_parameter as usize) < parameters.len())
+        {
+            return Ok(());
+        }
+    }
+    Err(WorkloadError::new(
+        FailureKind::Incorrect,
+        format!(
+            "signature help did not select `{expected_label}` parameter {expected_active_parameter}: {value}"
+        ),
+    ))
+}
+
 fn validate_references(
     value: Value,
     min_count: usize,
@@ -2674,6 +2746,59 @@ scenarios:
             )
             .is_ok()
         );
+    }
+
+    #[test]
+    fn signature_help_validator_checks_the_active_signature_and_parameter() {
+        let value = json!({
+            "signatures": [
+                {"label": "other()"},
+                {
+                    "label": "add(uint256 a, uint256 b)",
+                    "parameters": [{"label": "uint256 a"}, {"label": "uint256 b"}]
+                }
+            ],
+            "activeSignature": 1,
+            "activeParameter": 1
+        });
+        assert!(validate_signature_help(value.clone(), "add(uint256 a, uint256 b)", 1).is_ok());
+        assert!(validate_signature_help(value.clone(), "other()", 1).is_err());
+        assert!(validate_signature_help(value, "add(uint256 a, uint256 b)", 0).is_err());
+
+        let value = json!({
+            "signatures": [{"label": "add(uint256)", "activeParameter": 0}],
+            "activeParameter": 1
+        });
+        assert!(validate_signature_help(value, "add(uint256)", 0).is_ok());
+        assert!(
+            validate_signature_help(
+                json!({"signatures": [{"label": "add(uint256)"}]}),
+                "add(uint256)",
+                0
+            )
+            .is_ok()
+        );
+    }
+
+    #[test]
+    fn signature_help_validator_rejects_empty_malformed_and_invalid_results() {
+        for value in [
+            Value::Null,
+            json!({}),
+            json!({"signatures": []}),
+            json!({"signatures": [{"label": ""}]}),
+            json!({"signatures": [{"label": "add(uint256)"}, {"label": 7}]}),
+            json!({"signatures": [{"label": "add(uint256)"}], "activeSignature": 1}),
+            json!({"signatures": [{"label": "add(uint256)"}], "activeParameter": -1}),
+        ] {
+            assert!(validate_signature_help(value.clone(), "add(uint256)", 0).is_err(), "{value}");
+        }
+        let invalid_parameter = json!({
+            "signatures": [{"label": "add(uint256)", "parameters": [{"label": "uint256"}]}],
+            "activeParameter": 1
+        });
+        assert!(validate_signature_help(invalid_parameter, "add(uint256)", 1).is_err());
+        assert!(validate_signature_help(json!({"signatures": [{"label": ""}]}), "", 0).is_err());
     }
 
     #[test]

--- a/tools/lsp-bench/tests/fake_lsp.rs
+++ b/tools/lsp-bench/tests/fake_lsp.rs
@@ -27,6 +27,91 @@ fn assert_hex_digest(value: &Value, digits: usize) {
 }
 
 #[test]
+fn signature_help_records_real_requests_and_validates_the_selected_parameter() {
+    let directory = tempfile::tempdir().unwrap();
+    let fixture = directory.path().join("fixture");
+    fs::create_dir(&fixture).unwrap();
+    let source = "contract Main { function call() external { add(1, 2); } }\n";
+    fs::write(fixture.join("Main.sol"), source).unwrap();
+    let config = directory.path().join("benchmark.json");
+    fs::write(
+        &config,
+        serde_json::to_vec(&serde_json::json!({
+            "version": 1,
+            "profiles": {"smoke": {
+                "warmup": 1,
+                "samples": 2,
+                "cold_samples": 1,
+                "lifecycle_samples": 1,
+                "timeout_ms": 2000,
+                "readiness_quiet_ms": 20
+            }},
+            "servers": [{
+                "id": "fake",
+                "command": env!("CARGO_BIN_EXE_solar-lsp-bench-fake"),
+                "version_args": ["--version"]
+            }],
+            "fixtures": [{
+                "id": "synthetic",
+                "root": fixture,
+                "source_roots": ["."],
+                "anchors": {"call": {"path": "Main.sol", "needle": "add(1, 2)", "offset": 7}}
+            }],
+            "scenarios": [{
+                "id": "signature-help",
+                "fixture": "synthetic",
+                "steps": [
+                    {"kind": "open", "path": "Main.sol"},
+                    {"kind": "probe", "name": "cold-ready", "probe": {
+                        "kind": "hover", "path": "Main.sol", "anchor": "call", "expected_text": "add"
+                    }},
+                    {"kind": "warm", "probe": {
+                        "kind": "signature-help", "path": "Main.sol", "anchor": "call",
+                        "expected_label": "add(uint256 a, uint256 b)", "expected_active_parameter": 1
+                    }}
+                ]
+            }]
+        }))
+        .unwrap(),
+    )
+    .unwrap();
+    let output = directory.path().join("results");
+    let status = Command::new(env!("CARGO_BIN_EXE_solar-lsp-bench"))
+        .args(["run", "--config"])
+        .arg(&config)
+        .args(["--profile", "smoke", "--repeat", "1", "--output"])
+        .arg(&output)
+        .status()
+        .unwrap();
+    assert!(status.success());
+
+    let samples = read_json(&output.join("samples.json"));
+    let sample = &samples["samples"][0];
+    assert_eq!(sample["status"], "pass");
+    let requests = sample["observations"]["requests"].as_array().unwrap();
+    assert_eq!(requests.len(), 2);
+    for request in requests {
+        assert_eq!(request["method"], "textDocument/signatureHelp");
+    }
+    let sent = sample["observations"]["events"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter(|event| {
+            event["direction"] == "send" && event["method"] == "textDocument/signatureHelp"
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(sent.len(), 4);
+    for event in sent {
+        assert_eq!(event["message"]["params"]["position"]["line"], 0);
+        assert_eq!(
+            event["message"]["params"]["position"]["character"],
+            source.find("add(1, 2)").unwrap() + 7
+        );
+    }
+}
+
+#[test]
 fn dispatcher_preserves_out_of_order_messages_and_server_requests() {
     let directory = tempfile::tempdir().unwrap();
     let fixture = directory.path().join("fixture");

--- a/tools/lsp-bench/tests/support/fake_server.rs
+++ b/tools/lsp-bench/tests/support/fake_server.rs
@@ -116,6 +116,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                         "textDocumentSync":{"openClose":true,"change":1,"save":{"includeText":true}},
                         "hoverProvider":true,
                         "completionProvider":false,
+                        "signatureHelpProvider":{},
                         "documentSymbolProvider":true,
                         "workspaceSymbolProvider":true,
                         "renameProvider":true,
@@ -406,6 +407,23 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 write_message(
                     &mut writer,
                     &json!({"jsonrpc":"2.0","id":message["id"],"result":{"isIncomplete":false,"items":[{"label":label,"kind":3}]}}),
+                )?;
+            }
+            Some("textDocument/signatureHelp") => {
+                write_message(
+                    &mut writer,
+                    &json!({
+                        "jsonrpc":"2.0",
+                        "id":message["id"],
+                        "result":{
+                            "signatures":[{
+                                "label":"add(uint256 a, uint256 b)",
+                                "parameters":[{"label":"uint256 a"},{"label":"uint256 b"}]
+                            }],
+                            "activeSignature":0,
+                            "activeParameter":1
+                        }
+                    }),
                 )?;
             }
             Some("textDocument/rename") => {


### PR DESCRIPTION
Towards OSS-738 , 

Signature help rebuilt the document's line index while checking each candidate call site. On large files, that repeated work dominated the request.

- Build one `LspPositionIndex` per request and reuse it for cursor, call-site, and callee range conversions.
- Add `signature-help` probes to the LSP benchmark harness, checking the selected signature and active parameter before accepting timings.
- Cover malformed responses, parameter selection, and real request dispatch in the harness tests.

Warm `textDocument/signatureHelp` round trips on the tracked [`testdata/UniswapV3.sol`](https://github.com/paradigmxyz/solar/blob/cc1001e6a77d184eb8d2f38674fcdf895fcc4f67/testdata/UniswapV3.sol):

| Call / active argument | Before p50 | After p50 | Reduction | Before p95 | After p95 | Reduction |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| `FullMath.mulDiv` / second | 6.0968 ms | 0.3000 ms | **95.1%** | 6.4023 ms | 0.4135 ms | **93.5%** |
| `deploy` / third | 6.3220 ms | 0.3055 ms | **95.2%** | 6.9128 ms | 0.4179 ms | **94.0%** |
