### PR TITLE
fix: repair Windows CI tests

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -2,6 +2,11 @@
 slow-timeout = { period = "60s", terminate-after = 2 }
 status-level = "leak"
 
+# The UI harness runs the full compiler fixture suite in one test process.
+[[profile.default.overrides]]
+filter = 'package(solar-compiler) & test(=ui_test)'
+slow-timeout = { period = "60s", terminate-after = 10 }
+
 # The external Foundry suite compiles and tests whole real-world projects;
 # warn instead of terminating (no `terminate-after`).
 [[profile.default.overrides]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -803,6 +803,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arraydeque"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
+
+[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1473,6 +1479,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "core_detect"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f8f80099a98041a3d1622845c271458a2d73e688351bf3cb999266764b81d48"
+
+[[package]]
 name = "cpubits"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1965,6 +1977,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a7a45518d2863d18aa47f4a0cf9faec2aa4304cc09df5e41299f276b3ad135e"
+dependencies = [
+ "cfg-if",
+ "core_detect",
+ "multiversion",
+ "multiversion_no_op",
+ "rustversion",
+ "scopeguard",
+ "simdutf8",
+]
+
+[[package]]
+name = "encoding_rs_io"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fba3fe847045ecff794b9c138293a80db914678c453ad63fbf0c6a9eb6e00b22"
+dependencies = [
+ "encoding_rs",
+]
+
+[[package]]
 name = "enum-ordinalize"
 version = "4.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2329,6 +2365,16 @@ name = "glob"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
+
+[[package]]
+name = "granit-parser"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65ec0d45986cd51c847c75c5b69a00852c4fc84d0e5e79f041173f73437d0cdf"
+dependencies = [
+ "arraydeque",
+ "smallvec",
+]
 
 [[package]]
 name = "group"
@@ -3002,6 +3048,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "multiversion"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7edb7f0ff51249dfda9ab96b5823695e15a052dc15074c9dbf3d118afaf2c201"
+dependencies = [
+ "multiversion-macros",
+ "target-features",
+]
+
+[[package]]
+name = "multiversion-macros"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b093064383341eb3271f42e381cb8f10a01459478446953953c75d24bd339fc0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "target-features",
+]
+
+[[package]]
+name = "multiversion_no_op"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743fb55ba31b18fb1ecef6bdc9aa2743314978ac084044301a7eee33fb99a20d"
+
+[[package]]
 name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3018,6 +3092,12 @@ dependencies = [
  "cfg_aliases",
  "libc",
 ]
+
+[[package]]
+name = "nohash-hasher"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
 
 [[package]]
 name = "nom"
@@ -3929,12 +4009,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
-name = "ryu"
-version = "1.0.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
-
-[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4086,6 +4160,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-saphyr"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3afb591f9cdb6223c88ba39269aff895620c7f0716dc42b705b5733d5c7c0823"
+dependencies = [
+ "annotate-snippets 0.12.16",
+ "base64",
+ "encoding_rs_io",
+ "granit-parser",
+ "nohash-hasher",
+ "num-traits",
+ "serde_core",
+ "smallvec",
+ "zmij",
+]
+
+[[package]]
 name = "serde_core"
 version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4170,19 +4261,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
-]
-
-[[package]]
-name = "serde_yaml_ng"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b4db627b98b36d4203a7b458cf3573730f2bb591b28871d916dfa9efabfd41f"
-dependencies = [
- "indexmap 2.14.2",
- "itoa",
- "ryu",
- "serde",
- "unsafe-libyaml",
 ]
 
 [[package]]
@@ -4287,6 +4365,12 @@ name = "simd-adler32"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "similar"
@@ -4550,7 +4634,7 @@ dependencies = [
  "solar-data-structures",
  "solar-macros",
  "tempfile",
- "thiserror 1.0.69",
+ "thiserror 2.0.20",
  "tracing",
  "tracing-subscriber",
  "unicode-width",
@@ -4587,7 +4671,7 @@ dependencies = [
  "solar-parse",
  "solar-sema",
  "tempfile",
- "thiserror 1.0.69",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-util",
  "toml_edit",
@@ -4605,8 +4689,8 @@ dependencies = [
  "libc",
  "lsp-types",
  "serde",
+ "serde-saphyr",
  "serde_json",
- "serde_yaml_ng",
  "sha2 0.10.9",
  "snapbox",
  "tempfile",
@@ -4874,6 +4958,12 @@ name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
+name = "target-features"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1bbb9f3c5c463a01705937a24fdabc5047929ac764b2d5b9cf681c1f5041ed5"
 
 [[package]]
 name = "tempfile"
@@ -5417,12 +5507,6 @@ name = "unit-prefix"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
-
-[[package]]
-name = "unsafe-libyaml"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "url"

--- a/tests/ui/standard-json/debug/cli-emit-conflict.jsonc
+++ b/tests/ui/standard-json/debug/cli-emit-conflict.jsonc
@@ -4,5 +4,6 @@
 //@[resources] compile-flags: --emit=ethdebug-resources
 //@[srcmap] compile-flags: --emit=srcmap
 //@ failure-status: 2
+//@ normalize-stderr-test: "solar\\.exe" -> "solar"
 // Clap rejects conflicting modes before compiler diagnostics are initialized.
 {}

--- a/tools/lsp-bench/Cargo.toml
+++ b/tools/lsp-bench/Cargo.toml
@@ -22,8 +22,8 @@ clap = { workspace = true, features = ["derive"] }
 glob = "0.3"
 lsp-types.workspace = true
 serde = { workspace = true, features = ["derive"] }
+serde-saphyr = "1.2"
 serde_json.workspace = true
-serde_yaml_ng = "0.10"
 sha2 = "0.10"
 tempfile.workspace = true
 thiserror = "1.0"

--- a/tools/lsp-bench/src/config.rs
+++ b/tools/lsp-bench/src/config.rs
@@ -719,7 +719,7 @@ fn resolve_manifest_path(base: &Path, path: &Path) -> Result<PathBuf> {
 fn load_yaml<T: for<'de> Deserialize<'de>>(path: &Path, kind: &str) -> Result<(T, String)> {
     let bytes =
         fs::read(path).with_context(|| format!("failed to read {kind} `{}`", path.display()))?;
-    let document = serde_yaml_ng::from_slice(&bytes)
+    let document = serde_saphyr::from_slice(&bytes)
         .with_context(|| format!("failed to parse {kind} `{}`", path.display()))?;
     Ok((document, sha256_bytes(&bytes)))
 }

--- a/tools/lsp-bench/src/process.rs
+++ b/tools/lsp-bench/src/process.rs
@@ -2347,8 +2347,9 @@ mod tests {
 
     #[test]
     fn dynamic_document_selector_matches_all_filter_fields() {
-        let solidity = Url::from_file_path("/workspace/src/Main.sol").unwrap();
-        let javascript = Url::from_file_path("/workspace/src/Main.js").unwrap();
+        let workspace = std::env::current_dir().unwrap();
+        let solidity = Url::from_file_path(workspace.join("src/Main.sol")).unwrap();
+        let javascript = Url::from_file_path(workspace.join("src/Main.js")).unwrap();
         let selector = json!({
             "documentSelector": [{
                 "language": "solidity",
@@ -2383,10 +2384,11 @@ mod tests {
         assert!(parsed.contains_key("workspace/willDeleteFiles"));
         assert!(!parsed.contains_key("workspace/didRenameFiles"));
 
-        let root = Url::from_file_path("/workspace").unwrap();
-        let source = Url::from_file_path("/workspace/src/Main.sol").unwrap();
-        let root_file = Url::from_file_path("/workspace/Main.sol").unwrap();
-        let folder = Url::from_file_path("/workspace/src").unwrap();
+        let workspace = std::env::current_dir().unwrap();
+        let root = Url::from_file_path(&workspace).unwrap();
+        let source = Url::from_file_path(workspace.join("src/Main.sol")).unwrap();
+        let root_file = Url::from_file_path(workspace.join("Main.sol")).unwrap();
+        let folder = Url::from_file_path(workspace.join("src")).unwrap();
         assert!(parsed["workspace/didCreateFiles"][0].filters.as_ref().unwrap()[0].matches(
             root.as_str(),
             &source,

--- a/tools/lsp-bench/tests/fake_lsp.rs
+++ b/tools/lsp-bench/tests/fake_lsp.rs
@@ -138,7 +138,7 @@ fn dispatcher_preserves_out_of_order_messages_and_server_requests() {
             r#"version: 1
 servers:
   - id: fake
-    command: "{}"
+    command: {}
     version_args: [--version]
     env:
       LSP_BENCH_EXPECT_TOOLCHAIN: "1"
@@ -146,7 +146,7 @@ servers:
       solidity:
         compiler: fake
 "#,
-            env!("CARGO_BIN_EXE_solar-lsp-bench-fake"),
+            serde_json::to_string(env!("CARGO_BIN_EXE_solar-lsp-bench-fake")).unwrap(),
         ),
     )
     .unwrap();
@@ -165,11 +165,11 @@ profiles:
     timeout_ms: 2000
 fixtures:
   - id: synthetic
-    root: "{}"
+    root: {}
     source_roots: [.]
     solc:
       version: "1"
-      native: "{}"
+      native: {}
     anchors:
       call:
         path: Main.sol
@@ -319,8 +319,8 @@ scenarios:
           path: Main.sol
           expected_name: Recovered
 "#,
-            fixture.display(),
-            env!("CARGO_BIN_EXE_solar-lsp-bench-fake"),
+            serde_json::to_string(&fixture).unwrap(),
+            serde_json::to_string(env!("CARGO_BIN_EXE_solar-lsp-bench-fake")).unwrap(),
         ),
     )
     .unwrap();
@@ -612,13 +612,13 @@ profiles:
     timeout_ms: 300
 servers:
   - id: ignores-files
-    command: "{}"
+    command: {}
     version_args: [--version]
     env:
       LSP_BENCH_FAKE_BEHAVIOR: ignore-file-notifications
 fixtures:
   - id: synthetic
-    root: "{}"
+    root: {}
     source_roots: [.]
 scenarios:
   - id: create
@@ -635,8 +635,8 @@ scenarios:
           expected_name: Scratch
           expected_path: Scratch.sol
 "#,
-            env!("CARGO_BIN_EXE_solar-lsp-bench-fake"),
-            fixture.display(),
+            serde_json::to_string(env!("CARGO_BIN_EXE_solar-lsp-bench-fake")).unwrap(),
+            serde_json::to_string(&fixture).unwrap(),
         ),
     )
     .unwrap();
@@ -682,13 +682,13 @@ profiles:
     timeout_ms: 300
 servers:
   - id: missing-result
-    command: "{}"
+    command: {}
     version_args: [--version]
     env:
       LSP_BENCH_FAKE_BEHAVIOR: missing-negative-workspace-symbol-result
 fixtures:
   - id: synthetic
-    root: "{}"
+    root: {}
 scenarios:
   - id: lifecycle
     fixture: synthetic
@@ -712,8 +712,8 @@ scenarios:
           expected_path: Scratch.sol
           present: false
 "#,
-            env!("CARGO_BIN_EXE_solar-lsp-bench-fake"),
-            fixture.display(),
+            serde_json::to_string(env!("CARGO_BIN_EXE_solar-lsp-bench-fake")).unwrap(),
+            serde_json::to_string(&fixture).unwrap(),
         ),
     )
     .unwrap();
@@ -760,22 +760,22 @@ profiles:
     readiness_quiet_ms: 20
 servers:
   - id: incorrect
-    command: "{}"
+    command: {}
     version_args: [--version]
     env:
       LSP_BENCH_FAKE_BEHAVIOR: incorrect-hover
   - id: timeout
-    command: "{}"
+    command: {}
     version_args: [--version]
     env:
       LSP_BENCH_FAKE_BEHAVIOR: timeout-hover
 fixtures:
   - id: synthetic
-    root: "{}"
+    root: {}
     source_roots: [.]
     solc:
       version: "1"
-      native: "{}"
+      native: {}
     anchors:
       call:
         path: Main.sol
@@ -794,10 +794,10 @@ scenarios:
           anchor: call
           expected_text: add
 "#,
-            env!("CARGO_BIN_EXE_solar-lsp-bench-fake"),
-            env!("CARGO_BIN_EXE_solar-lsp-bench-fake"),
-            fixture.display(),
-            env!("CARGO_BIN_EXE_solar-lsp-bench-fake"),
+            serde_json::to_string(env!("CARGO_BIN_EXE_solar-lsp-bench-fake")).unwrap(),
+            serde_json::to_string(env!("CARGO_BIN_EXE_solar-lsp-bench-fake")).unwrap(),
+            serde_json::to_string(&fixture).unwrap(),
+            serde_json::to_string(env!("CARGO_BIN_EXE_solar-lsp-bench-fake")).unwrap(),
         ),
     )
     .unwrap();
@@ -842,13 +842,13 @@ profiles:
     timeout_ms: 200
 servers:
   - id: timeout
-    command: "{}"
+    command: {}
     version_args: [--version]
     env:
       LSP_BENCH_FAKE_BEHAVIOR: timeout-initialize
 fixtures:
   - id: synthetic
-    root: "{}"
+    root: {}
     source_roots: [.]
 scenarios:
   - id: initialize
@@ -857,8 +857,8 @@ scenarios:
       - kind: open
         path: Main.sol
 "#,
-            env!("CARGO_BIN_EXE_solar-lsp-bench-fake"),
-            fixture.display(),
+            serde_json::to_string(env!("CARGO_BIN_EXE_solar-lsp-bench-fake")).unwrap(),
+            serde_json::to_string(&fixture).unwrap(),
         ),
     )
     .unwrap();
@@ -893,13 +893,13 @@ profiles:
     timeout_ms: 1000
 servers:
   - id: cleanup
-    command: "{}"
+    command: {}
     version_args: [--version]
     env:
       LSP_BENCH_FAKE_BEHAVIOR: leave-descendant-on-exit
 fixtures:
   - id: synthetic
-    root: "{}"
+    root: {}
     source_roots: [.]
 scenarios:
   - id: restart
@@ -911,8 +911,8 @@ scenarios:
       - kind: open
         path: Main.sol
 "#,
-            env!("CARGO_BIN_EXE_solar-lsp-bench-fake"),
-            fixture.display(),
+            serde_json::to_string(env!("CARGO_BIN_EXE_solar-lsp-bench-fake")).unwrap(),
+            serde_json::to_string(&fixture).unwrap(),
         ),
     )
     .unwrap();
@@ -961,7 +961,7 @@ profiles:
     timeout_ms: 200
 servers:
   - id: blocked-stdin
-    command: "{}"
+    command: {}
     version_args: [--version]
     env:
       LSP_BENCH_FAKE_BEHAVIOR: never-read-stdin
@@ -969,7 +969,7 @@ servers:
       payload: {initialization_payload}
 fixtures:
   - id: synthetic
-    root: "{}"
+    root: {}
     source_roots: [.]
 scenarios:
   - id: initialize
@@ -978,8 +978,8 @@ scenarios:
       - kind: open
         path: Main.sol
 "#,
-            env!("CARGO_BIN_EXE_solar-lsp-bench-fake"),
-            fixture.display(),
+            serde_json::to_string(env!("CARGO_BIN_EXE_solar-lsp-bench-fake")).unwrap(),
+            serde_json::to_string(&fixture).unwrap(),
         ),
     )
     .unwrap();
@@ -1015,13 +1015,13 @@ profiles:
     timeout_ms: 500
 servers:
   - id: crash
-    command: "{}"
+    command: {}
     version_args: [--version]
     env:
       LSP_BENCH_FAKE_BEHAVIOR: no-text-sync-shutdown-crash
 fixtures:
   - id: synthetic
-    root: "{}"
+    root: {}
     source_roots: [.]
     anchors:
       main:
@@ -1041,8 +1041,8 @@ scenarios:
           path: Main.sol
           expected_name: Renamed
 "#,
-            env!("CARGO_BIN_EXE_solar-lsp-bench-fake"),
-            fixture.display(),
+            serde_json::to_string(env!("CARGO_BIN_EXE_solar-lsp-bench-fake")).unwrap(),
+            serde_json::to_string(&fixture).unwrap(),
         ),
     )
     .unwrap();
@@ -1083,13 +1083,13 @@ profiles:
     timeout_ms: 1000
 servers:
   - id: negotiated
-    command: "{}"
+    command: {}
     version_args: [--version]
     env:
       LSP_BENCH_FAKE_BEHAVIOR: negotiated-capabilities
 fixtures:
   - id: synthetic
-    root: "{}"
+    root: {}
     source_roots: [.]
     anchors:
       call:
@@ -1132,8 +1132,8 @@ scenarios:
           path: Main.sol
           expected_name: Renamed
 "#,
-            env!("CARGO_BIN_EXE_solar-lsp-bench-fake"),
-            fixture.display(),
+            serde_json::to_string(env!("CARGO_BIN_EXE_solar-lsp-bench-fake")).unwrap(),
+            serde_json::to_string(&fixture).unwrap(),
         ),
     )
     .unwrap();
@@ -1197,13 +1197,13 @@ profiles:
     timeout_ms: 1000
 servers:
   - id: fake
-    command: "{}"
+    command: {}
     version_args: [--version]
     env:
       LSP_BENCH_FAKE_BEHAVIOR: position-sensitive-hover
 fixtures:
   - id: synthetic
-    root: "{}"
+    root: {}
     source_roots: [.]
     anchors:
       header:
@@ -1228,8 +1228,8 @@ scenarios:
           anchor: target
           expected_text: function add
 "#,
-            env!("CARGO_BIN_EXE_solar-lsp-bench-fake"),
-            fixture.display(),
+            serde_json::to_string(env!("CARGO_BIN_EXE_solar-lsp-bench-fake")).unwrap(),
+            serde_json::to_string(&fixture).unwrap(),
         ),
     )
     .unwrap();
@@ -1270,13 +1270,13 @@ profiles:
     timeout_ms: 1000
 servers:
   - id: numeric
-    command: "{}"
+    command: {}
     version_args: [--version]
     env:
       LSP_BENCH_FAKE_BEHAVIOR: numeric-text-sync
 fixtures:
   - id: synthetic
-    root: "{}"
+    root: {}
     source_roots: [.]
     anchors:
       call:
@@ -1296,8 +1296,8 @@ scenarios:
           anchor: call
           expected_text: add
 "#,
-            env!("CARGO_BIN_EXE_solar-lsp-bench-fake"),
-            fixture.display(),
+            serde_json::to_string(env!("CARGO_BIN_EXE_solar-lsp-bench-fake")).unwrap(),
+            serde_json::to_string(&fixture).unwrap(),
         ),
     )
     .unwrap();
@@ -1347,13 +1347,13 @@ profiles:
     timeout_ms: 1000
 servers:
   - id: no-sync
-    command: "{}"
+    command: {}
     version_args: [--version]
     env:
       LSP_BENCH_FAKE_BEHAVIOR: no-text-sync
 fixtures:
   - id: synthetic
-    root: "{}"
+    root: {}
     source_roots: [.]
     anchors:
       call:
@@ -1403,8 +1403,8 @@ scenarios:
           anchor: call
           expected_label: add
 "#,
-            env!("CARGO_BIN_EXE_solar-lsp-bench-fake"),
-            fixture.display(),
+            serde_json::to_string(env!("CARGO_BIN_EXE_solar-lsp-bench-fake")).unwrap(),
+            serde_json::to_string(&fixture).unwrap(),
         ),
     )
     .unwrap();
@@ -1461,13 +1461,13 @@ profiles:
     timeout_ms: 1000
 servers:
   - id: dynamic-sync
-    command: "{}"
+    command: {}
     version_args: [--version]
     env:
       LSP_BENCH_FAKE_BEHAVIOR: dynamic-text-sync
 fixtures:
   - id: synthetic
-    root: "{}"
+    root: {}
     source_roots: [.]
     anchors:
       main:
@@ -1495,8 +1495,8 @@ scenarios:
           path: Main.sol
           expected_name: Renamed
 "#,
-            env!("CARGO_BIN_EXE_solar-lsp-bench-fake"),
-            fixture.display(),
+            serde_json::to_string(env!("CARGO_BIN_EXE_solar-lsp-bench-fake")).unwrap(),
+            serde_json::to_string(&fixture).unwrap(),
         ),
     )
     .unwrap();
@@ -1548,13 +1548,13 @@ profiles:
     timeout_ms: 1000
 servers:
   - id: dynamic-sync
-    command: "{}"
+    command: {}
     version_args: [--version]
     env:
       LSP_BENCH_FAKE_BEHAVIOR: dynamic-text-sync-selector-mismatch
 fixtures:
   - id: synthetic
-    root: "{}"
+    root: {}
     source_roots: [.]
     anchors:
       main:
@@ -1576,8 +1576,8 @@ scenarios:
           path: Main.sol
           expected_name: Renamed
 "#,
-            env!("CARGO_BIN_EXE_solar-lsp-bench-fake"),
-            fixture.display(),
+            serde_json::to_string(env!("CARGO_BIN_EXE_solar-lsp-bench-fake")).unwrap(),
+            serde_json::to_string(&fixture).unwrap(),
         ),
     )
     .unwrap();
@@ -1623,12 +1623,12 @@ profiles:
     timeout_ms: 500
 servers:
   - id: incompatible
-    command: "{}"
+    command: {}
     version_args: [--version]
     locked_version: "2"
 fixtures:
   - id: synthetic
-    root: "{}"
+    root: {}
     source_roots: [.]
 scenarios:
   - id: open
@@ -1637,8 +1637,8 @@ scenarios:
       - kind: open
         path: Main.sol
 "#,
-            env!("CARGO_BIN_EXE_solar-lsp-bench-fake"),
-            fixture.display(),
+            serde_json::to_string(env!("CARGO_BIN_EXE_solar-lsp-bench-fake")).unwrap(),
+            serde_json::to_string(&fixture).unwrap(),
         ),
     )
     .unwrap();
@@ -1678,11 +1678,11 @@ profiles:
     require_authoritative: true
 servers:
   - id: fake
-    command: "{}"
+    command: {}
     version_args: [--version]
 fixtures:
   - id: synthetic
-    root: "{}"
+    root: {}
     source_roots: [.]
 scenarios:
   - id: open
@@ -1691,8 +1691,8 @@ scenarios:
       - kind: open
         path: Main.sol
 "#,
-            env!("CARGO_BIN_EXE_solar-lsp-bench-fake"),
-            fixture.display(),
+            serde_json::to_string(env!("CARGO_BIN_EXE_solar-lsp-bench-fake")).unwrap(),
+            serde_json::to_string(&fixture).unwrap(),
         ),
     )
     .unwrap();
@@ -1745,13 +1745,13 @@ profiles:
     timeout_ms: 2000
 servers:
   - id: fake
-    command: "{}"
+    command: {}
     version_args: [--version]
     env:
       LSP_BENCH_FAKE_BEHAVIOR: {behavior}
 fixtures:
   - id: synthetic
-    root: "{}"
+    root: {}
     source_roots: [.]
 scenarios:
   - id: cold
@@ -1766,8 +1766,8 @@ scenarios:
           path: Main.sol
           expected_name: Main
 "#,
-                env!("CARGO_BIN_EXE_solar-lsp-bench-fake"),
-                fixture.display(),
+                serde_json::to_string(env!("CARGO_BIN_EXE_solar-lsp-bench-fake")).unwrap(),
+                serde_json::to_string(&fixture).unwrap(),
             ),
         )
         .unwrap();
@@ -1819,11 +1819,11 @@ profiles:
     timeout_ms: 2000
 servers:
   - id: fake
-    command: "{}"
+    command: {}
     version_args: [--version]
 fixtures:
   - id: synthetic
-    root: "{}"
+    root: {}
     source_roots: [.]
     anchors:
       call-double:
@@ -1850,8 +1850,8 @@ scenarios:
           - path: Math.sol
             anchor: math-double
 "#,
-            env!("CARGO_BIN_EXE_solar-lsp-bench-fake"),
-            fixture.display(),
+            serde_json::to_string(env!("CARGO_BIN_EXE_solar-lsp-bench-fake")).unwrap(),
+            serde_json::to_string(&fixture).unwrap(),
         ),
     )
     .unwrap();
@@ -1890,13 +1890,13 @@ profiles:
     timeout_ms: 2000
 servers:
   - id: fake
-    command: "{}"
+    command: {}
     version_args: [--version]
     env:
       LSP_BENCH_FAKE_BEHAVIOR: oversized-rename
 fixtures:
   - id: synthetic
-    root: "{}"
+    root: {}
     source_roots: [.]
     anchors:
       main:
@@ -1917,8 +1917,8 @@ scenarios:
           - path: Main.sol
             anchor: main
 "#,
-            env!("CARGO_BIN_EXE_solar-lsp-bench-fake"),
-            fixture.display(),
+            serde_json::to_string(env!("CARGO_BIN_EXE_solar-lsp-bench-fake")).unwrap(),
+            serde_json::to_string(&fixture).unwrap(),
         ),
     )
     .unwrap();
@@ -1961,13 +1961,13 @@ profiles:
     timeout_ms: 2000
 servers:
   - id: fake
-    command: "{}"
+    command: {}
     version_args: [--version]
     env:
       LSP_BENCH_FAKE_BEHAVIOR: stale-versioned-edit
 fixtures:
   - id: synthetic
-    root: "{}"
+    root: {}
     source_roots: [.]
 scenarios:
   - id: open
@@ -1976,8 +1976,8 @@ scenarios:
       - kind: open
         path: Main.sol
 "#,
-            env!("CARGO_BIN_EXE_solar-lsp-bench-fake"),
-            fixture.display(),
+            serde_json::to_string(env!("CARGO_BIN_EXE_solar-lsp-bench-fake")).unwrap(),
+            serde_json::to_string(&fixture).unwrap(),
         ),
     )
     .unwrap();
@@ -2018,13 +2018,13 @@ profiles:
     timeout_ms: 2000
 servers:
   - id: fake
-    command: "{}"
+    command: {}
     version_args: [--version]
     env:
       LSP_BENCH_FAKE_BEHAVIOR: multi-edit-apply
 fixtures:
   - id: synthetic
-    root: "{}"
+    root: {}
     source_roots: [.]
 scenarios:
   - id: open
@@ -2033,8 +2033,8 @@ scenarios:
       - kind: open
         path: Main.sol
 "#,
-            env!("CARGO_BIN_EXE_solar-lsp-bench-fake"),
-            fixture.display(),
+            serde_json::to_string(env!("CARGO_BIN_EXE_solar-lsp-bench-fake")).unwrap(),
+            serde_json::to_string(&fixture).unwrap(),
         ),
     )
     .unwrap();
@@ -2101,13 +2101,13 @@ profiles:
     timeout_ms: 2000
 servers:
   - id: fake
-    command: "{}"
+    command: {}
     version_args: [--version]
     env:
       LSP_BENCH_FAKE_BEHAVIOR: shutdown-apply-edit
 fixtures:
   - id: synthetic
-    root: "{}"
+    root: {}
     source_roots: [.]
 scenarios:
   - id: open
@@ -2116,8 +2116,8 @@ scenarios:
       - kind: open
         path: Main.sol
 "#,
-            env!("CARGO_BIN_EXE_solar-lsp-bench-fake"),
-            fixture.display(),
+            serde_json::to_string(env!("CARGO_BIN_EXE_solar-lsp-bench-fake")).unwrap(),
+            serde_json::to_string(&fixture).unwrap(),
         ),
     )
     .unwrap();

--- a/tools/lsp-bench/tests/fake_lsp.rs
+++ b/tools/lsp-bench/tests/fake_lsp.rs
@@ -2,6 +2,7 @@
 
 use serde::Serialize;
 use serde_json::Value;
+use serde_saphyr::SerializerOptions;
 use sha2::{Digest, Sha256};
 use snapbox::{assert_data_eq, str};
 use std::{
@@ -23,7 +24,9 @@ fn run_benchmark(config: &Path, output: &Path, args: &[&str]) -> ExitStatus {
 }
 
 fn yaml(value: impl Serialize) -> String {
-    serde_yaml_ng::to_string(&value).unwrap().trim_end().to_owned()
+    let mut options = SerializerOptions::default();
+    options.quote_all = true;
+    serde_saphyr::to_string_with_options(&value, options).unwrap().trim_end().to_owned()
 }
 
 fn read_json(path: &Path) -> Value {

--- a/tools/lsp-bench/tests/fake_lsp.rs
+++ b/tools/lsp-bench/tests/fake_lsp.rs
@@ -1,5 +1,6 @@
 #![allow(unused_crate_dependencies)]
 
+use serde::Serialize;
 use serde_json::Value;
 use sha2::{Digest, Sha256};
 use snapbox::{assert_data_eq, str};
@@ -19,6 +20,10 @@ fn run_benchmark(config: &Path, output: &Path, args: &[&str]) -> ExitStatus {
         .arg(output)
         .status()
         .unwrap()
+}
+
+fn yaml(value: impl Serialize) -> String {
+    serde_yaml_ng::to_string(&value).unwrap().trim_end().to_owned()
 }
 
 fn read_json(path: &Path) -> Value {
@@ -146,7 +151,7 @@ servers:
       solidity:
         compiler: fake
 "#,
-            serde_json::to_string(env!("CARGO_BIN_EXE_solar-lsp-bench-fake")).unwrap(),
+            yaml(env!("CARGO_BIN_EXE_solar-lsp-bench-fake")),
         ),
     )
     .unwrap();
@@ -319,8 +324,8 @@ scenarios:
           path: Main.sol
           expected_name: Recovered
 "#,
-            serde_json::to_string(&fixture).unwrap(),
-            serde_json::to_string(env!("CARGO_BIN_EXE_solar-lsp-bench-fake")).unwrap(),
+            yaml(&fixture),
+            yaml(env!("CARGO_BIN_EXE_solar-lsp-bench-fake")),
         ),
     )
     .unwrap();
@@ -635,8 +640,8 @@ scenarios:
           expected_name: Scratch
           expected_path: Scratch.sol
 "#,
-            serde_json::to_string(env!("CARGO_BIN_EXE_solar-lsp-bench-fake")).unwrap(),
-            serde_json::to_string(&fixture).unwrap(),
+            yaml(env!("CARGO_BIN_EXE_solar-lsp-bench-fake")),
+            yaml(&fixture),
         ),
     )
     .unwrap();
@@ -712,8 +717,8 @@ scenarios:
           expected_path: Scratch.sol
           present: false
 "#,
-            serde_json::to_string(env!("CARGO_BIN_EXE_solar-lsp-bench-fake")).unwrap(),
-            serde_json::to_string(&fixture).unwrap(),
+            yaml(env!("CARGO_BIN_EXE_solar-lsp-bench-fake")),
+            yaml(&fixture),
         ),
     )
     .unwrap();
@@ -794,10 +799,10 @@ scenarios:
           anchor: call
           expected_text: add
 "#,
-            serde_json::to_string(env!("CARGO_BIN_EXE_solar-lsp-bench-fake")).unwrap(),
-            serde_json::to_string(env!("CARGO_BIN_EXE_solar-lsp-bench-fake")).unwrap(),
-            serde_json::to_string(&fixture).unwrap(),
-            serde_json::to_string(env!("CARGO_BIN_EXE_solar-lsp-bench-fake")).unwrap(),
+            yaml(env!("CARGO_BIN_EXE_solar-lsp-bench-fake")),
+            yaml(env!("CARGO_BIN_EXE_solar-lsp-bench-fake")),
+            yaml(&fixture),
+            yaml(env!("CARGO_BIN_EXE_solar-lsp-bench-fake")),
         ),
     )
     .unwrap();
@@ -857,8 +862,8 @@ scenarios:
       - kind: open
         path: Main.sol
 "#,
-            serde_json::to_string(env!("CARGO_BIN_EXE_solar-lsp-bench-fake")).unwrap(),
-            serde_json::to_string(&fixture).unwrap(),
+            yaml(env!("CARGO_BIN_EXE_solar-lsp-bench-fake")),
+            yaml(&fixture),
         ),
     )
     .unwrap();
@@ -911,8 +916,8 @@ scenarios:
       - kind: open
         path: Main.sol
 "#,
-            serde_json::to_string(env!("CARGO_BIN_EXE_solar-lsp-bench-fake")).unwrap(),
-            serde_json::to_string(&fixture).unwrap(),
+            yaml(env!("CARGO_BIN_EXE_solar-lsp-bench-fake")),
+            yaml(&fixture),
         ),
     )
     .unwrap();
@@ -946,7 +951,7 @@ fn server_that_never_reads_stdin_is_bounded_by_request_timeout() {
     let fixture = directory.path().join("fixture");
     fs::create_dir(&fixture).unwrap();
     fs::write(fixture.join("Main.sol"), "contract Main {}\n").unwrap();
-    let initialization_payload = serde_json::to_string(&"x".repeat(1024 * 1024)).unwrap();
+    let initialization_payload = yaml("x".repeat(1024 * 1024));
     let config = directory.path().join("benchmark.yaml");
     fs::write(
         &config,
@@ -978,8 +983,8 @@ scenarios:
       - kind: open
         path: Main.sol
 "#,
-            serde_json::to_string(env!("CARGO_BIN_EXE_solar-lsp-bench-fake")).unwrap(),
-            serde_json::to_string(&fixture).unwrap(),
+            yaml(env!("CARGO_BIN_EXE_solar-lsp-bench-fake")),
+            yaml(&fixture),
         ),
     )
     .unwrap();
@@ -1041,8 +1046,8 @@ scenarios:
           path: Main.sol
           expected_name: Renamed
 "#,
-            serde_json::to_string(env!("CARGO_BIN_EXE_solar-lsp-bench-fake")).unwrap(),
-            serde_json::to_string(&fixture).unwrap(),
+            yaml(env!("CARGO_BIN_EXE_solar-lsp-bench-fake")),
+            yaml(&fixture),
         ),
     )
     .unwrap();
@@ -1132,8 +1137,8 @@ scenarios:
           path: Main.sol
           expected_name: Renamed
 "#,
-            serde_json::to_string(env!("CARGO_BIN_EXE_solar-lsp-bench-fake")).unwrap(),
-            serde_json::to_string(&fixture).unwrap(),
+            yaml(env!("CARGO_BIN_EXE_solar-lsp-bench-fake")),
+            yaml(&fixture),
         ),
     )
     .unwrap();
@@ -1228,8 +1233,8 @@ scenarios:
           anchor: target
           expected_text: function add
 "#,
-            serde_json::to_string(env!("CARGO_BIN_EXE_solar-lsp-bench-fake")).unwrap(),
-            serde_json::to_string(&fixture).unwrap(),
+            yaml(env!("CARGO_BIN_EXE_solar-lsp-bench-fake")),
+            yaml(&fixture),
         ),
     )
     .unwrap();
@@ -1296,8 +1301,8 @@ scenarios:
           anchor: call
           expected_text: add
 "#,
-            serde_json::to_string(env!("CARGO_BIN_EXE_solar-lsp-bench-fake")).unwrap(),
-            serde_json::to_string(&fixture).unwrap(),
+            yaml(env!("CARGO_BIN_EXE_solar-lsp-bench-fake")),
+            yaml(&fixture),
         ),
     )
     .unwrap();
@@ -1403,8 +1408,8 @@ scenarios:
           anchor: call
           expected_label: add
 "#,
-            serde_json::to_string(env!("CARGO_BIN_EXE_solar-lsp-bench-fake")).unwrap(),
-            serde_json::to_string(&fixture).unwrap(),
+            yaml(env!("CARGO_BIN_EXE_solar-lsp-bench-fake")),
+            yaml(&fixture),
         ),
     )
     .unwrap();
@@ -1495,8 +1500,8 @@ scenarios:
           path: Main.sol
           expected_name: Renamed
 "#,
-            serde_json::to_string(env!("CARGO_BIN_EXE_solar-lsp-bench-fake")).unwrap(),
-            serde_json::to_string(&fixture).unwrap(),
+            yaml(env!("CARGO_BIN_EXE_solar-lsp-bench-fake")),
+            yaml(&fixture),
         ),
     )
     .unwrap();
@@ -1576,8 +1581,8 @@ scenarios:
           path: Main.sol
           expected_name: Renamed
 "#,
-            serde_json::to_string(env!("CARGO_BIN_EXE_solar-lsp-bench-fake")).unwrap(),
-            serde_json::to_string(&fixture).unwrap(),
+            yaml(env!("CARGO_BIN_EXE_solar-lsp-bench-fake")),
+            yaml(&fixture),
         ),
     )
     .unwrap();
@@ -1637,8 +1642,8 @@ scenarios:
       - kind: open
         path: Main.sol
 "#,
-            serde_json::to_string(env!("CARGO_BIN_EXE_solar-lsp-bench-fake")).unwrap(),
-            serde_json::to_string(&fixture).unwrap(),
+            yaml(env!("CARGO_BIN_EXE_solar-lsp-bench-fake")),
+            yaml(&fixture),
         ),
     )
     .unwrap();
@@ -1691,8 +1696,8 @@ scenarios:
       - kind: open
         path: Main.sol
 "#,
-            serde_json::to_string(env!("CARGO_BIN_EXE_solar-lsp-bench-fake")).unwrap(),
-            serde_json::to_string(&fixture).unwrap(),
+            yaml(env!("CARGO_BIN_EXE_solar-lsp-bench-fake")),
+            yaml(&fixture),
         ),
     )
     .unwrap();
@@ -1766,8 +1771,8 @@ scenarios:
           path: Main.sol
           expected_name: Main
 "#,
-                serde_json::to_string(env!("CARGO_BIN_EXE_solar-lsp-bench-fake")).unwrap(),
-                serde_json::to_string(&fixture).unwrap(),
+                yaml(env!("CARGO_BIN_EXE_solar-lsp-bench-fake")),
+                yaml(&fixture),
             ),
         )
         .unwrap();
@@ -1850,8 +1855,8 @@ scenarios:
           - path: Math.sol
             anchor: math-double
 "#,
-            serde_json::to_string(env!("CARGO_BIN_EXE_solar-lsp-bench-fake")).unwrap(),
-            serde_json::to_string(&fixture).unwrap(),
+            yaml(env!("CARGO_BIN_EXE_solar-lsp-bench-fake")),
+            yaml(&fixture),
         ),
     )
     .unwrap();
@@ -1917,8 +1922,8 @@ scenarios:
           - path: Main.sol
             anchor: main
 "#,
-            serde_json::to_string(env!("CARGO_BIN_EXE_solar-lsp-bench-fake")).unwrap(),
-            serde_json::to_string(&fixture).unwrap(),
+            yaml(env!("CARGO_BIN_EXE_solar-lsp-bench-fake")),
+            yaml(&fixture),
         ),
     )
     .unwrap();
@@ -1976,8 +1981,8 @@ scenarios:
       - kind: open
         path: Main.sol
 "#,
-            serde_json::to_string(env!("CARGO_BIN_EXE_solar-lsp-bench-fake")).unwrap(),
-            serde_json::to_string(&fixture).unwrap(),
+            yaml(env!("CARGO_BIN_EXE_solar-lsp-bench-fake")),
+            yaml(&fixture),
         ),
     )
     .unwrap();
@@ -2033,8 +2038,8 @@ scenarios:
       - kind: open
         path: Main.sol
 "#,
-            serde_json::to_string(env!("CARGO_BIN_EXE_solar-lsp-bench-fake")).unwrap(),
-            serde_json::to_string(&fixture).unwrap(),
+            yaml(env!("CARGO_BIN_EXE_solar-lsp-bench-fake")),
+            yaml(&fixture),
         ),
     )
     .unwrap();
@@ -2116,8 +2121,8 @@ scenarios:
       - kind: open
         path: Main.sol
 "#,
-            serde_json::to_string(env!("CARGO_BIN_EXE_solar-lsp-bench-fake")).unwrap(),
-            serde_json::to_string(&fixture).unwrap(),
+            yaml(env!("CARGO_BIN_EXE_solar-lsp-bench-fake")),
+            yaml(&fixture),
         ),
     )
     .unwrap();


### PR DESCRIPTION
Fix the Windows failures in [this CI run](https://github.com/paradigmxyz/solar/actions/runs/34279994350/job/102242190016) by escaping paths in benchmark YAML, using native absolute paths in URI tests, and normalizing the executable suffix in CLI snapshots. Switch benchmark config parsing and the shared YAML serialization helper to serde-saphyr, with quoted strings for inline fixture values. Give the full UI harness ten minutes before nextest terminates it, since it runs the entire fixture suite in one process.