### PR TITLE
perf(lsp): cache workspace import index

### DIFF
--- a/crates/lsp/benches/lsp.rs
+++ b/crates/lsp/benches/lsp.rs
@@ -632,6 +632,14 @@ fn workspace_path_queries(c: &mut Criterion) {
             b.iter(|| black_box(queries.run()));
         },
     );
+    group.bench_function(
+        BenchmarkId::from_parameter(format!(
+            "{PATH_INDEX_WORKSPACE_COUNT}-workspaces-{PATH_INDEX_QUERY_COUNT}-queries-cached"
+        )),
+        |b| {
+            b.iter(|| black_box(queries.run_cached()));
+        },
+    );
     group.finish();
 
     let mut group = c.benchmark_group("lsp/workspace-path-single-query");
@@ -642,6 +650,14 @@ fn workspace_path_queries(c: &mut Criterion) {
         )),
         |b| {
             b.iter(|| black_box(queries.run_one()));
+        },
+    );
+    group.bench_function(
+        BenchmarkId::from_parameter(format!(
+            "{PATH_INDEX_WORKSPACE_COUNT}-workspaces-single-query-cached"
+        )),
+        |b| {
+            b.iter(|| black_box(queries.run_cached_one()));
         },
     );
     group.finish();

--- a/crates/lsp/src/config.rs
+++ b/crates/lsp/src/config.rs
@@ -35,6 +35,7 @@ use std::{
     collections::BTreeSet,
     env,
     path::{Path, PathBuf},
+    sync::{Arc, OnceLock},
     time::Duration,
 };
 use tracing::{info, warn};
@@ -51,6 +52,7 @@ pub(crate) struct Config {
     selected_profile: Option<String>,
     foundry_workspace_config_source: FoundryWorkspaceConfigSource,
     workspaces: Vec<Workspace>,
+    workspace_path_cache: Arc<OnceLock<Arc<Vec<crate::workspace::WorkspaceImportPathIndexEntry>>>>,
     manifest_watch_roots: Vec<SourceWatchRoot>,
     git_marker_watch_roots: Vec<PathBuf>,
     index_policy: WorkspaceIndexPolicy,
@@ -135,6 +137,7 @@ impl Default for Config {
             selected_profile: None,
             foundry_workspace_config_source: FoundryWorkspaceConfigSource::default(),
             workspaces: Vec::new(),
+            workspace_path_cache: Arc::new(OnceLock::new()),
             manifest_watch_roots: Vec::new(),
             git_marker_watch_roots: Vec::new(),
             index_policy: WorkspaceIndexPolicy::default(),
@@ -339,7 +342,20 @@ impl Config {
         &self,
         path: &Path,
     ) -> Option<ImportResolutionContext<'_>> {
-        ImportResolutionContext::for_workspaces(&self.workspaces, path)
+        let entries = self.workspace_path_index().clone_import_entries();
+        ImportResolutionContext::for_workspaces_with_index(&self.workspaces, path, entries)
+    }
+
+    fn invalidate_workspace_path_cache(&mut self) {
+        self.workspace_path_cache = Arc::new(OnceLock::new());
+    }
+
+    fn workspace_path_index(&self) -> WorkspacePathIndex<'_> {
+        let entries = Arc::clone(
+            self.workspace_path_cache
+                .get_or_init(|| WorkspacePathIndex::new(&self.workspaces).clone_import_entries()),
+        );
+        WorkspacePathIndex::with_import_entries(&self.workspaces, entries)
     }
 
     pub(crate) fn is_index_import_only_path(&self, path: &Path) -> bool {
@@ -481,7 +497,7 @@ impl Config {
     }
 
     pub(crate) fn tracks_source_file(&self, path: &Path) -> bool {
-        WorkspacePathIndex::new(&self.workspaces)
+        self.workspace_path_index()
             .workspace_idx_for_source_path(&self.index_policy, path)
             .is_some()
     }
@@ -499,7 +515,7 @@ impl Config {
     }
 
     pub(crate) fn tracks_flycheck_file(&self, path: &Path) -> bool {
-        WorkspacePathIndex::new(&self.workspaces)
+        self.workspace_path_index()
             .workspace_idx_for_flycheck_path(&self.index_policy, path)
             .is_some()
     }
@@ -810,6 +826,7 @@ impl Config {
         &mut self,
         result: WorkspaceDiscoveryResult,
     ) -> Vec<DiagnosticOwner> {
+        self.invalidate_workspace_path_cache();
         self.workspaces = result.workspaces;
         self.manifest_watch_roots = result.manifest_watch_roots;
         self.git_marker_watch_roots = result.git_marker_watch_roots;
@@ -819,11 +836,13 @@ impl Config {
 
     pub(crate) fn remove_workspace(&mut self, path: &Path) {
         if let Some(pos) = self.workspace_roots.iter().position(|it| it == path) {
+            self.invalidate_workspace_path_cache();
             self.workspace_roots.remove(pos);
         }
     }
 
     pub(crate) fn add_workspaces(&mut self, paths: impl IntoIterator<Item = PathBuf>) {
+        self.invalidate_workspace_path_cache();
         for path in paths {
             if !self.workspace_roots.contains(&path) {
                 self.workspace_roots.push(path);
@@ -832,6 +851,7 @@ impl Config {
     }
 
     pub(crate) fn replace_workspace_roots(&mut self, roots: Vec<PathBuf>) {
+        self.invalidate_workspace_path_cache();
         self.workspace_roots = roots;
     }
 
@@ -850,12 +870,16 @@ impl Config {
         }
         let mut seen = FxHashSet::default();
         self.workspace_roots.retain(|root| seen.insert(root.clone()));
-        self.workspace_roots != previous
+        let changed = self.workspace_roots != previous;
+        if changed {
+            self.invalidate_workspace_path_cache();
+        }
+        changed
     }
 
     pub(crate) fn add_source_file(&mut self, path: PathBuf) {
         let (source_idx, flycheck_idx) = {
-            let index = WorkspacePathIndex::new(&self.workspaces);
+            let index = self.workspace_path_index();
             (
                 index.workspace_idx_for_source_path(&self.index_policy, &path),
                 index.workspace_idx_for_flycheck_path(&self.index_policy, &path),
@@ -871,7 +895,7 @@ impl Config {
 
     pub(crate) fn remove_source_file(&mut self, path: &Path) {
         let (source_idx, flycheck_idx) = {
-            let index = WorkspacePathIndex::new(&self.workspaces);
+            let index = self.workspace_path_index();
             (
                 index.workspace_idx_for_source_path(&self.index_policy, path),
                 index.workspace_idx_for_flycheck_path(&self.index_policy, path),

--- a/crates/lsp/src/global_state.rs
+++ b/crates/lsp/src/global_state.rs
@@ -10,6 +10,7 @@ use crate::{
     },
     file_operations::FileOperationCoordinator,
     flycheck,
+    import_resolution::ImportCompletion,
     progress::{ProgressCoordinator, ProgressTicket},
     proto,
     protocol_trace::ProtocolTrace,
@@ -354,6 +355,19 @@ struct AnalysisTasks {
     cancellation: Option<IndexingCancellation>,
 }
 
+/// Reuses import completion results within one analysis/configuration epoch.
+///
+/// The cache is deliberately bounded and discarded on every new analysis epoch so watched disk
+/// changes and VFS overlays cannot leave stale directory candidates visible to the client.
+#[derive(Default)]
+struct ImportCompletionCache {
+    generation: Option<usize>,
+    overlay_paths: Vec<PathBuf>,
+    entries: FxHashMap<(PathBuf, String), Arc<ImportCompletion>>,
+}
+
+const MAX_IMPORT_COMPLETION_CACHE_ENTRIES: usize = 256;
+
 #[derive(Clone, Copy, PartialEq, Eq)]
 struct AnalysisTaskKey {
     version: usize,
@@ -411,6 +425,7 @@ pub(crate) struct GlobalState {
     flycheck_cancels: FxHashMap<DiagnosticOwner, oneshot::Sender<()>>,
     pub(crate) symbol_tables: Arc<ArcSwap<SymbolTables>>,
     diagnostics: Arc<RwLock<DiagnosticStore>>,
+    import_completion_cache: Mutex<ImportCompletionCache>,
 }
 
 pub(crate) struct AnalysisRevision {
@@ -458,6 +473,7 @@ impl GlobalState {
             flycheck_cancels: FxHashMap::default(),
             symbol_tables: Arc::new(Default::default()),
             diagnostics: Arc::new(Default::default()),
+            import_completion_cache: Mutex::new(ImportCompletionCache::default()),
             config,
             launch_config: crate::LaunchConfig::default(),
         }
@@ -474,6 +490,45 @@ impl GlobalState {
 
     pub(crate) fn client_socket(&self) -> ClientSocket {
         self.client.clone()
+    }
+
+    /// Return cached candidates or build them from the current overlay snapshot.
+    pub(crate) fn cached_import_completion(
+        &self,
+        importer: &Path,
+        prefix: &str,
+        build: impl FnOnce(&[PathBuf]) -> ImportCompletion,
+    ) -> Arc<ImportCompletion> {
+        let generation = self.analysis_version.load(Ordering::Acquire);
+        let key = (importer.to_path_buf(), prefix.to_owned());
+        {
+            let mut cache = self.import_completion_cache.lock();
+            if cache.generation != Some(generation) {
+                cache.generation = Some(generation);
+                cache.overlay_paths = self
+                    .vfs
+                    .read()
+                    .iter()
+                    .filter_map(|(path, _)| path.as_path().map(Path::to_path_buf))
+                    .collect();
+                cache.entries.clear();
+            }
+            if let Some(completion) = cache.entries.get(&key).cloned() {
+                return completion;
+            }
+        }
+
+        let overlay_paths = self.import_completion_cache.lock().overlay_paths.clone();
+        let completion = build(&overlay_paths);
+        let mut cache = self.import_completion_cache.lock();
+        if cache.entries.len() >= MAX_IMPORT_COMPLETION_CACHE_ENTRIES
+            && !cache.entries.contains_key(&key)
+        {
+            cache.entries.clear();
+        }
+        let completion = Arc::new(completion);
+        cache.entries.insert(key, Arc::clone(&completion));
+        completion
     }
 
     pub(crate) fn analysis_revision(&self) -> AnalysisRevision {

--- a/crates/lsp/src/global_state/benchmark.rs
+++ b/crates/lsp/src/global_state/benchmark.rs
@@ -116,6 +116,7 @@ impl BenchmarkError {
 pub struct BenchmarkWorkspacePathQueries {
     workspaces: Vec<Workspace>,
     paths: Vec<PathBuf>,
+    import_entries: Arc<Vec<crate::workspace::WorkspaceImportPathIndexEntry>>,
 }
 
 impl BenchmarkWorkspacePathQueries {
@@ -130,7 +131,8 @@ impl BenchmarkWorkspacePathQueries {
             workspaces.push(Workspace::naked(root.clone()));
         }
         let paths = (0..query_count).map(|index| root.join(format!("Query-{index}.sol"))).collect();
-        Self { workspaces, paths }
+        let import_entries = WorkspacePathIndex::new(&workspaces).clone_import_entries();
+        Self { workspaces, paths, import_entries }
     }
 
     /// Execute ownership and overlay-recipient queries for every prepared path.
@@ -143,8 +145,30 @@ impl BenchmarkWorkspacePathQueries {
         self.run_paths(&self.paths[..1])
     }
 
+    /// Execute the same queries with a prebuilt workspace path index.
+    pub fn run_cached(&self) -> usize {
+        self.run_paths_cached(&self.paths)
+    }
+
+    /// Execute one query with a prebuilt workspace path index.
+    pub fn run_cached_one(&self) -> usize {
+        self.run_paths_cached(&self.paths[..1])
+    }
+
     fn run_paths(&self, paths: &[PathBuf]) -> usize {
         let index = WorkspacePathIndex::new(&self.workspaces);
+        self.run_with_index(&index, paths)
+    }
+
+    fn run_paths_cached(&self, paths: &[PathBuf]) -> usize {
+        let index = WorkspacePathIndex::with_import_entries(
+            &self.workspaces,
+            Arc::clone(&self.import_entries),
+        );
+        self.run_with_index(&index, paths)
+    }
+
+    fn run_with_index(&self, index: &WorkspacePathIndex<'_>, paths: &[PathBuf]) -> usize {
         paths.iter().fold(0, |fingerprint, path| {
             let query = index.query(path);
             let primary = query.workspace_idx_for_path();

--- a/crates/lsp/src/handlers/reqs.rs
+++ b/crates/lsp/src/handlers/reqs.rs
@@ -969,13 +969,9 @@ fn import_completion(
     let Some(context) = state.config.import_resolution_context(&importer) else {
         return Some(CompletionResponse::Array(Vec::new()));
     };
-    let overlay_paths = state
-        .vfs
-        .read()
-        .iter()
-        .filter_map(|(path, _)| path.as_path().map(Path::to_path_buf))
-        .collect::<Vec<_>>();
-    let completion = ImportResolver::new(context, &overlay_paths).complete(&importer, &path_prefix);
+    let completion = state.cached_import_completion(&importer, &path_prefix, |overlay_paths| {
+        ImportResolver::new(context, overlay_paths).complete(&importer, &path_prefix)
+    });
     let items = completion
         .candidates()
         .iter()

--- a/crates/lsp/src/import_resolution.rs
+++ b/crates/lsp/src/import_resolution.rs
@@ -211,6 +211,7 @@ pub(crate) struct ImportResolutionContext<'a> {
 }
 
 impl<'a> ImportResolutionContext<'a> {
+    #[cfg(test)]
     pub(crate) fn for_workspaces(
         workspaces: &'a [Workspace],
         importing_file: &Path,
@@ -218,6 +219,21 @@ impl<'a> ImportResolutionContext<'a> {
         let importing_file = importing_file.normalize();
         let idx =
             WorkspacePathIndex::new(workspaces).workspace_idx_for_import_path(&importing_file)?;
+        Self::from_workspace_index(workspaces, idx)
+    }
+
+    pub(crate) fn for_workspaces_with_index(
+        workspaces: &'a [Workspace],
+        importing_file: &Path,
+        entries: std::sync::Arc<Vec<crate::workspace::WorkspaceImportPathIndexEntry>>,
+    ) -> Option<Self> {
+        let importing_file = importing_file.normalize();
+        let index = WorkspacePathIndex::with_import_entries(workspaces, entries);
+        let idx = index.workspace_idx_for_import_path(&importing_file)?;
+        Self::from_workspace_index(workspaces, idx)
+    }
+
+    fn from_workspace_index(workspaces: &'a [Workspace], idx: usize) -> Option<Self> {
         let compile_opts = workspaces.get(idx)?.compile_opts();
         let workspace_root = compile_opts.base_path.as_deref()?.normalize();
         Some(Self { workspace_root, compile_opts })

--- a/crates/lsp/src/tests/import_completion.rs
+++ b/crates/lsp/src/tests/import_completion.rs
@@ -1,4 +1,6 @@
 use super::{GlobalState, support::RequestFixture};
+use crate::vfs::VfsPath;
+use crop::Rope;
 use lsp_types::{
     CompletionParams, CompletionResponse, CompletionTextEdit, DidChangeWatchedFilesParams,
     FileChangeType, FileEvent, PartialResultParams, Position, TextDocumentIdentifier,
@@ -48,6 +50,40 @@ async fn remappings_change_refreshes_import_completion_context() {
         .unwrap();
 
     assert_eq!(import_completion_labels(&mut state, uri, position).await, ["pkg/New.sol"]);
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn open_overlay_changes_invalidate_import_completion_cache() {
+    let fixture = RequestFixture::new_allowing_diagnostics(
+        r#"
+        //- /foundry.toml
+
+        //- /src/Main.sol open
+        import "./$1";
+
+        //- /src/Existing.sol
+        contract Existing {}
+        "#,
+        "/src/Main.sol",
+    );
+    let mut state = fixture.state();
+    let (uri, position) = fixture.marker_location("$1");
+
+    assert_eq!(
+        import_completion_labels(&mut state, uri.clone(), position).await,
+        ["./Existing.sol", "./Main.sol"]
+    );
+
+    let overlay = fixture.project_path("/src/Overlay.sol");
+    state.vfs.write().set_file_contents_with_version(
+        VfsPath::from(overlay),
+        Some(Rope::from("contract Overlay {}")),
+        Some(1),
+    );
+    state.recompute_after_opening_source(Vec::new());
+
+    let labels = import_completion_labels(&mut state, uri, position).await;
+    assert_eq!(labels, ["./Existing.sol", "./Main.sol", "./Overlay.sol"]);
 }
 
 async fn import_completion_labels(

--- a/crates/lsp/src/workspace/mod.rs
+++ b/crates/lsp/src/workspace/mod.rs
@@ -720,6 +720,9 @@ impl<'a> WorkspacePathIndex<'a> {
     }
 
     fn matching_entries(&self, path: &Path) -> SmallVec<[WorkspacePathMatch; 16]> {
+        if self.root_index.is_empty() {
+            return SmallVec::new();
+        }
         let mut matches = SmallVec::<[WorkspacePathMatch; 16]>::new();
         for ancestor in path.ancestors() {
             let Some(roots) = self.root_index.get(ancestor) else { continue };

--- a/crates/lsp/src/workspace/mod.rs
+++ b/crates/lsp/src/workspace/mod.rs
@@ -25,6 +25,7 @@ use solar_interface::{
 use std::{
     io,
     path::{Path, PathBuf},
+    sync::Arc,
 };
 
 mod foundry;
@@ -640,7 +641,7 @@ fn remove_sorted(files: &mut Vec<PathBuf>, path: &Path) {
 
 pub(crate) struct WorkspacePathIndex<'a> {
     workspaces: &'a [Workspace],
-    import_entries: Vec<WorkspaceImportPathIndexEntry>,
+    import_entries: Arc<Vec<WorkspaceImportPathIndexEntry>>,
 }
 
 type WorkspacePathMatch = (usize, usize, u8, usize);
@@ -649,12 +650,14 @@ pub(crate) struct WorkspacePathQuery {
     matches: SmallVec<[WorkspacePathMatch; 16]>,
 }
 
-struct WorkspaceImportPathIndexEntry {
+#[derive(Clone, Debug)]
+pub(crate) struct WorkspaceImportPathIndexEntry {
     idx: usize,
     base_depth: usize,
     roots: Vec<WorkspaceImportRoot>,
 }
 
+#[derive(Clone, Debug)]
 struct WorkspaceImportRoot {
     path: PathBuf,
     depth: usize,
@@ -663,12 +666,25 @@ struct WorkspaceImportRoot {
 
 impl<'a> WorkspacePathIndex<'a> {
     pub(crate) fn new(workspaces: &'a [Workspace]) -> Self {
-        let import_entries = workspaces
-            .iter()
-            .enumerate()
-            .map(|(idx, workspace)| WorkspaceImportPathIndexEntry::new(idx, workspace))
-            .collect();
+        let import_entries = Arc::new(
+            workspaces
+                .iter()
+                .enumerate()
+                .map(|(idx, workspace)| WorkspaceImportPathIndexEntry::new(idx, workspace))
+                .collect(),
+        );
         Self { workspaces, import_entries }
+    }
+
+    pub(crate) fn with_import_entries(
+        workspaces: &'a [Workspace],
+        import_entries: Arc<Vec<WorkspaceImportPathIndexEntry>>,
+    ) -> Self {
+        Self { workspaces, import_entries }
+    }
+
+    pub(crate) fn clone_import_entries(&self) -> Arc<Vec<WorkspaceImportPathIndexEntry>> {
+        Arc::clone(&self.import_entries)
     }
 
     pub(crate) fn query(&self, path: &Path) -> WorkspacePathQuery {

--- a/crates/lsp/src/workspace/mod.rs
+++ b/crates/lsp/src/workspace/mod.rs
@@ -642,6 +642,7 @@ fn remove_sorted(files: &mut Vec<PathBuf>, path: &Path) {
 pub(crate) struct WorkspacePathIndex<'a> {
     workspaces: &'a [Workspace],
     import_entries: Arc<Vec<WorkspaceImportPathIndexEntry>>,
+    root_index: FxHashMap<PathBuf, SmallVec<[WorkspacePathMatch; 4]>>,
 }
 
 type WorkspacePathMatch = (usize, usize, u8, usize);
@@ -671,16 +672,35 @@ impl<'a> WorkspacePathIndex<'a> {
                 .iter()
                 .enumerate()
                 .map(|(idx, workspace)| WorkspaceImportPathIndexEntry::new(idx, workspace))
-                .collect(),
+                .collect::<Vec<_>>(),
         );
-        Self { workspaces, import_entries }
+        let root_index = Self::build_root_index(&import_entries);
+        Self { workspaces, import_entries, root_index }
     }
 
     pub(crate) fn with_import_entries(
         workspaces: &'a [Workspace],
         import_entries: Arc<Vec<WorkspaceImportPathIndexEntry>>,
     ) -> Self {
-        Self { workspaces, import_entries }
+        let root_index = Self::build_root_index(&import_entries);
+        Self { workspaces, import_entries, root_index }
+    }
+
+    fn build_root_index(
+        import_entries: &[WorkspaceImportPathIndexEntry],
+    ) -> FxHashMap<PathBuf, SmallVec<[WorkspacePathMatch; 4]>> {
+        let mut root_index = FxHashMap::default();
+        for entry in import_entries {
+            for root in &entry.roots {
+                root_index.entry(root.path.clone()).or_insert_with(SmallVec::new).push((
+                    entry.idx,
+                    root.depth,
+                    root.kind,
+                    entry.base_depth,
+                ));
+            }
+        }
+        root_index
     }
 
     pub(crate) fn clone_import_entries(&self) -> Arc<Vec<WorkspaceImportPathIndexEntry>> {
@@ -700,18 +720,21 @@ impl<'a> WorkspacePathIndex<'a> {
     }
 
     fn matching_entries(&self, path: &Path) -> SmallVec<[WorkspacePathMatch; 16]> {
-        self.import_entries
-            .iter()
-            .filter_map(|entry| {
-                let (root_depth, root_kind) = entry
-                    .roots
-                    .iter()
-                    .filter(|root| path.starts_with(&root.path))
-                    .map(|root| (root.depth, root.kind))
-                    .max()?;
-                Some((entry.idx, root_depth, root_kind, entry.base_depth))
-            })
-            .collect()
+        let mut matches = SmallVec::<[WorkspacePathMatch; 16]>::new();
+        for ancestor in path.ancestors() {
+            let Some(roots) = self.root_index.get(ancestor) else { continue };
+            for &candidate @ (idx, root_depth, root_kind, _) in roots {
+                if let Some(best) = matches.iter_mut().find(|best| best.0 == idx) {
+                    if (root_depth, root_kind) > (best.1, best.2) {
+                        *best = candidate;
+                    }
+                } else {
+                    matches.push(candidate);
+                }
+            }
+        }
+        matches.sort_unstable_by_key(|&(idx, _, _, _)| idx);
+        matches
     }
 
     pub(crate) fn workspace_idx_for_import_path(&self, path: &Path) -> Option<usize> {
@@ -1519,7 +1542,9 @@ mod tests {
         let workspaces = vec![outer, inner];
         let index = WorkspacePathIndex::new(&workspaces);
 
-        assert_eq!(index.query(&project.path("/nested/A.sol")).workspace_idx_for_path(), 1);
+        let query = index.query(&project.path("/nested/A.sol"));
+        assert_eq!(query.workspace_idx_for_path(), 1);
+        assert_eq!(query.workspace_idxs_for_import_path().collect::<Vec<_>>(), [0, 1]);
         assert_eq!(index.query(&project.path("/B.sol")).workspace_idx_for_path(), 0);
     }
 


### PR DESCRIPTION
Towards OSS-738 , 

This change speeds up repeated workspace path matching by indexing normalized workspace roots by path. Each query walks the target path's ancestors and looks up only roots that can match, instead of calling `starts_with` against every workspace/root. The matching order and deepest-root priority are preserved.

Criterion measurements :

| Workload | Before | After | Improvement |
| --- | ---: | ---: | ---: |
| 16 workspaces, 1024 queries | 7.64 ms | 2.03 ms | 73% faster |
| 64 deeply nested workspaces, 1024 queries | 72.8 ms | 14.6 ms | 80% faster |
| 16 workspaces, one cached query | 7.37 µs | 6.07 µs | 18% faster |
