### PR TITLE
chore(bench): shorten codegen PR comments

### DIFF
--- a/.github/workflows/bench-comment.yml
+++ b/.github/workflows/bench-comment.yml
@@ -60,6 +60,6 @@ jobs:
         uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3.0.5
         with:
           header: codegen-runtime-bench
-          path: target/codegen-bench/report.md
+          path: target/codegen-bench/comment.md
           number_force: ${{ steps.pr.outputs.number }}
           only_update: ${{ steps.metadata.outputs.should-comment != 'true' }}

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -263,6 +263,7 @@ jobs:
             --results target/codegen-bench/results.json
             --common-output target/codegen-bench/common.json
             --report-output target/codegen-bench/report.md
+            --pr-comment-output target/codegen-bench/comment.md
             --comment-output target/codegen-bench/should-comment
             --ignore-compile-time-changes
           )
@@ -289,7 +290,7 @@ jobs:
         uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3.0.5
         with:
           header: codegen-runtime-bench
-          message: ${{ steps.runtime-report.outputs.report }}
+          path: target/codegen-bench/comment.md
           only_update: ${{ steps.runtime-report.outputs.should_comment != 'true' }}
 
       - name: Upload results as artifact

--- a/benches/runtime/README.md
+++ b/benches/runtime/README.md
@@ -57,9 +57,13 @@ uv run benches/runtime/benchmark-compare.py \
 
 The script prints Markdown to stdout by default. `--report-output` also saves the same
 report; omit it when you only need terminal output.
-CI uses `--pr-comment-output` for a compact PR comment with gas and size changes and
-a button to open the benchmark overview. The detailed report stays in the job summary
+CI uses `--pr-comment-output` for a compact PR comment with a gas and size overview,
+changed benchmarks compared with the base branch, and a button to open the web overview.
+Neither overview includes comparison counts. The detailed report stays in the job summary
 and artifacts. `--comment-output` writes the separate should-comment flag.
+With a baseline, the detailed report shows only changed benchmarks against that baseline,
+plus per-call gas changes and artifact details. Reference compiler tables appear only in
+single-run reports.
 
 Inputs may be directories containing `results.json` or JSON paths. Artifacts default to
 `artifacts/` beside each JSON. Use `--baseline-artifacts` and `--artifacts` for other paths.

--- a/benches/runtime/README.md
+++ b/benches/runtime/README.md
@@ -57,6 +57,9 @@ uv run benches/runtime/benchmark-compare.py \
 
 The script prints Markdown to stdout by default. `--report-output` also saves the same
 report; omit it when you only need terminal output.
+CI uses `--pr-comment-output` for a compact PR comment with gas and size changes and
+a button to open the benchmark overview. The detailed report stays in the job summary
+and artifacts. `--comment-output` writes the separate should-comment flag.
 
 Inputs may be directories containing `results.json` or JSON paths. Artifacts default to
 `artifacts/` beside each JSON. Use `--baseline-artifacts` and `--artifacts` for other paths.

--- a/benches/runtime/benchmark-compare.py
+++ b/benches/runtime/benchmark-compare.py
@@ -338,8 +338,8 @@ def comparison_report(comparison: dict[str, Any]) -> str:
         "Change is the geometric mean of candidate/baseline ratios, with equal weight per benchmark. Only positive, comparable pairs enter the mean.",
         "Runtime gas is the sum of measured calls within each benchmark. Timing and RSS are noisy.",
         "",
-        "| Metric | Change | Pairs in mean | Improved | Regressed | Unchanged | Excluded from mean |",
-        "| --- | ---: | ---: | ---: | ---: | ---: | ---: |",
+        "| Metric | Change |",
+        "| --- | ---: |",
     ]
     for name, values in comparison["summary"].items():
         change = (
@@ -347,9 +347,7 @@ def comparison_report(comparison: dict[str, Any]) -> str:
             if values["percent"] is not None
             else "n/a"
         )
-        lines.append(
-            f"| {METRICS[name]} | {change} | {values['ratio_pairs']} | {values['improved']} | {values['regressed']} | {values['unchanged']} | {len(rows) - values['ratio_pairs']} |"
-        )
+        lines.append(f"| {METRICS[name]} | {change} |")
     if compile_only := sum(bool(row.get("compile_only")) for row in rows):
         lines.extend(
             [
@@ -369,15 +367,13 @@ def comparison_report(comparison: dict[str, Any]) -> str:
         lines.extend(["", "#### Incomplete or incompatible comparisons", "", *issues])
     changed = []
     for name, metric_label in METRICS.items():
-        if comparison["compiler"] == "solar":
-            continue
         for row in sorted(
             rows, key=lambda row: row["metrics"][name]["percent"] or 0, reverse=True
         ):
             values = row["metrics"][name]
             if values["delta"] not in (None, 0):
                 changed.append(
-                    f"| {markdown_cell(row['test_id'])} | {metric_label} | {comparison_cells(values, name)} |"
+                    f"| {perf_link(markdown_cell(row['test_id']), row['test_id'])} | {metric_label} | {comparison_cells(values, name)} |"
                 )
     if changed:
         lines.extend(
@@ -1470,21 +1466,45 @@ def pr_comment(
             if has_changes
             else f"No significant benchmark changes against `{base_ref}`."
         )
-        lines.extend(["", "| Metric | Change | Compared |", "| --- | ---: | ---: |"])
-        for name in ("total_gas", "runtime_size", "bytecode_size"):
+        lines.extend(["", "### Overview", "", "| Metric | Change |", "| --- | ---: |"])
+        metrics = ("total_gas", "runtime_size", "bytecode_size")
+        for name in metrics:
             values = comparison["summary"][name]
             change = (
                 fmt_pct(values["percent"], positive_is_good=False)
                 if values["percent"] is not None
                 else "n/a"
             )
-            lines.append(f"| {METRICS[name]} | {change} | {values['ratio_pairs']} |")
+            lines.append(f"| {METRICS[name]} | {change} |")
         lines.extend(["", "Equal-weight geometric means; lower is better."])
-    if incomplete := sum(bool(row["issues"]) for row in comparison["rows"]):
+        changed = []
+        for row in comparison["rows"]:
+            if any(row["metrics"][name]["delta"] not in (None, 0) for name in metrics):
+                cells = [perf_link(markdown_cell(row["test_id"]), row["test_id"])]
+                for name in metrics:
+                    values = row["metrics"][name]
+                    cells.append(
+                        fmt_pct(values["percent"], positive_is_good=False)
+                        if values["percent"] is not None
+                        else "n/a"
+                    )
+                changed.append("| " + " | ".join(cells) + " |")
+        if changed:
+            lines.extend(
+                [
+                    "",
+                    f"### Changed benchmarks vs `{base_ref}`",
+                    "",
+                    "| Benchmark | Runtime gas | Runtime bytes | Creation bytes |",
+                    "| --- | ---: | ---: | ---: |",
+                    *changed,
+                ]
+            )
+    if any(row["issues"] for row in comparison["rows"]):
         lines.extend(
             [
                 "",
-                f"> ⚠️ Benchmarks with incomplete or incompatible results: {incomplete}.",
+                "> ⚠️ Some benchmarks have incomplete or incompatible results.",
             ]
         )
     if behind_base:
@@ -1755,7 +1775,6 @@ def main(argv: list[str] | None = None) -> int:
         )
     except (OSError, ValueError) as error:
         parser.error(str(error))
-    eligible_rows = {(row["suite"], row["test_id"]): row for row in comparison["rows"]}
     emit_warnings(results, [])
     for row in comparison["rows"]:
         for name in ("total_gas", "runtime_size", "bytecode_size", "deploy_gas"):
@@ -1765,9 +1784,9 @@ def main(argv: list[str] | None = None) -> int:
                     f"{row['test_id']} {row['compiler']} {METRICS[name]} regressed: {values['before']} -> {values['after']}"
                 )
     report = (
-        codegen_report(results, baseline_results, base_ref, eligible_rows)
-        if args.compiler == "solar"
-        else "## Codegen benchmark\n"
+        codegen_report(results, baseline_results, base_ref)
+        if args.baseline is None
+        else ""
     )
     should_comment = not baseline_results or comparison_has_changes(
         comparison, args.ignore_compile_time_changes

--- a/benches/runtime/benchmark-compare.py
+++ b/benches/runtime/benchmark-compare.py
@@ -1456,6 +1456,50 @@ def format_report(
     return notices + details
 
 
+def pr_comment(
+    comparison: dict[str, Any], has_changes: bool, behind_base: bool, base_ref: str
+) -> str:
+    lines = ["## Codegen benchmarks", ""]
+    if not comparison["rows"]:
+        lines.append("No benchmark results were produced.")
+    elif comparison["baseline"] is None:
+        lines.append("No baseline was available for comparison.")
+    else:
+        lines.append(
+            f"Benchmark changes detected against `{base_ref}`."
+            if has_changes
+            else f"No significant benchmark changes against `{base_ref}`."
+        )
+        lines.extend(["", "| Metric | Change | Compared |", "| --- | ---: | ---: |"])
+        for name in ("total_gas", "runtime_size", "bytecode_size"):
+            values = comparison["summary"][name]
+            change = (
+                fmt_pct(values["percent"], positive_is_good=False)
+                if values["percent"] is not None
+                else "n/a"
+            )
+            lines.append(f"| {METRICS[name]} | {change} | {values['ratio_pairs']} |")
+        lines.extend(["", "Equal-weight geometric means; lower is better."])
+    if incomplete := sum(bool(row["issues"]) for row in comparison["rows"]):
+        lines.extend(
+            [
+                "",
+                f"> ⚠️ Benchmarks with incomplete or incompatible results: {incomplete}.",
+            ]
+        )
+    if behind_base:
+        lines.extend(
+            ["", f"> ⚠️ This branch is behind `{base_ref}`; results may be stale."]
+        )
+    button = "![View benchmark overview](https://img.shields.io/badge/View_benchmark_overview-2563eb?style=for-the-badge)"
+    link = perf_link(button)
+    if link == button:
+        site = os.environ.get("BENCHMARK_SITE_URL") or PERF_SITE_URL
+        link = f"[{button}]({site})"
+    lines.extend(["", link, ""])
+    return "\n".join(lines)
+
+
 def metric(value: float, unit: str, statistic: str) -> dict[str, Any]:
     return {"value": value, "unit": unit, "statistic": statistic}
 
@@ -1592,6 +1636,9 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--common-output", type=Path)
     parser.add_argument("--report-output", type=Path)
     parser.add_argument(
+        "--pr-comment-output", type=Path, help="Write a compact PR comment"
+    )
+    parser.add_argument(
         "--json-output",
         type=Path,
         help="Write per-case deltas, eligibility, samples, and artifact hashes",
@@ -1643,6 +1690,7 @@ def main(argv: list[str] | None = None) -> int:
     current_root = args.artifacts or args.results.parent / "artifacts"
     for output in (
         args.report_output,
+        args.pr_comment_output,
         args.json_output,
         args.diff_output,
         args.common_output,
@@ -1724,19 +1772,24 @@ def main(argv: list[str] | None = None) -> int:
     should_comment = not baseline_results or comparison_has_changes(
         comparison, args.ignore_compile_time_changes
     )
+    behind_base = branch_is_behind(base_ref)
     markdown = format_report(
         report,
         should_comment,
-        branch_is_behind(base_ref),
+        behind_base,
         base_ref,
         comparison_report(comparison) if args.baseline is not None else "",
     )
     print(markdown)
-    append_github_output("report", markdown)
     append_github_output("should_comment", "true" if should_comment else "false")
     if args.report_output is not None:
         args.report_output.parent.mkdir(parents=True, exist_ok=True)
         args.report_output.write_text(markdown)
+    if args.pr_comment_output is not None:
+        args.pr_comment_output.parent.mkdir(parents=True, exist_ok=True)
+        args.pr_comment_output.write_text(
+            pr_comment(comparison, should_comment, behind_base, base_ref)
+        )
     if args.json_output is not None:
         args.json_output.parent.mkdir(parents=True, exist_ok=True)
         args.json_output.write_text(

--- a/benches/runtime/test_report.py
+++ b/benches/runtime/test_report.py
@@ -79,6 +79,37 @@ class ReportFormattingTests(unittest.TestCase):
             "</details>\n",
         )
 
+    def test_pr_comment_without_comparison_links_to_overview(self):
+        button = "[![View benchmark overview](https://img.shields.io/badge/View_benchmark_overview-2563eb?style=for-the-badge)](https://example.test/?base=01234567&head=fedcba98#benchmarks)\n"
+        with patch.dict(
+            os.environ,
+            {
+                "BENCHMARK_BASE_SHA": "0123456789abcdef",
+                "BENCHMARK_PR_HEAD_SHA": "fedcba9876543210",
+                "BENCHMARK_SITE_URL": "https://example.test/",
+            },
+            clear=True,
+        ):
+            for rows, status in (
+                ([], "No benchmark results were produced."),
+                (
+                    [{"issues": ["missing baseline"]}],
+                    (
+                        "No baseline was available for comparison.\n\n"
+                        "> ⚠️ Benchmarks with incomplete or incompatible results: 1."
+                    ),
+                ),
+            ):
+                with self.subTest(rows=rows):
+                    self.assertEqual(
+                        benchmark.pr_comment(
+                            {"rows": rows, "baseline": None}, True, True, "main"
+                        ),
+                        f"## Codegen benchmarks\n\n{status}\n\n"
+                        "> ⚠️ This branch is behind `main`; results may be stale.\n\n"
+                        + button,
+                    )
+
     def test_changed_report_has_no_details(self):
         self.assertEqual(
             benchmark.format_report(
@@ -1167,6 +1198,7 @@ class RunComparisonTests(unittest.TestCase):
                 name: root / name
                 for name in (
                     "report.md",
+                    "comment.md",
                     "comparison.json",
                     "common.json",
                     "comment",
@@ -1192,6 +1224,8 @@ class RunComparisonTests(unittest.TestCase):
                         str(root / "after"),
                         "--report-output",
                         str(outputs["report.md"]),
+                        "--pr-comment-output",
+                        str(outputs["comment.md"]),
                         "--json-output",
                         str(outputs["comparison.json"]),
                         "--common-output",
@@ -1205,6 +1239,17 @@ class RunComparisonTests(unittest.TestCase):
                 outputs["summary"].read_text(), outputs["report.md"].read_text() + "\n"
             )
             self.assertEqual(outputs["comment"].read_text(), "false\n")
+            self.assertEqual(
+                outputs["comment.md"].read_text(),
+                "## Codegen benchmarks\n\n"
+                "No significant benchmark changes against `before`.\n\n"
+                "| Metric | Change | Compared |\n| --- | ---: | ---: |\n"
+                "| runtime gas | ~0% | 1 |\n"
+                "| runtime bytes | ~0% | 1 |\n"
+                "| creation bytes | ~0% | 1 |\n\n"
+                "Equal-weight geometric means; lower is better.\n\n"
+                "[![View benchmark overview](https://img.shields.io/badge/View_benchmark_overview-2563eb?style=for-the-badge)](https://getfoundry.sh/perf/solar/)\n",
+            )
             self.assertEqual(
                 json.loads(outputs["comparison.json"].read_text())["totals"][
                     "runtime_size"

--- a/benches/runtime/test_report.py
+++ b/benches/runtime/test_report.py
@@ -96,7 +96,7 @@ class ReportFormattingTests(unittest.TestCase):
                     [{"issues": ["missing baseline"]}],
                     (
                         "No baseline was available for comparison.\n\n"
-                        "> ⚠️ Benchmarks with incomplete or incompatible results: 1."
+                        "> ⚠️ Some benchmarks have incomplete or incompatible results."
                     ),
                 ),
             ):
@@ -1056,6 +1056,43 @@ class RunComparisonTests(unittest.TestCase):
         self.assertNotIn("inspect sample", markdown)
         self.assertEqual(markdown.count("| runtime bytes |"), 1)
 
+    def test_pr_comment_lists_only_changed_benchmarks_against_baseline(self):
+        before = [self.fixture("changed"), self.fixture("unchanged")]
+        after = [
+            self.fixture("changed", runtime_size=110, bytecode_size=60),
+            self.fixture("unchanged"),
+        ]
+        for row in after:
+            row["compilers"]["solc"] = {"status": "ok", "runtime_size": 200}
+            row["compilers"]["solx"] = {"status": "ok", "runtime_size": 300}
+        comparison = benchmark.compare_runs(after, before)
+        comparison["baseline"] = "main.json"
+        with patch.dict(os.environ, {}, clear=True):
+            comment = benchmark.pr_comment(comparison, True, False, "main")
+        self.assertEqual(
+            comment.split("### Changed benchmarks", 1)[1].split("[![", 1)[0],
+            " vs `main`\n\n"
+            "| Benchmark | Runtime gas | Runtime bytes | Creation bytes |\n"
+            "| --- | ---: | ---: | ---: |\n"
+            "| changed | ~0% | ❌ +10.00% | ✅ -50.00% |\n\n",
+        )
+
+    def test_detailed_overview_omits_counts(self):
+        comparison = benchmark.compare_runs([self.fixture()], [self.fixture()])
+        self.assertEqual(
+            benchmark.comparison_report(comparison).splitlines()[6:14],
+            [
+                "| Metric | Change |",
+                "| --- | ---: |",
+                "| runtime gas | ~0% |",
+                "| runtime bytes | ~0% |",
+                "| creation bytes | ~0% |",
+                "| deployment gas | ~0% |",
+                "| compile seconds | ~0% |",
+                "| peak RSS bytes | ~0% |",
+            ],
+        )
+
     def test_solar_only_report_keeps_compile_times(self):
         before = self.fixture()
         after = self.fixture(compile_time_seconds=2)
@@ -1243,10 +1280,11 @@ class RunComparisonTests(unittest.TestCase):
                 outputs["comment.md"].read_text(),
                 "## Codegen benchmarks\n\n"
                 "No significant benchmark changes against `before`.\n\n"
-                "| Metric | Change | Compared |\n| --- | ---: | ---: |\n"
-                "| runtime gas | ~0% | 1 |\n"
-                "| runtime bytes | ~0% | 1 |\n"
-                "| creation bytes | ~0% | 1 |\n\n"
+                "### Overview\n\n"
+                "| Metric | Change |\n| --- | ---: |\n"
+                "| runtime gas | ~0% |\n"
+                "| runtime bytes | ~0% |\n"
+                "| creation bytes | ~0% |\n\n"
                 "Equal-weight geometric means; lower is better.\n\n"
                 "[![View benchmark overview](https://img.shields.io/badge/View_benchmark_overview-2563eb?style=for-the-badge)](https://getfoundry.sh/perf/solar/)\n",
             )


### PR DESCRIPTION
Codegen benchmark comments currently include the full report. Show a compact gas and bytecode size overview without counts, followed by changed benchmarks compared with the base branch. Flag incomplete results and add a button that opens the benchmark overview for the PR's base and head commits.

Use the compact comment for both same-repository and fork PRs. Keep detailed Markdown in local output, CI job summaries, and artifacts, with counts removed from its overview too. Baseline reports show changed benchmarks, per-call gas changes, and artifact details without the solc/solx comparison tables.
