### PR TITLE
feat(bench): add solx reference compiler

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -27,6 +27,7 @@ env:
   CARGO_TERM_COLOR: always
   RUSTC_WRAPPER: "sccache"
   SOLC_VERSION: ${{ inputs.solc_version || '0.8.36' }}
+  SOLX_VERSION: '0.1.8'
 
 jobs:
   codegen-runtime:
@@ -84,6 +85,18 @@ jobs:
             -o "$RUNNER_TEMP/solc/solc-${SOLC_VERSION}"
           chmod +x "$RUNNER_TEMP/solc/solc-${SOLC_VERSION}"
           "$RUNNER_TEMP/solc/solc-${SOLC_VERSION}" --version
+
+      - name: Install solx (main only)
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        run: |
+          set -euo pipefail
+          mkdir -p "$RUNNER_TEMP/solx"
+          curl -fsSL \
+            "https://github.com/NomicFoundation/solx/releases/download/${SOLX_VERSION}/solx-linux-amd64-gnu-v${SOLX_VERSION}" \
+            -o "$RUNNER_TEMP/solx/solx"
+          echo "2f6b8feb6a28ac6297a2c0c5afa936e4c013e7175ca88a9bf8e435e61fa1a226  $RUNNER_TEMP/solx/solx" | sha256sum --check
+          chmod +x "$RUNNER_TEMP/solx/solx"
+          "$RUNNER_TEMP/solx/solx" --version
 
       - name: Build Solar
         run: |
@@ -227,6 +240,9 @@ jobs:
               --solar-only
               --reference-results target/codegen-bench/baseline/results.json
             )
+          fi
+          if [[ "$GITHUB_EVENT_NAME" == "push" && "$GITHUB_REF" == "refs/heads/main" ]]; then
+            args+=(--solx "$RUNNER_TEMP/solx/solx")
           fi
           if ! python3 benches/runtime/benchmark.py "${args[@]}"; then
             echo "::warning::Codegen benchmark failed to complete"

--- a/benches/runtime/README.md
+++ b/benches/runtime/README.md
@@ -39,7 +39,9 @@ and raw Standard JSON input and output. Solc emits unoptimized `ir.yul` and opti
 `optimized-ir.yul` where available, disassembly,
 bytecode, and raw Standard JSON input and output. When `--reference-results` points to a result next
 to an `artifacts` directory, the matching reference files are copied into the new run. Solx artifacts
-include unoptimized `ir.yul`, disassembly, bytecode, and raw Standard JSON input and output.
+use the same output requests as solc, saving `ir.yul` and `optimized-ir.yul` when returned,
+alongside disassembly, bytecode, and raw Standard JSON input and output. Solx 0.1.8 returns
+`ir` but omits `irOptimized`.
 
 Compare two runs with `benchmark-compare.py`, which also generates CI's Markdown report,
 common benchmark JSON, job summary, and comment metadata:

--- a/benches/runtime/README.md
+++ b/benches/runtime/README.md
@@ -4,7 +4,7 @@ This directory contains fixtures and workload documentation for the codegen benc
 project archives live in `../../testdata/projects/`; archives group cases from the same upstream
 project. The default `runtime` mode selects each entrypoint's transitive Solidity import closure and
 omits the heavy full-project cases. The `compile-time` mode measures those cases by passing full
-archived Standard JSON inputs to both compilers without deployment or runtime workloads. CI runs
+archived Standard JSON inputs to each compiler without deployment or runtime workloads. CI runs
 both modes with `--mode runtime compile-time`.
 
 Keeping the inputs here makes the benchmark reproducible from this checkout and removes the CI
@@ -15,22 +15,30 @@ corpus against one EVM version. Use `--solar-only` when the selected target is n
 installed solc. When available, solc still provides helper contracts for cold-path runtime checks.
 
 The default runs only our compiler. Pass `--solc PATH` to record a two-compiler baseline.
-Use `--solar-only` to skip solc benchmark compilation even when `--solc PATH` supplies a binary
+Pass `--solx PATH` to include [solx](https://github.com/NomicFoundation/solx) as a separate compiler,
+with its own compilation, gas, runtime checks, and artifacts. CI pins solx 0.1.8 and installs and
+runs it only on pushes to main. Its measurements appear alongside solc in the Markdown report.
+Unsupported inputs remain visible as compiler failures.
+
+Use `--solar-only` to skip solc and solx benchmark compilation even when `--solc PATH` supplies a binary
 for reference validation or helper contracts. The default skips the
 reference solc compile for each case while retaining Solar compilation, gas measurements, and
 runtime failure checks. A one-compiler run cannot make differential runtime claims, so successful
 runtime comparisons are marked as skipped unless a matching reference result is supplied.
 
-Pass `--reference-results PATH` to reuse matching solc results from a prior
-run. The benchmark copies solc compile, gas, and runtime data only when the input fingerprint
+Pass `--reference-results PATH` to reuse matching solc and solx results from a prior
+run. The benchmark copies reference compile, gas, and runtime data only when the input fingerprint
 matches, then performs the normal cross-compiler runtime checks. PR CI uses the exact-base result
 as the reference, so solc runs on the base revision instead of repeating unchanged work on the PR.
+PR jobs never run solx, including when they must rebuild a missing baseline; solx columns appear
+when matching results are available in the downloaded main artifact.
 
 Pass `--artifacts PATH` to write a file tree for each runtime case and compiler. This extra compile
 runs outside the timed samples. Solar emits MIR, creation and runtime EVM IR, disassembly, bytecode,
 and raw Standard JSON input and output. Solc emits optimized Yul IR where available, disassembly,
 bytecode, and raw Standard JSON input and output. When `--reference-results` points to a result next
-to an `artifacts` directory, the matching solc files are copied into the new run.
+to an `artifacts` directory, the matching reference files are copied into the new run. Solx artifacts
+include disassembly, bytecode, and raw Standard JSON input and output.
 
 Compare two runs with `benchmark-compare.py`, which also generates CI's Markdown report,
 common benchmark JSON, job summary, and comment metadata:
@@ -49,7 +57,8 @@ report; omit it when you only need terminal output.
 Inputs may be directories containing `results.json` or JSON paths. Artifacts default to
 `artifacts/` beside each JSON. Use `--baseline-artifacts` and `--artifacts` for other paths.
 Add `--tests factorial counter` to select cases, `--artifact mir` for MIR diffs, or
-`--artifact evm-ir disasm bytecode` for backend output. `--compiler solc` inspects solc;
+`--artifact evm-ir disasm bytecode` for backend output. `--compiler solc` or `--compiler solx`
+inspects that reference compiler;
 the default compares our compiler between runs. `--results PATH` without a baseline produces
 a single-run CI report. Numeric regressions do not cause a nonzero exit status;
 missing or invalid result inputs do. The shared CI schema (`--common-output`)

--- a/benches/runtime/README.md
+++ b/benches/runtime/README.md
@@ -35,7 +35,8 @@ when matching results are available in the downloaded main artifact.
 
 Pass `--artifacts PATH` to write a file tree for each runtime case and compiler. This extra compile
 runs outside the timed samples. Solar emits MIR, creation and runtime EVM IR, disassembly, bytecode,
-and raw Standard JSON input and output. Solc emits optimized Yul IR where available, disassembly,
+and raw Standard JSON input and output. Solc emits unoptimized `ir.yul` and optimized
+`optimized-ir.yul` where available, disassembly,
 bytecode, and raw Standard JSON input and output. When `--reference-results` points to a result next
 to an `artifacts` directory, the matching reference files are copied into the new run. Solx artifacts
 include disassembly, bytecode, and raw Standard JSON input and output.

--- a/benches/runtime/README.md
+++ b/benches/runtime/README.md
@@ -39,7 +39,7 @@ and raw Standard JSON input and output. Solc emits unoptimized `ir.yul` and opti
 `optimized-ir.yul` where available, disassembly,
 bytecode, and raw Standard JSON input and output. When `--reference-results` points to a result next
 to an `artifacts` directory, the matching reference files are copied into the new run. Solx artifacts
-include disassembly, bytecode, and raw Standard JSON input and output.
+include unoptimized `ir.yul`, disassembly, bytecode, and raw Standard JSON input and output.
 
 Compare two runs with `benchmark-compare.py`, which also generates CI's Markdown report,
 common benchmark JSON, job summary, and comment metadata:

--- a/benches/runtime/benchmark-compare.py
+++ b/benches/runtime/benchmark-compare.py
@@ -1088,13 +1088,22 @@ def metric_rows(
         test_id = str(result.get("test_id", "<unknown>"))
         base = baseline.get(suite_key(result), {})
         solar_gas = compiler_metric(result, "solar", gas_metric)
-        solc_gas = compiler_metric(result, "solc", gas_metric)
+        reference_gas = [
+            compiler_metric(result, name, gas_metric)
+            for name in reference_compiler_ids(results)
+        ]
         base_solar_gas = compared_baseline(result, base, gas_metric, compared)
         solar_size = compiler_metric(result, "solar", size_metric)
-        solc_size = compiler_metric(result, "solc", size_metric)
+        reference_size = [
+            compiler_metric(result, name, size_metric)
+            for name in reference_compiler_ids(results)
+        ]
         base_solar_size = compared_baseline(result, base, size_metric, compared)
 
-        if all(value is None for value in (solar_gas, solc_gas, solar_size, solc_size)):
+        if all(
+            value is None
+            for value in (solar_gas, *reference_gas, solar_size, *reference_size)
+        ):
             continue
 
         rows.append(
@@ -1105,12 +1114,16 @@ def metric_rows(
                     fmt_value_with_lower_is_better_delta(
                         solar_gas, solar_gas, base_solar_gas
                     ),
-                    fmt_value_with_delta_vs_current(solc_gas, solar_gas, solc_gas),
+                    *(
+                        fmt_value_with_delta_vs_current(value, solar_gas, value)
+                        for value in reference_gas
+                    ),
                     fmt_value_with_lower_is_better_delta(
                         solar_size, solar_size, base_solar_size, "B"
                     ),
-                    fmt_value_with_delta_vs_current(
-                        solc_size, solar_size, solc_size, "B"
+                    *(
+                        fmt_value_with_delta_vs_current(value, solar_size, value, "B")
+                        for value in reference_size
                     ),
                 ]
             )
@@ -1126,6 +1139,13 @@ def compiler_ids(results: list[dict[str, Any]]) -> list[str]:
             if compiler_id not in ids:
                 ids.append(compiler_id)
     return ids
+
+
+def reference_compiler_ids(results: list[dict[str, Any]]) -> list[str]:
+    return [
+        "solc",
+        *(name for name in compiler_ids(results) if name not in ("solar", "solc")),
+    ]
 
 
 def memory_summary_rows(results: list[dict[str, Any]]) -> list[str]:
@@ -1215,7 +1235,6 @@ def compile_time_rows(
     rows = []
     for result in results:
         test_id = str(result.get("test_id", "<unknown>"))
-        solc_time = compile_time(result, "solc")
         solar_time = compile_time(result, "solar")
         base = baseline.get(suite_key(result), {})
         base_solar_time = compared_baseline(
@@ -1230,7 +1249,11 @@ def compile_time_rows(
                         f"{fmt_duration(solar_time)} "
                         f"({fmt_pct_change_lower_is_better(solar_time, base_solar_time)})"
                     ),
-                    f"{fmt_duration(solc_time)} ({fmt_pct_vs_current(solar_time, solc_time)})",
+                    *(
+                        f"{fmt_duration(value)} ({fmt_pct_vs_current(solar_time, value)})"
+                        for name in reference_compiler_ids(results)
+                        for value in [compile_time(result, name)]
+                    ),
                 ]
             )
             + " |"
@@ -1244,35 +1267,34 @@ def compile_time_report(
     baseline_label: str,
     compared: dict | None = None,
 ) -> list[str]:
-    # Aggregate only tests where both compilers succeeded, so a new failure
+    # Aggregate only tests where all compilers succeeded, so a new failure
     # cannot make the Solar total look faster.
-    paired = [
-        (compile_time(result, "solc"), compile_time(result, "solar"))
-        for result in results
-    ]
-    paired = [
-        (solc, solar)
-        for solc, solar in paired
-        if solc is not None and solar is not None
-    ]
+    ids = ["solar", *reference_compiler_ids(results)]
+    paired = [[compile_time(result, name) for name in ids] for result in results]
+    paired = [values for values in paired if all(value is not None for value in values)]
     if not any(compile_time(result, "solar") is not None for result in results):
         return []
 
-    solc_sum = sum(solc for solc, _ in paired)
-    solar_sum = sum(solar for _, solar in paired)
+    sums = [sum(values[index] for values in paired) for index in range(len(ids))]
+    solar_sum = sums[0]
+    reference_headers = " | ".join(ids[1:])
 
     return [
         "<details>",
         "<summary>Compilation time</summary>",
         "",
-        f"| bench | time (vs {baseline_label}) | solc |",
-        "| ----- | --------------------- | ---- |",
+        f"| bench | time (vs {baseline_label}) | {reference_headers} |",
+        "| ----- | --------------------- |" + " ---- |" * (len(ids) - 1),
         *compile_time_rows(results, baseline, compared),
         *(
             [
                 (
                     f"| **sum of medians** | **{fmt_duration(solar_sum)}** | "
-                    f"**{fmt_duration(solc_sum)} ({fmt_pct_vs_current(solar_sum, solc_sum)})** |"
+                    + " | ".join(
+                        f"**{fmt_duration(value)} ({fmt_pct_vs_current(solar_sum, value)})**"
+                        for value in sums[1:]
+                    )
+                    + " |"
                 )
             ]
             if paired
@@ -1303,13 +1325,22 @@ def report_section(
             [f"No `{baseline_ref}` baseline artifact was available for comparison.", ""]
         )
     lines.extend(compilation_failure_report(results, baseline_results, baseline_ref))
+    references = reference_compiler_ids(results)
+    reference_headers = " | ".join(references)
+    metric_header = f"| bench | gas (vs {baseline_label}) | {reference_headers} | size (vs {baseline_label}) | {reference_headers} |"
+    metric_separator = (
+        "| ----- | ------------- |"
+        + " ---- |" * len(references)
+        + " -------------- |"
+        + " ---- |" * len(references)
+    )
 
     rows = benchmark_rows(results, baseline, compared)
     if rows:
         lines.extend(
             [
-                f"| bench | gas (vs {baseline_label}) | solc | size (vs {baseline_label}) | solc |",
-                "| ----- | ------------- | ---- | -------------- | ---- |",
+                metric_header,
+                metric_separator,
                 *rows,
                 "",
             ]
@@ -1320,8 +1351,8 @@ def report_section(
             [
                 f"### {perf_link('Deployment')}",
                 "",
-                f"| bench | gas (vs {baseline_label}) | solc | size (vs {baseline_label}) | solc |",
-                "| ----- | ------------- | ---- | -------------- | ---- |",
+                metric_header,
+                metric_separator,
                 *deployment,
                 "",
             ]
@@ -1564,7 +1595,9 @@ def main(argv: list[str] | None = None) -> int:
         help="Artifact kinds to inspect or diff",
     )
     parser.add_argument("--tests", nargs="+", help="Select test IDs from either run")
-    parser.add_argument("--compiler", choices=("solar", "solc"), default="solar")
+    parser.add_argument(
+        "--compiler", choices=("solar", "solc", "solx"), default="solar"
+    )
     parser.add_argument(
         "--comment-output", type=Path, help="Write CI should-comment metadata"
     )
@@ -1579,7 +1612,7 @@ def main(argv: list[str] | None = None) -> int:
     if args.common_output and (args.tests or args.compiler != "solar"):
         parser.error("--common-output requires the complete run and --compiler solar")
     if args.compiler != "solar" and args.baseline is None:
-        parser.error("--compiler solc requires a baseline comparison")
+        parser.error(f"--compiler {args.compiler} requires a baseline comparison")
     for name in ("baseline", "results"):
         path = getattr(args, name)
         if path is not None and path.is_dir():

--- a/benches/runtime/benchmark.py
+++ b/benches/runtime/benchmark.py
@@ -325,9 +325,7 @@ def artifact_compiler_input(input_text: str, test_case: TestCase, kind: str) -> 
         "evm.deployedBytecode.object",
     ]
     if kind in ("solc", "solx"):
-        outputs.append("ir")
-    if kind == "solc":
-        outputs.append("irOptimized")
+        outputs.extend(("ir", "irOptimized"))
     payload.setdefault("settings", {})["outputSelection"] = {
         source: {test_case.contract_name: outputs}
     }
@@ -443,7 +441,7 @@ def write_artifacts(
             (output_dir / "runtime.disasm").write_text(disassemble_evm(runtime))
     if spec.kind in ("solc", "solx") and (ir := contract.get("ir")):
         (output_dir / "ir.yul").write_text(str(ir).rstrip() + "\n")
-    if spec.kind == "solc" and (ir := contract.get("irOptimized")):
+    if spec.kind in ("solc", "solx") and (ir := contract.get("irOptimized")):
         (output_dir / "optimized-ir.yul").write_text(str(ir).rstrip() + "\n")
     return ""
 

--- a/benches/runtime/benchmark.py
+++ b/benches/runtime/benchmark.py
@@ -324,8 +324,10 @@ def artifact_compiler_input(input_text: str, test_case: TestCase, kind: str) -> 
         "evm.bytecode.object",
         "evm.deployedBytecode.object",
     ]
+    if kind in ("solc", "solx"):
+        outputs.append("ir")
     if kind == "solc":
-        outputs.extend(("ir", "irOptimized"))
+        outputs.append("irOptimized")
     payload.setdefault("settings", {})["outputSelection"] = {
         source: {test_case.contract_name: outputs}
     }
@@ -439,7 +441,7 @@ def write_artifacts(
             (output_dir / "creation.disasm").write_text(disassemble_evm(deployment))
         if runtime:
             (output_dir / "runtime.disasm").write_text(disassemble_evm(runtime))
-    if spec.kind == "solc" and (ir := contract.get("ir")):
+    if spec.kind in ("solc", "solx") and (ir := contract.get("ir")):
         (output_dir / "ir.yul").write_text(str(ir).rstrip() + "\n")
     if spec.kind == "solc" and (ir := contract.get("irOptimized")):
         (output_dir / "optimized-ir.yul").write_text(str(ir).rstrip() + "\n")

--- a/benches/runtime/benchmark.py
+++ b/benches/runtime/benchmark.py
@@ -325,7 +325,7 @@ def artifact_compiler_input(input_text: str, test_case: TestCase, kind: str) -> 
         "evm.deployedBytecode.object",
     ]
     if kind == "solc":
-        outputs.append("irOptimized")
+        outputs.extend(("ir", "irOptimized"))
     payload.setdefault("settings", {})["outputSelection"] = {
         source: {test_case.contract_name: outputs}
     }
@@ -439,6 +439,8 @@ def write_artifacts(
             (output_dir / "creation.disasm").write_text(disassemble_evm(deployment))
         if runtime:
             (output_dir / "runtime.disasm").write_text(disassemble_evm(runtime))
+    if spec.kind == "solc" and (ir := contract.get("ir")):
+        (output_dir / "ir.yul").write_text(str(ir).rstrip() + "\n")
     if spec.kind == "solc" and (ir := contract.get("irOptimized")):
         (output_dir / "optimized-ir.yul").write_text(str(ir).rstrip() + "\n")
     return ""

--- a/benches/runtime/benchmark.py
+++ b/benches/runtime/benchmark.py
@@ -1433,8 +1433,7 @@ def compare_runtime_results(
         }
         if any(value is None for value in values.values()):
             failed = True
-            continue
-        unique_values = set(values.values())
+        unique_values = {value for value in values.values() if value is not None}
         if len(unique_values) > 1:
             mismatches.append({"label": label, "values": values})
 
@@ -1510,7 +1509,8 @@ def merge_reference_compiler(
         return False
     if entry.get("gas_profile") != reference.get("gas_profile"):
         return False
-    if not any(
+    # Compilation failures have no runtime workload to match.
+    if reference_data.get("status") != "failed" and not any(
         workload_signature(data) == workload_signature(reference_data)
         for data in compilers.values()
         if isinstance(data, dict)
@@ -1958,10 +1958,8 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     skipped = []
     if (
-        args.solc
-        and (not args.solar_only or use_reference_solc)
-        and not args.include_incompatible
-    ):
+        (args.solc and not args.solar_only) or use_reference_solc
+    ) and not args.include_incompatible:
         compatible_tests = []
         for test in tests:
             if test.project_file is not None and not version_in_range(

--- a/benches/runtime/benchmark.py
+++ b/benches/runtime/benchmark.py
@@ -431,7 +431,7 @@ def write_artifacts(
                 return f"invalid {prefix} bytecode: {error}"
             bytecodes[prefix] = bytes_
             (output_dir / f"{prefix}.hex").write_text(str(object_hex) + "\n")
-    if spec.kind == "solc":
+    if spec.kind != "solar":
         runtime = bytecodes.get("runtime", b"")
         creation = bytecodes.get("creation", b"")
         if creation:
@@ -1758,6 +1758,10 @@ def main(argv: Sequence[str] | None = None) -> int:
         help="Path to solc binary; enables solc comparison unless --solar-only is set",
     )
     parser.add_argument(
+        "--solx",
+        help="Path to solx binary; enables solx comparison unless --solar-only is set",
+    )
+    parser.add_argument(
         "--solar",
         help="Path to solar binary (default: solar or target/{release,debug}/solar)",
     )
@@ -1792,12 +1796,12 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser.add_argument(
         "--solar-only",
         action="store_true",
-        help="Skip solc benchmark compilation even when --solc is supplied",
+        help="Skip reference compiler compilation even when --solc or --solx is supplied",
     )
     parser.add_argument(
         "--reference-results",
         type=Path,
-        help="Reuse matching solc results from another benchmark result document",
+        help="Reuse matching solc and solx results from another benchmark result document",
     )
     parser.add_argument("--tests", nargs="*", help="Subset of test IDs to run")
     parser.add_argument(
@@ -1850,10 +1854,10 @@ def main(argv: Sequence[str] | None = None) -> int:
         help="Exit successfully even if a compiler fails for one or more tests",
     )
     args = parser.parse_args(argv)
-    args.solar_only = args.solar_only or args.solc is None
+    args.solar_only = args.solar_only or (args.solc is None and args.solx is None)
 
     if args.reference_results and not args.solar_only:
-        parser.error("--reference-results with --solc requires --solar-only")
+        parser.error("--reference-results with --solc or --solx requires --solar-only")
     try:
         reference_results = (
             load_reference_results(args.reference_results)
@@ -1883,7 +1887,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         return 0
 
     solc = find_binary(args.solc, ["solc"])
-    if not solc and (not args.solar_only or args.reference_results):
+    if not solc and ((args.solc and not args.solar_only) or args.reference_results):
         print(_color(f"solc not found: {args.solc}", RED), file=sys.stderr)
         return 1
 
@@ -1921,14 +1925,22 @@ def main(argv: Sequence[str] | None = None) -> int:
     solar_version, solar_version_error = binary_version(solar)
 
     specs = []
-    if not args.solar_only:
+    if args.solc and not args.solar_only:
         assert solc is not None
         specs.append(CompilerSpec("solc", f"solc {solc_version}", solc, "solc"))
+    if args.solx and not args.solar_only:
+        solx = find_binary(args.solx, ["solx"])
+        if solx is None:
+            parser.error(f"solx not found: {args.solx}")
+        solx_version, solx_error = binary_version(solx)
+        if solx_error:
+            parser.error(f"solx --version failed: {solx_error}")
+        specs.append(CompilerSpec("solx", f"solx {solx_version}", solx, "solx"))
     specs.append(CompilerSpec("solar", f"solar {solar_version}", solar, "solar"))
-    reference_solc_spec = (
-        CompilerSpec("solc", f"solc {solc_version}", solc, "solc")
-        if use_reference_solc and solc is not None
-        else None
+    reference_specs = (
+        [CompilerSpec(name, name, Path(name), name) for name in ("solc", "solx")]
+        if args.reference_results
+        else []
     )
 
     if args.tests:
@@ -1943,7 +1955,11 @@ def main(argv: Sequence[str] | None = None) -> int:
         tests = list(suite_tests)
 
     skipped = []
-    if (not args.solar_only or use_reference_solc) and not args.include_incompatible:
+    if (
+        args.solc
+        and (not args.solar_only or use_reference_solc)
+        and not args.include_incompatible
+    ):
         compatible_tests = []
         for test in tests:
             if test.project_file is not None and not version_in_range(
@@ -1979,7 +1995,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     for spec in specs:
         print(f"Using {spec.label}")
     if args.reference_results:
-        print(f"Reusing solc results from {display_path(args.reference_results)}")
+        print(f"Reusing reference results from {display_path(args.reference_results)}")
     if (not args.solar_only or use_reference_solc) and solc_version_error:
         print(
             _color(
@@ -2057,8 +2073,11 @@ def main(argv: Sequence[str] | None = None) -> int:
                     file=sys.stderr,
                 )
                 result = failed_test_result(test, specs, args.gas_profile, exc)
-            if reference_solc_spec:
-                if merge_reference_compiler(result, reference_results, "solc"):
+            merged_specs = []
+            for reference_spec in reference_specs:
+                compiler_id = reference_spec.compiler_id
+                if merge_reference_compiler(result, reference_results, compiler_id):
+                    merged_specs.append(reference_spec)
                     if (
                         args.artifacts is not None
                         and args.reference_results is not None
@@ -2067,24 +2086,24 @@ def main(argv: Sequence[str] | None = None) -> int:
                             args.reference_results.parent
                             / "artifacts"
                             / test.test_id
-                            / "solc"
+                            / compiler_id
                         )
                         if source.is_dir():
                             shutil.copytree(
                                 source,
-                                args.artifacts / test.test_id / "solc",
+                                args.artifacts / test.test_id / compiler_id,
                                 dirs_exist_ok=True,
                             )
-                    if args.gas:
-                        compare_runtime_results(result, (reference_solc_spec, *specs))
                 else:
                     print(
                         _color(
-                            f"[{test.test_id}] matching solc reference result not found",
+                            f"[{test.test_id}] matching {compiler_id} reference result not found",
                             YELLOW,
                         ),
                         file=sys.stderr,
                     )
+            if args.gas and merged_specs:
+                compare_runtime_results(result, (*merged_specs, *specs))
             results.append(result)
         if current_suite is not None and suite_started is not None:
             timings[current_suite] = (

--- a/benches/runtime/test_benchmark.py
+++ b/benches/runtime/test_benchmark.py
@@ -222,6 +222,9 @@ class FailureHandlingTests(unittest.TestCase):
             (["--solar-only"], {"solar"}),
             (["--solc", "solc"], {"solar", "solc"}),
             (["--solc", "solc", "--solar-only"], {"solar"}),
+            (["--solx", "solx"], {"solar", "solx"}),
+            (["--solc", "solc", "--solx", "solx"], {"solar", "solc", "solx"}),
+            (["--solx", "solx", "--solar-only"], {"solar"}),
         ):
             with self.subTest(flags=flags):
                 self.check_unexpected_test_error(flags, compilers)
@@ -347,6 +350,17 @@ class RuntimeComparisonTests(unittest.TestCase):
         self.assertTrue(merged)
         self.assertEqual(entry["runtime_status"], "ok")
         self.assertEqual(list(entry["compilers"]), ["solc", "solar"])
+
+        references[("runtime", "test")]["compilers"]["solx"] = references[
+            ("runtime", "test")
+        ]["compilers"]["solc"]
+        self.assertTrue(benchmark.merge_reference_compiler(entry, references, "solx"))
+        benchmark.compare_runtime_results(
+            entry,
+            (*specs, benchmark.CompilerSpec("solx", "solx", Path("solx"), "solx")),
+        )
+        self.assertEqual(entry["runtime_status"], "ok")
+        self.assertEqual(set(entry["compilers"]), {"solar", "solc", "solx"})
 
 
 class ArtifactTests(unittest.TestCase):

--- a/benches/runtime/test_benchmark.py
+++ b/benches/runtime/test_benchmark.py
@@ -393,10 +393,7 @@ class ArtifactTests(unittest.TestCase):
         self.assertNotIn("ir", solar_outputs)
         self.assertIn("ir", solc_outputs)
         self.assertIn("irOptimized", solc_outputs)
-        self.assertEqual(
-            solx_outputs,
-            ["abi", "evm.bytecode.object", "evm.deployedBytecode.object", "ir"],
-        )
+        self.assertEqual(solx_outputs, solc_outputs)
 
     def test_disassemble_evm_matches_solar_dump_style(self) -> None:
         self.assertEqual(

--- a/benches/runtime/test_benchmark.py
+++ b/benches/runtime/test_benchmark.py
@@ -384,6 +384,8 @@ class ArtifactTests(unittest.TestCase):
         self.assertNotIn("evm.deployedBytecode.opcodes", solar_outputs)
         self.assertNotIn("evm.deployedBytecode.opcodes", solc_outputs)
         self.assertNotIn("irOptimized", solar_outputs)
+        self.assertNotIn("ir", solar_outputs)
+        self.assertIn("ir", solc_outputs)
         self.assertIn("irOptimized", solc_outputs)
 
     def test_disassemble_evm_matches_solar_dump_style(self) -> None:

--- a/benches/runtime/test_benchmark.py
+++ b/benches/runtime/test_benchmark.py
@@ -374,10 +374,16 @@ class ArtifactTests(unittest.TestCase):
         solc = json.loads(
             benchmark.artifact_compiler_input(input_text, test_case, "solc")
         )
+        solx = json.loads(
+            benchmark.artifact_compiler_input(input_text, test_case, "solx")
+        )
         solar_outputs = next(iter(solar["settings"]["outputSelection"].values()))[
             test_case.contract_name
         ]
         solc_outputs = next(iter(solc["settings"]["outputSelection"].values()))[
+            test_case.contract_name
+        ]
+        solx_outputs = next(iter(solx["settings"]["outputSelection"].values()))[
             test_case.contract_name
         ]
 
@@ -387,6 +393,10 @@ class ArtifactTests(unittest.TestCase):
         self.assertNotIn("ir", solar_outputs)
         self.assertIn("ir", solc_outputs)
         self.assertIn("irOptimized", solc_outputs)
+        self.assertEqual(
+            solx_outputs,
+            ["abi", "evm.bytecode.object", "evm.deployedBytecode.object", "ir"],
+        )
 
     def test_disassemble_evm_matches_solar_dump_style(self) -> None:
         self.assertEqual(

--- a/benches/runtime/test_benchmark.py
+++ b/benches/runtime/test_benchmark.py
@@ -362,6 +362,42 @@ class RuntimeComparisonTests(unittest.TestCase):
         self.assertEqual(entry["runtime_status"], "ok")
         self.assertEqual(set(entry["compilers"]), {"solar", "solc", "solx"})
 
+    def test_reuses_compile_failure_without_runtime_observations(self) -> None:
+        entry = {
+            "test_id": "test",
+            "suite": "runtime",
+            "gas_profile": "hot",
+            "compilers": {
+                "solar": {
+                    "input_fingerprint": "input",
+                    "runtime_results": [{"label": "value", "value": "1"}],
+                },
+            },
+        }
+        failure = {
+            "status": "failed",
+            "error": "unsupported input",
+            "input_fingerprint": "input",
+        }
+        references = {
+            ("runtime", "test"): {
+                "gas_profile": "hot",
+                "compilers": {"solx": failure},
+            },
+        }
+        self.assertTrue(benchmark.merge_reference_compiler(entry, references, "solx"))
+        self.assertEqual(entry["compilers"]["solx"], failure)
+        self.assertIsNot(entry["compilers"]["solx"], failure)
+
+        entry["compilers"].pop("solx")
+        for fingerprint, profile in (("other", "hot"), ("input", "smoke")):
+            with self.subTest(fingerprint=fingerprint, profile=profile):
+                failure["input_fingerprint"] = fingerprint
+                entry["gas_profile"] = profile
+                self.assertFalse(
+                    benchmark.merge_reference_compiler(entry, references, "solx")
+                )
+
 
 class ArtifactTests(unittest.TestCase):
     def test_artifact_input_requests_portable_outputs(self) -> None:
@@ -509,6 +545,18 @@ class ArtifactTests(unittest.TestCase):
             entry["runtime_mismatches"],
             [{"label": "value", "values": {"solc": "1", "solar": "2"}}],
         )
+        specs = (*specs, benchmark.CompilerSpec("solx", "solx", Path("solx"), "solx"))
+        entry["compilers"]["solx"] = {"status": "failed"}
+        benchmark.compare_runtime_results(entry, specs)
+        self.assertEqual(entry["runtime_status"], "mismatch")
+        self.assertEqual(
+            entry["runtime_mismatches"],
+            [{"label": "value", "values": {"solc": "1", "solar": "2", "solx": None}}],
+        )
+        entry["compilers"]["solar"]["runtime_results"][0]["value"] = "1"
+        benchmark.compare_runtime_results(entry, specs)
+        self.assertEqual(entry["runtime_status"], "failed")
+        self.assertEqual(entry["runtime_mismatches"], [])
 
 
 class RpcTransportTests(unittest.TestCase):

--- a/benches/runtime/test_report.py
+++ b/benches/runtime/test_report.py
@@ -235,6 +235,30 @@ class ReportFormattingTests(unittest.TestCase):
             "| test | 110 (❌ +10.00%) | n/a (n/a) | 210B (❌ +5.00%) | n/a (n/a) |\n",
         )
 
+    def test_codegen_report_adds_reference_compiler_columns(self):
+        current = result()
+        current["compilers"]["extra"] = {
+            "status": "ok",
+            "total_gas": 10,
+            "runtime_size": 20,
+            "deploy_gas": 30,
+            "bytecode_size": 40,
+        }
+        self.assertEqual(
+            benchmark.codegen_report([current], [current]),
+            "## Codegen benchmark\n"
+            "\n"
+            "| bench | gas (vs main) | solc | extra | size (vs main) | solc | extra |\n"
+            "| ----- | ------------- | ---- | ---- | -------------- | ---- | ---- |\n"
+            "| test | n/a (n/a) | n/a (n/a) | 10 (n/a) | n/a (n/a) | n/a (n/a) | 20B (n/a) |\n"
+            "\n"
+            "### Deployment\n"
+            "\n"
+            "| bench | gas (vs main) | solc | extra | size (vs main) | solc | extra |\n"
+            "| ----- | ------------- | ---- | ---- | -------------- | ---- | ---- |\n"
+            "| test | n/a (n/a) | n/a (n/a) | 30 (n/a) | n/a (n/a) | n/a (n/a) | 40B (n/a) |\n",
+        )
+
     def test_codegen_report_labels_failed_revision(self):
         def timed_result(test_id, solar_status):
             return {
@@ -543,6 +567,28 @@ class CompileTimeReportTests(unittest.TestCase):
         self.assertIn("| failed | n/a (n/a) | 400.0 ms (n/a) |", text)
         self.assertIn(
             "| **sum of medians** | **10.0 ms** | **200.0 ms (✅ +1900.00%)** |", text
+        )
+
+    def test_compile_time_report_with_third_compiler(self):
+        results = [self.timed_result("test", 0.010, 0.010)]
+        results[0]["compilers"]["extra"] = {
+            "status": "ok",
+            "compile_time_seconds": 0.010,
+        }
+        self.assertEqual(
+            benchmark.compile_time_report(results, {}, "main"),
+            [
+                "<details>",
+                "<summary>Compilation time</summary>",
+                "",
+                "| bench | time (vs main) | solc | extra |",
+                "| ----- | --------------------- | ---- | ---- |",
+                "| test | 10.0 ms (n/a) | 10.0 ms (~0%) | 10.0 ms (~0%) |",
+                "| **sum of medians** | **10.0 ms** | **10.0 ms (~0%)** | **10.0 ms (~0%)** |",
+                "",
+                "</details>",
+                "",
+            ],
         )
 
     def test_compile_time_report_uses_solar_baseline_delta(self):


### PR DESCRIPTION
Add NomicFoundation/solx as a separate reference compiler in the runtime benchmarks, with its own compilation, gas, runtime checks, and artifacts. The CI Markdown report includes its gas, bytecode size, compilation time, and peak memory measurements alongside solc. Both reference compilers request Yul outputs and save `ir.yul` and `optimized-ir.yul` when returned.

CI pins solx 0.1.8 and runs it only on pushes to main. PR jobs reuse matching results from the exact-base artifact and never run solx, including when rebuilding a missing baseline.
