### PR TITLE
perf(lsp): skip import scans for indexed definitions

### DIFF
--- a/crates/lsp/src/handlers/reqs.rs
+++ b/crates/lsp/src/handlers/reqs.rs
@@ -3,7 +3,7 @@ use crate::{
     diagnostics::PullReport,
     document_links::solidity_string_contents,
     formatter::{self, FormatterError},
-    global_state::GlobalState,
+    global_state::{AnalysisRevision, GlobalState},
     import_resolution::{
         ImportCandidateKind, ImportResolver, decode_import_path, import_path_at,
         import_path_at_for_completion,
@@ -554,8 +554,12 @@ pub(crate) fn goto_definition(
     let params = params.text_document_position_params;
     let latest_analysis = latest_analysis_for_uri(state, &params.text_document.uri);
     let analysis_revision = state.analysis_revision();
-    let import_request =
-        import_definition_request(state, &params.text_document.uri, params.position);
+    let import_request = import_definition_request(
+        state,
+        &params.text_document.uri,
+        params.position,
+        &analysis_revision,
+    );
     let config = state.config.clone();
     async move {
         let Some(latest_analysis) = latest_analysis else { return Ok(None) };
@@ -598,15 +602,23 @@ fn import_definition_request(
     state: &GlobalState,
     uri: &Url,
     position: Position,
+    analysis_revision: &AnalysisRevision,
 ) -> Option<ImportDefinitionRequest> {
     let importer = uri.to_file_path().ok()?;
     let vfs_path = VfsPath::from(importer.clone());
-    let (vfs_content_revision, open_contents, overlay_paths) = {
+    let (vfs_content_revision, open_contents) = {
         let vfs = state.vfs.read();
-        let overlay_paths =
-            vfs.iter().filter_map(|(path, _)| path.as_path().map(Path::to_path_buf)).collect();
-        (vfs.content_revision(), vfs.get_file_contents(&vfs_path).cloned(), overlay_paths)
+        (vfs.content_revision(), vfs.get_file_contents(&vfs_path).cloned())
     };
+    // An indexed code symbol cannot overlap an import literal in the same source snapshot.
+    // Require an open, fully analyzed document; dirty buffers and closed files still need
+    // current-source parsing. The actual definition lookup still waits for latest analysis.
+    if open_contents.is_some()
+        && analysis_revision.is_current(vfs_content_revision)
+        && state.symbol_tables.load().has_code_symbol_at_position(uri, position)
+    {
+        return None;
+    }
     let contents = open_contents.or_else(|| {
         state
             .sess
@@ -622,6 +634,12 @@ fn import_definition_request(
     let source = contents.to_string();
     let import = import_path_at(&source, cursor_offset)?;
     let raw_path = import.raw_path;
+    let overlay_paths = state
+        .vfs
+        .read()
+        .iter()
+        .filter_map(|(path, _)| path.as_path().map(Path::to_path_buf))
+        .collect();
     Some(ImportDefinitionRequest { importer, raw_path, overlay_paths, vfs_content_revision })
 }
 

--- a/crates/lsp/src/symbols.rs
+++ b/crates/lsp/src/symbols.rs
@@ -723,6 +723,16 @@ impl SymbolTables {
         symbols
     }
 
+    /// Whether an unambiguous source snapshot indexes code at this position.
+    ///
+    /// These ranges cover HIR references and declaration names, never import path literals.
+    /// Callers must separately ensure that the current source matches this analysis.
+    pub(crate) fn has_code_symbol_at_position(&self, uri: &Url, position: Position) -> bool {
+        !self.rename.conflicting_contents().contains(uri)
+            && (self.reference_at_position(uri, position).is_some()
+                || self.declaration_at_position(uri, position).is_some())
+    }
+
     pub(crate) fn goto_definition(
         &self,
         uri: &Url,

--- a/crates/lsp/src/tests/definition_fast_path.rs
+++ b/crates/lsp/src/tests/definition_fast_path.rs
@@ -1,0 +1,103 @@
+use super::support::RequestFixture;
+use crate::vfs::VfsPath;
+use crop::Rope;
+use lsp_types::{
+    GotoDefinitionParams, GotoDefinitionResponse, PartialResultParams, Position,
+    TextDocumentIdentifier, TextDocumentPositionParams, Url, WorkDoneProgressParams,
+};
+use snapbox::str;
+
+#[test]
+fn current_open_code_and_import_literals_keep_distinct_targets() {
+    let fixture = RequestFixture::new(
+        r#"
+        //- /Main.sol open
+        import "./$1Target.sol";
+        contract Main {
+            function target() internal {}
+            function caller() external { $2target(); }
+        }
+
+        //- /Target.sol
+        contract Target {}
+        "#,
+        "/Main.sol",
+    );
+
+    fixture.check_goto_definition(
+        "$1",
+        str![[r#"
+/Target.sol:0:0 contract Target {}
+
+"#]],
+    );
+    fixture.check_goto_definition(
+        "$2",
+        str![[r#"
+/Main.sol:2:13 function target() internal {}
+
+"#]],
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn changed_open_import_does_not_use_an_old_code_symbol() {
+    let fixture = RequestFixture::new(
+        r#"
+        //- /Main.sol open
+        contract $1Main {}
+
+        //- /Target.sol
+        contract Target {}
+        "#,
+        "/Main.sol",
+    );
+    let mut state = fixture.state();
+    let (uri, position) = fixture.marker_location("$1");
+    state.vfs.write().set_file_contents(
+        VfsPath::from(fixture.project_path("/Main.sol")),
+        Some(Rope::from("import \"./Target.sol\";")),
+    );
+
+    let response =
+        crate::handlers::goto_definition(&mut state, goto_params(uri, position)).await.unwrap();
+
+    assert_eq!(response, None);
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn changed_closed_import_does_not_use_an_old_code_symbol() {
+    let fixture = RequestFixture::new(
+        r#"
+        //- /Main.sol
+        contract $1Main {}
+
+        //- /Target.sol
+        contract Target {}
+        "#,
+        "/Main.sol",
+    );
+    let mut state = fixture.state();
+    let (uri, position) = fixture.marker_location("$1");
+    std::fs::write(fixture.project_path("/Main.sol"), "import \"./Target.sol\";").unwrap();
+
+    let response =
+        crate::handlers::goto_definition(&mut state, goto_params(uri, position)).await.unwrap();
+
+    let Some(GotoDefinitionResponse::Array(locations)) = response else {
+        panic!("the current on-disk import should resolve");
+    };
+    assert_eq!(locations.len(), 1);
+    assert_eq!(locations[0].uri.to_file_path().unwrap(), fixture.project_path("/Target.sol"));
+}
+
+fn goto_params(uri: Url, position: Position) -> GotoDefinitionParams {
+    GotoDefinitionParams {
+        text_document_position_params: TextDocumentPositionParams {
+            text_document: TextDocumentIdentifier::new(uri),
+            position,
+        },
+        work_done_progress_params: WorkDoneProgressParams::default(),
+        partial_result_params: PartialResultParams::default(),
+    }
+}

--- a/crates/lsp/src/tests/mod.rs
+++ b/crates/lsp/src/tests/mod.rs
@@ -38,6 +38,7 @@ mod code_lens;
 mod compatibility_sessions;
 mod completion;
 mod completion_resolve;
+mod definition_fast_path;
 mod document_highlight;
 mod document_link;
 mod file_operations;


### PR DESCRIPTION
Towards OSS-738  , 

## What changed

- `textDocument/definition` checks the analyzed symbol index before preparing import resolution.
- For an open document whose VFS revision matches the analysis, a code-symbol hit avoids copying the source, scanning import literals, and collecting workspace overlay paths.
- Import literals, dirty buffers, closed files, stale analyses, and rename-conflicting documents keep the existing path.
- Added regression coverage for code-vs-import targets and changed open/closed documents.

## Benchmark

`solar-lsp-bench` was run with 10 independent processes, 10 warmups, and 50 measured requests per process. Every session and response passed validation.

| Fixture | p50 before | p50 after | p50 change | p95 change |
| --- | ---: | ---: | ---: | ---: |
| Solady | 0.149959 ms | 0.043875 ms | -70.7% | -70.5% |
| Uniswap | 0.173375 ms | 0.045500 ms | -73.8% | -69.4% |
| OpenZeppelin ERC20 | 0.049334 ms | 0.043291 ms | -12.2% | -20.4% |
| Synthetic | 0.066375 ms | 0.057833 ms | -12.9% | -5.2% |


