### PR TITLE
fix(bench): ignore reference failure noise

### DIFF
--- a/benches/runtime/README.md
+++ b/benches/runtime/README.md
@@ -18,7 +18,8 @@ The default runs only our compiler. Pass `--solc PATH` to record a two-compiler 
 Pass `--solx PATH` to include [solx](https://github.com/NomicFoundation/solx) as a separate compiler,
 with its own compilation, gas, runtime checks, and artifacts. CI pins solx 0.1.8 and installs and
 runs it only on pushes to main. Its measurements appear alongside solc in the Markdown report.
-Unsupported inputs remain visible as compiler failures.
+Reference compiler failures remain in the raw results but do not produce report warnings or
+trigger PR comments. Failures from our compiler and result mismatches involving it still do.
 
 Use `--solar-only` to skip solc and solx benchmark compilation even when `--solc PATH` supplies a binary
 for reference validation or helper contracts. The default skips the

--- a/benches/runtime/benchmark-compare.py
+++ b/benches/runtime/benchmark-compare.py
@@ -96,10 +96,7 @@ def compare_runs(
                 gas_reason = "ordered runtime workloads differ"
             elif old.get("gas_status") != "ok" or new.get("gas_status") != "ok":
                 gas_reason = "gas run failed or was not measured"
-            elif any(
-                data.get("runtime_status") in ("failed", "mismatch")
-                for data in (old, new, before, after)
-            ):
+            elif any(runtime_failed(case, compiler) for case in (before, after)):
                 gas_reason = "runtime checks failed"
         if (
             gas_reason
@@ -138,7 +135,7 @@ def compare_runs(
         for label, case in (("baseline", before), ("candidate", after)):
             if case.get("benchmark_error"):
                 issues.append(f"{label}: {case['benchmark_error']}")
-            if case.get("runtime_status") in ("failed", "mismatch"):
+            if runtime_mismatches(case, compiler):
                 issues.append(f"{label} cross-compiler runtime checks failed")
 
         measurements = {}
@@ -546,7 +543,7 @@ def compiler_failures(results: list[dict[str, Any]]) -> list[str]:
             continue
         compilers = result.get("compilers", {})
         for compiler_id, data in compilers.items():
-            if data.get("status") != "ok":
+            if compiler_id == "solar" and data.get("status") != "ok":
                 error_lines = str(data.get("error") or "").strip().splitlines()
                 error = error_lines[0] if error_lines else "compiler failed"
                 failures.append(f"{test_id} {compiler_id}: {error}")
@@ -566,21 +563,41 @@ def format_values(values: dict[str, Any]) -> str:
     )
 
 
+def runtime_mismatches(result: dict[str, Any], compiler: str) -> list[dict[str, Any]]:
+    return [
+        mismatch
+        for mismatch in result.get("runtime_mismatches") or []
+        if (value := (mismatch.get("values") or {}).get(compiler)) is not None
+        and any(
+            other is not None and other != value
+            for other in mismatch["values"].values()
+        )
+    ]
+
+
+def runtime_failed(result: dict[str, Any], compiler: str) -> bool:
+    return compiler_data(result, compiler).get("runtime_status") in (
+        "failed",
+        "mismatch",
+    ) or bool(runtime_mismatches(result, compiler))
+
+
 def runtime_issue_details(results: list[dict[str, Any]]) -> list[str]:
     details = []
     for result in results:
-        status = result.get("runtime_status")
-        if status in (None, "skipped", "ok"):
+        if not runtime_failed(result, "solar"):
             continue
         test_id = "/".join(suite_key(result))
         before = len(details)
 
-        for mismatch in result.get("runtime_mismatches") or []:
+        for mismatch in runtime_mismatches(result, "solar"):
             label = mismatch.get("label", "<unknown>")
             values = mismatch.get("values") or {}
             details.append(f"{test_id} {label}: {format_values(values)}")
 
         for compiler_id, data in (result.get("compilers") or {}).items():
+            if compiler_id != "solar":
+                continue
             for check in data.get("runtime_results") or []:
                 if check.get("status") == "ok":
                     continue
@@ -589,7 +606,8 @@ def runtime_issue_details(results: list[dict[str, Any]]) -> list[str]:
                 details.append(f"{test_id} {compiler_id} {label}: {shorten(error)}")
 
         if len(details) == before:
-            details.append(f"{test_id}: runtime_status={status}")
+            status = compiler_data(result, "solar").get("runtime_status")
+            details.append(f"{test_id} solar: runtime_status={status}")
 
     return details
 

--- a/benches/runtime/test_report.py
+++ b/benches/runtime/test_report.py
@@ -879,6 +879,69 @@ class RunComparisonTests(unittest.TestCase):
         row["compilers"]["solar"].update(values)
         return row
 
+    def test_reference_failures_do_not_trigger_comments_or_warnings(self):
+        for compiler in ("solc", "solx"):
+            for stage in ("status", "runtime_status", "gas_status"):
+                with self.subTest(compiler=compiler, stage=stage):
+                    before = self.fixture()
+                    after = self.fixture()
+                    after["compilers"][compiler] = {
+                        "status": "ok",
+                        stage: "failed",
+                        "error": "reference failed",
+                    }
+                    after["runtime_status"] = "failed"
+                    comparison = benchmark.compare_runs([after], [before])
+                    self.assertEqual(comparison["rows"][0]["issues"], [])
+                    self.assertEqual(
+                        comparison["rows"][0]["metrics"]["total_gas"]["delta"], 0
+                    )
+                    self.assertFalse(benchmark.comparison_has_changes(comparison, True))
+                    self.assertEqual(benchmark.compiler_failures([after]), [])
+                    self.assertEqual(benchmark.runtime_issue_details([after]), [])
+
+    def test_solar_failures_still_trigger_comments_and_warnings(self):
+        before = self.fixture()
+        for stage in ("status", "runtime_status"):
+            with self.subTest(stage=stage):
+                after = self.fixture(**{stage: "failed"})
+                comparison = benchmark.compare_runs([after], [before])
+                self.assertTrue(benchmark.comparison_has_changes(comparison, True))
+                if stage == "status":
+                    self.assertEqual(
+                        benchmark.compiler_failures([after]),
+                        ["repository/test solar: compiler failed"],
+                    )
+                else:
+                    self.assertEqual(
+                        benchmark.runtime_issue_details([after]),
+                        ["repository/test solar: runtime_status=failed"],
+                    )
+
+    def test_mismatches_require_a_solar_observation(self):
+        before = self.fixture()
+        after = self.fixture()
+        after["runtime_status"] = "mismatch"
+        after["runtime_mismatches"] = [
+            {"label": "value", "values": {"solc": "1", "solx": "2", "solar": None}}
+        ]
+        self.assertFalse(
+            benchmark.comparison_has_changes(
+                benchmark.compare_runs([after], [before]), True
+            )
+        )
+        self.assertEqual(benchmark.runtime_issue_details([after]), [])
+        after["runtime_mismatches"][0]["values"]["solar"] = "1"
+        self.assertTrue(
+            benchmark.comparison_has_changes(
+                benchmark.compare_runs([after], [before]), True
+            )
+        )
+        self.assertEqual(
+            benchmark.runtime_issue_details([after]),
+            ["repository/test value: solc=1, solx=2, solar=1"],
+        )
+
     def test_totals_exclude_failed_missing_and_changed_inputs(self):
         before = [
             self.fixture(name) for name in ("paired", "failed", "removed", "input")


### PR DESCRIPTION
Reference compiler failures were marking cross-compiler checks as failed and posting benchmark comments on unrelated PRs even when our compiler's output was unchanged, as in #1413. Solx rejects several archived EVM targets, so those failures persist across runs.

Ignore reference failures in CI warnings and in the comparison used to trigger PR comments. Keep their raw results and successful measurements, and continue reporting failures from our compiler and result mismatches involving it.
