### PR TITLE
perf(lsp): reuse unchanged analysis batches

### DIFF
--- a/crates/lsp/src/global_state.rs
+++ b/crates/lsp/src/global_state.rs
@@ -1,3 +1,4 @@
+use self::prototype_dependencies::DependencySnapshot;
 use crate::{
     NotifyResult,
     config::{
@@ -54,6 +55,8 @@ use tokio::{
     sync::{Mutex as AsyncMutex, Semaphore, oneshot, watch},
     task::{AbortHandle, JoinHandle},
 };
+
+mod prototype_dependencies;
 
 #[derive(Clone, Copy)]
 enum AnalysisMode {
@@ -139,11 +142,15 @@ impl ImportPathTracker {
 
 struct TrackingFileLoader {
     tracker: ImportPathTracker,
+    dependencies: Option<DependencySnapshot>,
 }
 
 impl FileLoader for TrackingFileLoader {
     fn canonicalize_path(&self, path: &Path) -> io::Result<PathBuf> {
         let result = RealFileLoader.canonicalize_path(path);
+        if let Some(dependencies) = &self.dependencies {
+            dependencies.record_canonicalize(path, &result);
+        }
         let mut probes = self.tracker.0.lock();
         if result.as_ref().is_err_and(|error| error.kind() == io::ErrorKind::NotFound) {
             probes.missing.insert(path.to_path_buf());
@@ -154,14 +161,24 @@ impl FileLoader for TrackingFileLoader {
     }
 
     fn load_stdin(&self) -> io::Result<String> {
+        if let Some(dependencies) = &self.dependencies {
+            dependencies.invalidate();
+        }
         RealFileLoader.load_stdin()
     }
 
     fn load_file(&self, path: &Path) -> io::Result<String> {
-        RealFileLoader.load_file(path)
+        let result = RealFileLoader.load_file(path);
+        if let Some(dependencies) = &self.dependencies {
+            dependencies.record_read(path, &result);
+        }
+        result
     }
 
     fn load_binary_file(&self, path: &Path) -> io::Result<Vec<u8>> {
+        if let Some(dependencies) = &self.dependencies {
+            dependencies.invalidate();
+        }
         RealFileLoader.load_binary_file(path)
     }
 }
@@ -274,6 +291,16 @@ struct CachedAnalysisOutput {
     config: Arc<Config>,
     output: AnalysisOutput<Arc<SymbolTables>>,
     inputs: Vec<AnalysisBatchInputs>,
+    /// Independently reusable batches whose inputs and loader observations can be revalidated.
+    ///
+    /// Keep these only for multiple nonempty workspaces: a single workspace can reuse the
+    /// aggregate directly, without retaining another copy of its symbol tables.
+    batches: Vec<Option<Arc<CachedAnalysisBatch>>>,
+}
+
+struct CachedAnalysisBatch {
+    output: AnalysisOutput,
+    dependencies: DependencySnapshot,
 }
 
 /// Exact analysis roots and overlays, excluding client document versions.
@@ -1622,7 +1649,9 @@ fn run_analysis(
             } else {
                 commit.cached_output.as_ref().and_then(|cached| {
                     (cached.vfs_content_revision == vfs_content_revision
-                        && Arc::ptr_eq(&cached.config, &config))
+                        && Arc::ptr_eq(&cached.config, &config)
+                        // Multi-workspace caches must validate each batch's filesystem observations below.
+                        && cached.batches.is_empty())
                     .then(|| cached.output.clone())
                 })
             }
@@ -1662,6 +1691,8 @@ fn run_analysis(
                 && Arc::ptr_eq(&cached.config, &config)
                 // The compared batches do not include disk-only imports or resolver probes.
                 && cached.output.analysis_paths.is_empty()
+                // Multi-workspace caches must validate each batch's filesystem observations below.
+                && cached.batches.is_empty()
                 && cached.inputs.len() == batches.len()
                 && cached.inputs.iter().zip(&batches).all(|(inputs, batch)| {
                     inputs.files == batch.files && inputs.preloaded_files == batch.preloaded_files
@@ -1683,6 +1714,21 @@ fn run_analysis(
         }
     }
 
+    let cache_batches = !has_disk_paths
+        && source_files_complete
+        && batches.iter().filter(|batch| !batch.files.is_empty()).take(2).count() > 1;
+    let cached_batches = if cache_batches {
+        let commit = snapshot.analysis_commit.lock();
+        commit.cached_output.as_ref().and_then(|cached| {
+            (!commit.cache_invalidated
+                && Arc::ptr_eq(&cached.config, &config)
+                && cached.inputs.len() == batches.len()
+                && cached.batches.len() == batches.len())
+            .then(|| (cached.inputs.clone(), cached.batches.clone()))
+        })
+    } else {
+        None
+    };
     let inputs = if has_disk_paths {
         Vec::new()
     } else {
@@ -1695,8 +1741,10 @@ fn run_analysis(
             .collect::<Vec<_>>()
     };
     let mut results = AnalysisOutputAccumulator::default();
+    let mut next_cached_batches =
+        if cache_batches { vec![None; batches.len()] } else { Vec::new() };
 
-    for batch in batches {
+    for (idx, batch) in batches.into_iter().enumerate() {
         if batch.files.is_empty() {
             continue;
         }
@@ -1705,8 +1753,34 @@ fn run_analysis(
             return AnalysisTaskOutcome::Superseded;
         }
 
-        let Some(result) = analyze_cancellable(batch, cancellation) else {
-            return AnalysisTaskOutcome::Superseded;
+        let cached = cached_batches.as_ref().and_then(|(inputs, outputs)| {
+            let inputs = &inputs[idx];
+            (inputs.files == batch.files && inputs.preloaded_files == batch.preloaded_files)
+                .then(|| outputs[idx].clone())
+                .flatten()
+                .filter(|cached| cached.dependencies.unchanged(cancellation))
+        });
+        let result = if let Some(cached) = cached {
+            let mut result = cached.output.clone();
+            // Exact source contents permit reuse, but document versions belong to this epoch.
+            for (uri, version) in &mut result.result.analyzed_documents {
+                *version = batch.open_file_versions.get(uri).copied();
+            }
+            next_cached_batches[idx] = Some(cached);
+            result
+        } else {
+            let dependencies = cache_batches.then(DependencySnapshot::default);
+            let Some(result) =
+                analyze_recording_dependencies(batch, cancellation, dependencies.clone())
+            else {
+                return AnalysisTaskOutcome::Superseded;
+            };
+            // Root text alone cannot establish freshness: replay all disk reads and path probes.
+            if let Some(dependencies) = dependencies {
+                next_cached_batches[idx] =
+                    Some(Arc::new(CachedAnalysisBatch { output: result.clone(), dependencies }));
+            }
+            result
         };
         results.push(result);
 
@@ -1723,7 +1797,12 @@ fn run_analysis(
                 vfs_content_revision,
                 config,
                 output: output.clone(),
-                inputs: if output.analysis_paths.is_empty() { inputs } else { Vec::new() },
+                inputs: if output.analysis_paths.is_empty() || cache_batches {
+                    inputs
+                } else {
+                    Vec::new()
+                },
+                batches: next_cached_batches,
             });
         }
     }
@@ -2863,13 +2942,22 @@ fn analyze_with_source_map(batch: AnalysisBatch, source_map: Arc<SourceMap>) -> 
     .result
 }
 
+#[cfg(any(test, feature = "bench"))]
 fn analyze_cancellable(
     batch: AnalysisBatch,
     cancellation: &IndexingCancellation,
 ) -> Option<AnalysisOutput> {
+    analyze_recording_dependencies(batch, cancellation, None)
+}
+
+fn analyze_recording_dependencies(
+    batch: AnalysisBatch,
+    cancellation: &IndexingCancellation,
+    dependencies: Option<DependencySnapshot>,
+) -> Option<AnalysisOutput> {
     let tracker = ImportPathTracker::default();
     let source_map = Arc::new(SourceMap::empty());
-    source_map.set_file_loader(TrackingFileLoader { tracker: tracker.clone() });
+    source_map.set_file_loader(TrackingFileLoader { tracker: tracker.clone(), dependencies });
     analyze_cancellable_with_source_map(batch, source_map, tracker, cancellation)
 }
 

--- a/crates/lsp/src/global_state/prototype_dependencies.rs
+++ b/crates/lsp/src/global_state/prototype_dependencies.rs
@@ -1,0 +1,302 @@
+//! Dependency validation for reusable per-batch analysis outputs.
+//!
+//! Record the loader's exact path resolutions and raw source reads, including failed resolution
+//! probes. Reuse requires replaying every observation and checking the working directory. This
+//! deliberately trades disk reads and retained source strings for avoiding repeated analysis;
+//! timestamps and hashes are not correctness substitutes.
+
+use crate::workspace::index_policy::IndexingCancellation;
+use solar_interface::{
+    data_structures::sync::Mutex,
+    source_map::{FileLoader, RealFileLoader},
+};
+use std::{
+    collections::HashMap,
+    env, io,
+    path::{Path, PathBuf},
+    sync::Arc,
+};
+
+/// Filesystem observations shared by a batch's loader and cache entry.
+#[derive(Clone)]
+pub(super) struct DependencySnapshot {
+    observations: Arc<Mutex<Option<Observations>>>,
+}
+
+struct Observations {
+    cwd: PathBuf,
+    entries: Vec<Observation>,
+    /// Deduplicate repeated loader calls while retaining conflict detection.
+    resolutions: HashMap<PathBuf, Resolution>,
+    reads: HashMap<PathBuf, usize>,
+}
+
+enum Resolution {
+    Canonical(PathBuf),
+    Missing(Option<i32>),
+}
+
+enum Observation {
+    Canonicalized { path: PathBuf, canonical: PathBuf },
+    Missing { path: PathBuf, raw_os_error: Option<i32> },
+    Read { path: PathBuf, source: String },
+}
+
+impl Default for DependencySnapshot {
+    fn default() -> Self {
+        let observations = env::current_dir().ok().map(|cwd| Observations {
+            cwd,
+            entries: Vec::new(),
+            resolutions: HashMap::new(),
+            reads: HashMap::new(),
+        });
+        Self { observations: Arc::new(Mutex::new(observations)) }
+    }
+}
+
+impl DependencySnapshot {
+    pub(super) fn record_canonicalize(&self, path: &Path, result: &io::Result<PathBuf>) {
+        let resolution = match result {
+            Ok(canonical) => Resolution::Canonical(canonical.clone()),
+            Err(error) if error.kind() == io::ErrorKind::NotFound => {
+                Resolution::Missing(error.raw_os_error())
+            }
+            Err(_) => {
+                self.invalidate();
+                return;
+            }
+        };
+        let mut conflict = false;
+        let mut observations_guard = self.observations.lock();
+        if let Some(observations) = observations_guard.as_mut() {
+            let key = path.to_path_buf();
+            match observations.resolutions.get(&key) {
+                Some(Resolution::Canonical(previous)) if matches!(&resolution, Resolution::Canonical(current) if current == previous) =>
+                    {}
+                Some(Resolution::Missing(previous)) if matches!(&resolution, Resolution::Missing(current) if current == previous) =>
+                    {}
+                Some(_) => conflict = true,
+                None => {
+                    let entry = match &resolution {
+                        Resolution::Canonical(canonical) => Observation::Canonicalized {
+                            path: key.clone(),
+                            canonical: canonical.clone(),
+                        },
+                        Resolution::Missing(raw_os_error) => {
+                            Observation::Missing { path: key.clone(), raw_os_error: *raw_os_error }
+                        }
+                    };
+                    observations.resolutions.insert(key, resolution);
+                    observations.entries.push(entry);
+                }
+            }
+        }
+        drop(observations_guard);
+        if conflict {
+            self.invalidate();
+        }
+    }
+
+    pub(super) fn record_read(&self, path: &Path, result: &io::Result<String>) {
+        let Ok(source) = result else {
+            self.invalidate();
+            return;
+        };
+        let mut observations_guard = self.observations.lock();
+        let mut conflict = false;
+        if let Some(observations) = observations_guard.as_mut() {
+            if let Some(&index) = observations.reads.get(path) {
+                let previous = match &observations.entries[index] {
+                    Observation::Read { source: previous, .. } => previous,
+                    _ => unreachable!(),
+                };
+                conflict = previous != source;
+            } else {
+                let index = observations.entries.len();
+                observations.reads.insert(path.to_path_buf(), index);
+                observations
+                    .entries
+                    .push(Observation::Read { path: path.to_path_buf(), source: source.clone() });
+            }
+        }
+        drop(observations_guard);
+        if conflict {
+            self.invalidate();
+        }
+    }
+
+    pub(super) fn invalidate(&self) {
+        *self.observations.lock() = None;
+    }
+
+    pub(super) fn unchanged(&self, cancellation: &IndexingCancellation) -> bool {
+        if cancellation.is_cancelled() {
+            return false;
+        }
+        let observations = self.observations.lock();
+        let Some(observations) = observations.as_ref() else {
+            return false;
+        };
+        if env::current_dir().ok().as_ref() != Some(&observations.cwd) {
+            return false;
+        }
+        for observation in &observations.entries {
+            if cancellation.is_cancelled() {
+                return false;
+            }
+            let matches = match observation {
+                Observation::Canonicalized { path, canonical } => {
+                    RealFileLoader.canonicalize_path(path).ok().as_ref() == Some(canonical)
+                }
+                Observation::Missing { path, raw_os_error } => {
+                    RealFileLoader.canonicalize_path(path).is_err_and(|error| {
+                        error.kind() == io::ErrorKind::NotFound
+                            && error.raw_os_error() == *raw_os_error
+                    })
+                }
+                Observation::Read { path, source } => {
+                    RealFileLoader.load_file(path).ok().as_ref() == Some(source)
+                }
+            };
+            if !matches {
+                return false;
+            }
+        }
+        !cancellation.is_cancelled()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    #[cfg(unix)]
+    use std::os::unix::fs::symlink;
+
+    #[test]
+    fn unchanged_resolutions_and_reads_are_reusable() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("source.sol");
+        fs::write(&path, "contract Source {}\n").unwrap();
+        let snapshot = DependencySnapshot::default();
+        snapshot.record_canonicalize(&path, &RealFileLoader.canonicalize_path(&path));
+        snapshot.record_read(&path, &RealFileLoader.load_file(&path));
+
+        assert!(snapshot.unchanged(&IndexingCancellation::default()));
+    }
+
+    #[test]
+    fn source_byte_changes_prevent_reuse() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("source.sol");
+        fs::write(&path, "contract Before {}\n").unwrap();
+        let snapshot = DependencySnapshot::default();
+        snapshot.record_read(&path, &RealFileLoader.load_file(&path));
+        fs::write(&path, "contract After_ {}\n").unwrap();
+
+        assert!(!snapshot.unchanged(&IndexingCancellation::default()));
+    }
+
+    #[test]
+    fn removing_a_byte_order_mark_prevents_reuse() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("source.sol");
+        fs::write(&path, "\u{feff}contract Source {}\n").unwrap();
+        let snapshot = DependencySnapshot::default();
+        snapshot.record_read(&path, &RealFileLoader.load_file(&path));
+        assert!(snapshot.unchanged(&IndexingCancellation::default()));
+        fs::write(&path, "contract Source {}\n").unwrap();
+
+        assert!(!snapshot.unchanged(&IndexingCancellation::default()));
+    }
+
+    #[test]
+    fn creating_a_missing_resolution_candidate_prevents_reuse() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("missing.sol");
+        let snapshot = DependencySnapshot::default();
+        let resolution = RealFileLoader.canonicalize_path(&path);
+        assert_eq!(resolution.as_ref().unwrap_err().kind(), io::ErrorKind::NotFound);
+        snapshot.record_canonicalize(&path, &resolution);
+        assert!(snapshot.unchanged(&IndexingCancellation::default()));
+        fs::write(&path, "contract Created {}\n").unwrap();
+
+        assert!(!snapshot.unchanged(&IndexingCancellation::default()));
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn retargeting_a_symlink_with_identical_contents_prevents_reuse() {
+        let directory = tempfile::tempdir().unwrap();
+        let first = directory.path().join("first.sol");
+        let second = directory.path().join("second.sol");
+        let link = directory.path().join("link.sol");
+        fs::write(&first, "contract Source {}\n").unwrap();
+        fs::write(&second, "contract Source {}\n").unwrap();
+        symlink(&first, &link).unwrap();
+        let snapshot = DependencySnapshot::default();
+        snapshot.record_canonicalize(&link, &RealFileLoader.canonicalize_path(&link));
+        snapshot.record_read(&link, &RealFileLoader.load_file(&link));
+        assert!(snapshot.unchanged(&IndexingCancellation::default()));
+        fs::remove_file(&link).unwrap();
+        symlink(&second, &link).unwrap();
+
+        assert!(!snapshot.unchanged(&IndexingCancellation::default()));
+    }
+
+    #[test]
+    fn unexpected_canonicalization_errors_prevent_reuse() {
+        let snapshot = DependencySnapshot::default();
+        snapshot.record_canonicalize(
+            Path::new("source.sol"),
+            &Err(io::Error::from(io::ErrorKind::PermissionDenied)),
+        );
+
+        assert!(!snapshot.unchanged(&IndexingCancellation::default()));
+    }
+
+    #[test]
+    fn read_errors_prevent_reuse() {
+        let snapshot = DependencySnapshot::default();
+        snapshot
+            .record_read(Path::new("missing.sol"), &Err(io::Error::from(io::ErrorKind::NotFound)));
+
+        assert!(!snapshot.unchanged(&IndexingCancellation::default()));
+    }
+
+    #[test]
+    fn conflicting_reads_are_not_overwritten() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("source.sol");
+        fs::write(&path, "contract Before {}\n").unwrap();
+        let snapshot = DependencySnapshot::default();
+        snapshot.record_read(&path, &RealFileLoader.load_file(&path));
+        fs::write(&path, "contract After_ {}\n").unwrap();
+        snapshot.record_read(&path, &RealFileLoader.load_file(&path));
+
+        assert!(!snapshot.unchanged(&IndexingCancellation::default()));
+    }
+
+    #[test]
+    fn cancellation_prevents_reuse() {
+        let snapshot = DependencySnapshot::default();
+        let cancellation = IndexingCancellation::default();
+        cancellation.cancel();
+
+        assert!(!snapshot.unchanged(&cancellation));
+    }
+
+    #[test]
+    fn invalidation_is_shared_and_cannot_be_reversed_by_recording() {
+        let directory = tempfile::tempdir().unwrap();
+        let snapshot = DependencySnapshot::default();
+        let loader_snapshot = snapshot.clone();
+        loader_snapshot.invalidate();
+        loader_snapshot.record_canonicalize(
+            directory.path(),
+            &RealFileLoader.canonicalize_path(directory.path()),
+        );
+
+        assert!(!snapshot.unchanged(&IndexingCancellation::default()));
+    }
+}

--- a/crates/lsp/src/tests/indexing.rs
+++ b/crates/lsp/src/tests/indexing.rs
@@ -200,6 +200,176 @@ async fn opening_identical_source_and_reverted_edits_reuse_analysis() {
     assert!(!Arc::ptr_eq(&edited, &state.symbol_tables.load()));
 }
 
+fn cached_batch_for_path(state: &GlobalState, path: &Path) -> Option<Arc<CachedAnalysisBatch>> {
+    let commit = state.analysis_commit.lock();
+    let cached = commit.cached_output.as_ref()?;
+    let idx = cached
+        .inputs
+        .iter()
+        .position(|inputs| inputs.files.iter().any(|(input_path, _)| input_path == path))?;
+    cached.batches.get(idx)?.clone()
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn editing_one_workspace_reuses_other_workspace_and_current_document_versions() {
+    let project = TestProject::from_fixture(
+        r#"
+        //- /a/Main.sol
+        contract Main { uint public original; }
+        //- /b/Other.sol
+        contract Other { uint public stable; }
+        "#,
+    );
+    let main = project.path("/a/Main.sol");
+    let other = project.path("/b/Other.sol");
+    let main_uri = Url::from_file_path(&main).unwrap();
+    let other_uri = Url::from_file_path(&other).unwrap();
+    let mut state = GlobalState::new(ClientSocket::new_closed());
+    state.config = Arc::new(project.config_with_roots(&["/a", "/b"]));
+    state.recompute_after_opening_source(Vec::new());
+    tokio::time::timeout(ASYNC_TEST_TIMEOUT, state.latest_analysis()).await.unwrap().unwrap();
+    let original_main = cached_batch_for_path(&state, &main).unwrap();
+    let original_other = cached_batch_for_path(&state, &other).unwrap();
+
+    for (uri, source) in [
+        (main_uri.clone(), project.read_file("/a/Main.sol")),
+        (other_uri.clone(), project.read_file("/b/Other.sol")),
+    ] {
+        let _ = handlers::did_open_text_document(
+            &mut state,
+            DidOpenTextDocumentParams {
+                text_document: TextDocumentItem::new(uri, "solidity".into(), 7, source),
+            },
+        );
+        tokio::time::timeout(ASYNC_TEST_TIMEOUT, state.latest_analysis()).await.unwrap().unwrap();
+    }
+
+    let _ = handlers::did_change_text_document(
+        &mut state,
+        DidChangeTextDocumentParams {
+            text_document: VersionedTextDocumentIdentifier::new(main_uri.clone(), 8),
+            content_changes: vec![TextDocumentContentChangeEvent {
+                range: None,
+                range_length: None,
+                text: "contract Main { uint public edited; }".into(),
+            }],
+        },
+    );
+    tokio::time::timeout(ASYNC_TEST_TIMEOUT, state.latest_analysis()).await.unwrap().unwrap();
+    assert!(!Arc::ptr_eq(&original_main, &cached_batch_for_path(&state, &main).unwrap()));
+    assert!(Arc::ptr_eq(&original_other, &cached_batch_for_path(&state, &other).unwrap()));
+    let tables = state.symbol_tables.load_full();
+    assert!(tables.workspace_symbols("original").is_empty());
+    assert_eq!(tables.workspace_symbols("edited").len(), 1);
+    assert_eq!(tables.workspace_symbols("stable").len(), 1);
+    let reports = state.diagnostics.read().workspace_pull_reports(Vec::new());
+    assert_eq!(reports.iter().find(|report| report.uri == main_uri).unwrap().version, Some(8));
+    assert_eq!(reports.iter().find(|report| report.uri == other_uri).unwrap().version, Some(7));
+
+    let _ = handlers::did_close_text_document(
+        &mut state,
+        DidCloseTextDocumentParams { text_document: TextDocumentIdentifier::new(main_uri.clone()) },
+    );
+    tokio::time::timeout(ASYNC_TEST_TIMEOUT, state.latest_analysis()).await.unwrap().unwrap();
+    let tables = state.symbol_tables.load_full();
+    assert!(tables.workspace_symbols("edited").is_empty());
+    assert_eq!(tables.workspace_symbols("original").len(), 1);
+    assert_eq!(tables.workspace_symbols("stable").len(), 1);
+    let reports = state.diagnostics.read().workspace_pull_reports(Vec::new());
+    assert_eq!(reports.iter().find(|report| report.uri == main_uri).unwrap().version, None);
+    assert_eq!(reports.iter().find(|report| report.uri == other_uri).unwrap().version, Some(7));
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn workspace_batch_cache_revalidates_config_and_disk_sources() {
+    let project = TestProject::from_fixture(
+        r#"
+        //- /a/Main.sol
+        contract Main {}
+        //- /b/Other.sol
+        contract Other {}
+        "#,
+    );
+    let main = project.path("/a/Main.sol");
+    let other = project.path("/b/Other.sol");
+    let mut state = GlobalState::new(ClientSocket::new_closed());
+    state.config = Arc::new(project.config_with_roots(&["/a", "/b"]));
+    state.recompute_after_opening_source(Vec::new());
+    tokio::time::timeout(ASYNC_TEST_TIMEOUT, state.latest_analysis()).await.unwrap().unwrap();
+    let original = cached_batch_for_path(&state, &other).unwrap();
+
+    state.config = Arc::new((*state.config).clone());
+    state.recompute_after_opening_source(Vec::new());
+    tokio::time::timeout(ASYNC_TEST_TIMEOUT, state.latest_analysis()).await.unwrap().unwrap();
+    let reconfigured = cached_batch_for_path(&state, &other).unwrap();
+    assert!(!Arc::ptr_eq(&original, &reconfigured));
+
+    // A source edit also observes changed disk roots without a watcher notification.
+    project.write_file("/b/Other.sol", "contract Other { uint public diskChanged; }");
+    state.vfs.write().set_file_contents_with_version(
+        VfsPath::from(main.clone()),
+        Some(Rope::from("contract Main { uint public edited; }")),
+        Some(1),
+    );
+    state.recompute_after_opening_source(vec![main.clone()]);
+    tokio::time::timeout(ASYNC_TEST_TIMEOUT, state.latest_analysis()).await.unwrap().unwrap();
+    assert!(!Arc::ptr_eq(&reconfigured, &cached_batch_for_path(&state, &other).unwrap()));
+    assert_eq!(state.symbol_tables.load().workspace_symbols("diskChanged").len(), 1);
+
+    // Reanalysis without a VFS revision must still observe an unnotified disk root change.
+    project.write_file("/b/Other.sol", "contract Other { uint public diskOnly; }");
+    state.recompute_after_opening_source(Vec::new());
+    tokio::time::timeout(ASYNC_TEST_TIMEOUT, state.latest_analysis()).await.unwrap().unwrap();
+    assert_eq!(state.symbol_tables.load().workspace_symbols("diskOnly").len(), 1);
+
+    project.write_file("/b/Other.sol", "contract Other { uint public notified; }");
+    state.recompute_for_file_changes(vec![other], Vec::new(), false);
+    // A new document request may cancel the pending disk worker; invalidation must survive it.
+    state.recompute_after_opening_source(vec![main]);
+    tokio::time::timeout(ASYNC_TEST_TIMEOUT, state.latest_analysis()).await.unwrap().unwrap();
+    assert!(state.symbol_tables.load().workspace_symbols("diskChanged").is_empty());
+    assert_eq!(state.symbol_tables.load().workspace_symbols("notified").len(), 1);
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn workspace_batch_cache_rechecks_untracked_imports_and_resolver_probes() {
+    for initially_missing in [false, true] {
+        let project = TestProject::from_fixture(
+            r#"
+            //- /a/Main.sol
+            contract Main {}
+            //- /b/Other.sol
+            import "./lib/Dep.sol";
+            contract Other is Dep {}
+            //- /b/lib/Dep.sol
+            contract Dep {}
+            "#,
+        );
+        let main = project.path("/a/Main.sol");
+        let other = project.path("/b/Other.sol");
+        if initially_missing {
+            project.remove_file("/b/lib/Dep.sol");
+        }
+        let mut state = GlobalState::new(ClientSocket::new_closed());
+        state.config = Arc::new(project.config_with_roots(&["/a", "/b"]));
+        state.recompute_after_opening_source(Vec::new());
+        tokio::time::timeout(ASYNC_TEST_TIMEOUT, state.latest_analysis()).await.unwrap().unwrap();
+        assert!(cached_batch_for_path(&state, &main).is_some());
+        assert!(cached_batch_for_path(&state, &other).is_some());
+
+        project.write_file("/b/lib/Dep.sol", "contract Dep { uint public dependencyChanged; }");
+        state.vfs.write().set_file_contents_with_version(
+            VfsPath::from(main.clone()),
+            Some(Rope::from("contract Main { uint public edited; }")),
+            Some(1),
+        );
+        state.recompute_after_opening_source(vec![main]);
+        tokio::time::timeout(ASYNC_TEST_TIMEOUT, state.latest_analysis()).await.unwrap().unwrap();
+        assert_eq!(state.symbol_tables.load().workspace_symbols("dependencyChanged").len(), 1);
+        assert!(cached_batch_for_path(&state, &other).is_some());
+    }
+}
+
 #[tokio::test(flavor = "current_thread")]
 async fn identical_inputs_do_not_hide_disk_dependency_changes() {
     let project = TestProject::from_fixture(


### PR DESCRIPTION
Towards OSS-738 ,

## Why this improves benchmark latency

- Before this change, every analysis request created a compiler and reran parsing, AST lowering, semantic analysis, and symbol-table construction for every workspace batch.
- A document edit in one workspace leaves other workspace batches unchanged. The new path skips those complete analyses and only analyzes the changed batch, then combines the reused and fresh outputs.
- Repeated dependency observations are deduplicated, reducing filesystem validation work while retaining conflict detection.
- The optimization is deliberately limited to complete, multi-workspace source snapshots. Disk-triggered analyses and incomplete source discovery retain the existing conservative behavior.

## Benchmark evidence

The paired lifecycle benchmark used the same `solar-head-baseline` and release candidate binaries, with identical fixtures and full diagnostic, symbol, and input semantic checks. The change column is computed from the paired candidate/baseline ratio; lower latency is better.

| Workload | Paired samples | Baseline p50 | Candidate p50 | Paired p50 improvement | Baseline p95 | Candidate p95 | Paired p95 improvement |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| `edit-one-root` control | 50 | 262.32 ms | 262.02 ms | ~0% | 264.13 ms | 264.96 ms | ~0% |
| `edit-two-roots` (10 paired sessions) | 50 | 366.08 ms | 287.98 ms | **20.68%** (ratio 0.7932, 95% CI 0.7821–0.8072) | 384.12 ms | 300.90 ms | **21.58%** (ratio 0.7842, CI 0.7688–0.8021) |
| `edit-two-roots` (deduplicated observations) | 25 | 368.68 ms | 283.87 ms | **21.89%** (ratio 0.7811, 95% CI 0.7688–0.7916) | 383.22 ms | 296.49 ms | **22.99%** (ratio 0.7701, CI 0.7521–0.7856) |
| `edit-two-roots` independent rerun | 25 | 374.13 ms | 300.38 ms | **19.67%** (ratio 0.8033, 95% CI 0.7859–0.8196) | 384.32 ms | 304.65 ms | **20.88%** (ratio 0.7912, CI 0.7812–0.8009) |

The control workload confirms that a single workspace does not pay for an artificial optimization path. The multi-workspace result is workload-specific; the independent rerun shows normal machine variance around the 20% threshold.

Raw evidence is retained in `target/lsp-followup-20260909-cache-final/summary.json` and `target/lsp-followup-20260909-cache-dedupe/summary.json`.
