### PR TITLE
feat(lint): support actionable help diagnostics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4561,6 +4561,8 @@ name = "solar-lint"
 version = "0.2.0"
 dependencies = [
  "rayon",
+ "serde_json",
+ "snapbox",
  "solar-ast",
  "solar-interface",
  "solar-sema",

--- a/crates/lint/Cargo.toml
+++ b/crates/lint/Cargo.toml
@@ -20,6 +20,11 @@ solar-ast.workspace = true
 solar-interface.workspace = true
 solar-sema.workspace = true
 
+[dev-dependencies]
+serde_json.workspace = true
+snapbox.workspace = true
+solar-interface = { workspace = true, features = ["json"] }
+
 [features]
 nightly = [
     "solar-ast/nightly",

--- a/crates/lint/src/context.rs
+++ b/crates/lint/src/context.rs
@@ -17,6 +17,10 @@ pub trait Lint {
     fn description(&self) -> &'static str;
     /// Help URL associated with the lint.
     fn help(&self) -> &'static str;
+    /// Actionable advice attached to diagnostics, separate from the help URL.
+    fn diagnostic_help(&self) -> Option<&'static str> {
+        None
+    }
 }
 
 /// Toolchain policy applied while emitting lint diagnostics.
@@ -76,12 +80,37 @@ impl<'s, 'p> LintContext<'s, 'p> {
         self.policy.is_lint_enabled(lint.id()) && !self.policy.is_lint_suppressed(lint.id(), span)
     }
 
-    fn add_help<'a>(&self, diag: DiagBuilder<'a, ()>, help: &'static str) -> DiagBuilder<'a, ()> {
-        if self.with_ansi_help { diag.help(hyperlink(help)) } else { diag.help(help) }
+    fn add_help<'a, L: Lint>(
+        &self,
+        mut diag: DiagBuilder<'a, ()>,
+        lint: &'static L,
+        help: Option<DiagMsg>,
+    ) -> DiagBuilder<'a, ()> {
+        if let Some(help) = help.or_else(|| lint.diagnostic_help().map(Into::into)) {
+            diag = diag.help(help);
+        }
+        if self.with_ansi_help { diag.help(hyperlink(lint.help())) } else { diag.help(lint.help()) }
     }
 
     /// Emits a lint's default diagnostic.
     pub fn emit<L: Lint>(&self, lint: &'static L, span: Span) {
+        self.emit_with_optional_help(lint, span, None);
+    }
+
+    /// Emits a lint's default diagnostic with caller-provided advice.
+    ///
+    /// The advice replaces the lint's default advice. Description visibility and deduplication
+    /// are the same as for [`Self::emit`], and the help URL remains attached separately.
+    pub fn emit_with_help<L: Lint>(&self, lint: &'static L, span: Span, help: impl Into<DiagMsg>) {
+        self.emit_with_optional_help(lint, span, Some(help.into()));
+    }
+
+    fn emit_with_optional_help<L: Lint>(
+        &self,
+        lint: &'static L,
+        span: Span,
+        help: Option<DiagMsg>,
+    ) {
         if !self.should_emit(lint, span) || !self.emitted.borrow_mut().insert((lint.id(), span)) {
             return;
         }
@@ -93,11 +122,34 @@ impl<'s, 'p> LintContext<'s, 'p> {
             .diag(lint.level(), message)
             .code(DiagId::new_str(lint.id()))
             .span(MultiSpan::from_span(span));
-        self.add_help(diag, lint.help()).emit();
+        self.add_help(diag, lint, help).emit();
     }
 
     /// Emits a lint diagnostic with a caller-provided message.
     pub fn emit_with_msg<L: Lint>(&self, lint: &'static L, span: Span, msg: impl Into<DiagMsg>) {
+        self.emit_with_msg_and_optional_help(lint, span, msg.into(), None);
+    }
+
+    /// Emits a caller-provided message and advice, replacing the lint's default advice.
+    ///
+    /// The lint's help URL is still attached separately.
+    pub fn emit_with_msg_and_help<L: Lint>(
+        &self,
+        lint: &'static L,
+        span: Span,
+        msg: impl Into<DiagMsg>,
+        help: impl Into<DiagMsg>,
+    ) {
+        self.emit_with_msg_and_optional_help(lint, span, msg.into(), Some(help.into()));
+    }
+
+    fn emit_with_msg_and_optional_help<L: Lint>(
+        &self,
+        lint: &'static L,
+        span: Span,
+        msg: DiagMsg,
+        help: Option<DiagMsg>,
+    ) {
         if !self.should_emit(lint, span) {
             return;
         }
@@ -105,10 +157,10 @@ impl<'s, 'p> LintContext<'s, 'p> {
         let diag = self
             .sess
             .dcx
-            .diag(lint.level(), msg.into())
+            .diag(lint.level(), msg)
             .code(DiagId::new_str(lint.id()))
             .span(MultiSpan::from_span(span));
-        self.add_help(diag, lint.help()).emit();
+        self.add_help(diag, lint, help).emit();
     }
 
     /// Emits a lint diagnostic with a suggestion.
@@ -140,15 +192,15 @@ impl<'s, 'p> LintContext<'s, 'p> {
                     style,
                 ),
             SuggestionKind::Example => {
-                if let Some(note) = suggestion.to_note() {
-                    diag.note(note.iter().map(|line| line.0.as_str()).collect::<String>())
+                if let Some(help) = suggestion.to_help() {
+                    diag.help(help.iter().map(|line| line.0.as_str()).collect::<String>())
                 } else {
                     diag
                 }
             }
         };
 
-        self.add_help(diag, lint.help()).emit();
+        self.add_help(diag, lint, None).emit();
     }
 
     /// Returns the source snippet covered by `span`.
@@ -179,7 +231,7 @@ impl<'s, 'p> LintContext<'s, 'p> {
 /// The presentation form of a lint suggestion.
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub enum SuggestionKind {
-    /// A standalone example emitted as a note.
+    /// A standalone example emitted as help.
     Example,
     /// A source replacement.
     Fix {
@@ -241,7 +293,7 @@ impl Suggestion {
         self
     }
 
-    fn to_note(&self) -> Option<Vec<(DiagMsg, Style)>> {
+    fn to_help(&self) -> Option<Vec<(DiagMsg, Style)>> {
         if matches!(self.kind, SuggestionKind::Fix { .. }) {
             return None;
         }
@@ -269,8 +321,523 @@ fn hyperlink(url: &'static str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use solar_interface::{BytePos, ColorChoice};
-    use std::path::PathBuf;
+    use snapbox::{IntoData as _, assert_data_eq, str};
+    use solar_interface::{
+        BytePos, ColorChoice,
+        diagnostics::{DiagCtxt, InMemoryEmitter, JsonEmitter},
+        source_map::SourceMap,
+    };
+    use std::{io, path::PathBuf, sync::Mutex};
+
+    struct TestLint;
+
+    impl Lint for TestLint {
+        fn id(&self) -> &'static str {
+            "test-lint"
+        }
+
+        fn level(&self) -> Level {
+            Level::Warning
+        }
+
+        fn description(&self) -> &'static str {
+            "test lint message"
+        }
+
+        fn help(&self) -> &'static str {
+            "https://example.com/lint"
+        }
+    }
+
+    struct HelpLint;
+
+    impl Lint for HelpLint {
+        fn id(&self) -> &'static str {
+            TestLint.id()
+        }
+
+        fn level(&self) -> Level {
+            TestLint.level()
+        }
+
+        fn description(&self) -> &'static str {
+            TestLint.description()
+        }
+
+        fn help(&self) -> &'static str {
+            TestLint.help()
+        }
+
+        fn diagnostic_help(&self) -> Option<&'static str> {
+            Some("use a supported value")
+        }
+    }
+
+    fn emit_help_diagnostics(session: &Session, policy: &dyn LintPolicy, with_description: bool) {
+        session.dcx.set_flags(|flags| flags.track_diagnostics = false);
+        let file =
+            session.source_map().new_source_file(PathBuf::from("test.sol"), "value\n").unwrap();
+        let span = Span::new(file.start_pos, file.start_pos + BytePos(5));
+        let ctx = LintContext::new(session, policy, with_description, false, Some(file));
+        ctx.emit(&HelpLint, span);
+        ctx.emit(&HelpLint, span);
+        ctx.emit_with_msg(&HelpLint, span, "custom lint message");
+        ctx.emit_with_msg_and_help(
+            &HelpLint,
+            span,
+            "conditional lint message",
+            "use another value",
+        );
+        ctx.emit_with_suggestion(
+            &HelpLint,
+            span,
+            Suggestion::fix("replacement".into(), Applicability::MaybeIncorrect)
+                .with_desc("replace this value"),
+        );
+        ctx.emit_with_suggestion(
+            &HelpLint,
+            span,
+            Suggestion::example("replacement".into()).with_desc("consider this example"),
+        );
+    }
+
+    #[test]
+    fn diagnostic_help_text() {
+        let session = Session::builder().with_buffer_emitter(ColorChoice::Never).build();
+        emit_help_diagnostics(&session, &TestPolicy, true);
+        assert_data_eq!(
+            trim_line_ends(&session.dcx.emitted_diagnostics().unwrap().to_string()),
+            str![[r#"
+warning[test-lint]: test lint message
+  ╭▸ test.sol:1:1
+  │
+1 │ value
+  │ ━━━━━
+  │
+  ├ help: use a supported value
+  ╰ help: https://example.com/lint
+
+warning[test-lint]: custom lint message
+  ╭▸ test.sol:1:1
+  │
+1 │ value
+  │ ━━━━━
+  │
+  ├ help: use a supported value
+  ╰ help: https://example.com/lint
+
+warning[test-lint]: conditional lint message
+  ╭▸ test.sol:1:1
+  │
+1 │ value
+  │ ━━━━━
+  │
+  ├ help: use another value
+  ╰ help: https://example.com/lint
+
+warning[test-lint]: test lint message
+  ╭▸ test.sol:1:1
+  │
+1 │ value
+  │ ━━━━━ help: replace this value: `replacement`
+  │
+  ├ help: use a supported value
+  ╰ help: https://example.com/lint
+
+warning[test-lint]: test lint message
+  ╭▸ test.sol:1:1
+  │
+1 │ value
+  │ ━━━━━
+  │
+  ├ help: consider this example
+  │
+  │       replacement
+  │
+  │
+  ├ help: use a supported value
+  ╰ help: https://example.com/lint
+
+"#]]
+        );
+    }
+
+    #[test]
+    fn diagnostic_help_without_description() {
+        let session = Session::builder().with_buffer_emitter(ColorChoice::Never).build();
+        emit_help_diagnostics(&session, &TestPolicy, false);
+        assert_data_eq!(
+            trim_line_ends(&session.dcx.emitted_diagnostics().unwrap().to_string()),
+            str![[r#"
+warning[test-lint]:
+  ╭▸ test.sol:1:1
+  │
+1 │ value
+  │ ━━━━━
+  │
+  ├ help: use a supported value
+  ╰ help: https://example.com/lint
+
+warning[test-lint]: custom lint message
+  ╭▸ test.sol:1:1
+  │
+1 │ value
+  │ ━━━━━
+  │
+  ├ help: use a supported value
+  ╰ help: https://example.com/lint
+
+warning[test-lint]: conditional lint message
+  ╭▸ test.sol:1:1
+  │
+1 │ value
+  │ ━━━━━
+  │
+  ├ help: use another value
+  ╰ help: https://example.com/lint
+
+warning[test-lint]:
+  ╭▸ test.sol:1:1
+  │
+1 │ value
+  │ ━━━━━ help: replace this value: `replacement`
+  │
+  ├ help: use a supported value
+  ╰ help: https://example.com/lint
+
+warning[test-lint]:
+  ╭▸ test.sol:1:1
+  │
+1 │ value
+  │ ━━━━━
+  │
+  ├ help: consider this example
+  │
+  │       replacement
+  │
+  │
+  ├ help: use a supported value
+  ╰ help: https://example.com/lint
+
+"#]]
+        );
+    }
+
+    struct SharedWriter(Arc<Mutex<Vec<u8>>>);
+
+    fn trim_line_ends(text: &str) -> String {
+        text.lines().map(str::trim_end).collect::<Vec<_>>().join("\n")
+    }
+
+    impl io::Write for SharedWriter {
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            self.0.lock().unwrap().write(buf)
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            self.0.lock().unwrap().flush()
+        }
+    }
+
+    #[test]
+    fn diagnostic_help_json() {
+        let source_map = Arc::new(SourceMap::empty());
+        let writer = Arc::new(Mutex::new(Vec::new()));
+        let emitter = JsonEmitter::new(
+            Box::new(SharedWriter(writer.clone())),
+            source_map.clone(),
+            ColorChoice::Never,
+        )
+        .rustc_like(true);
+        let session =
+            Session::builder().source_map(source_map).dcx(DiagCtxt::new(Box::new(emitter))).build();
+        emit_help_diagnostics(&session, &TestPolicy, true);
+        let output = String::from_utf8(writer.lock().unwrap().clone()).unwrap();
+        let diagnostics = output
+            .lines()
+            .map(|line| {
+                let diagnostic = serde_json::from_str::<serde_json::Value>(line).unwrap();
+                serde_json::json!({
+                    "message": diagnostic["message"],
+                    "code": diagnostic["code"],
+                    "children": diagnostic["children"],
+                })
+            })
+            .collect::<Vec<_>>();
+        assert_data_eq!(
+            serde_json::to_string_pretty(&diagnostics).unwrap(),
+            str![[r#"
+[
+  {
+    "children": [
+      {
+        "children": [],
+        "code": null,
+        "level": "help",
+        "message": "use a supported value",
+        "rendered": null,
+        "spans": []
+      },
+      {
+        "children": [],
+        "code": null,
+        "level": "help",
+        "message": "https://example.com/lint",
+        "rendered": null,
+        "spans": []
+      }
+    ],
+    "code": {
+      "code": "test-lint",
+      "explanation": null
+    },
+    "message": "test lint message"
+  },
+  {
+    "children": [
+      {
+        "children": [],
+        "code": null,
+        "level": "help",
+        "message": "use a supported value",
+        "rendered": null,
+        "spans": []
+      },
+      {
+        "children": [],
+        "code": null,
+        "level": "help",
+        "message": "https://example.com/lint",
+        "rendered": null,
+        "spans": []
+      }
+    ],
+    "code": {
+      "code": "test-lint",
+      "explanation": null
+    },
+    "message": "custom lint message"
+  },
+  {
+    "children": [
+      {
+        "children": [],
+        "code": null,
+        "level": "help",
+        "message": "use another value",
+        "rendered": null,
+        "spans": []
+      },
+      {
+        "children": [],
+        "code": null,
+        "level": "help",
+        "message": "https://example.com/lint",
+        "rendered": null,
+        "spans": []
+      }
+    ],
+    "code": {
+      "code": "test-lint",
+      "explanation": null
+    },
+    "message": "conditional lint message"
+  },
+  {
+    "children": [
+      {
+        "children": [],
+        "code": null,
+        "level": "help",
+        "message": "use a supported value",
+        "rendered": null,
+        "spans": []
+      },
+      {
+        "children": [],
+        "code": null,
+        "level": "help",
+        "message": "https://example.com/lint",
+        "rendered": null,
+        "spans": []
+      },
+      {
+        "children": [],
+        "code": null,
+        "level": "help",
+        "message": "replace this value",
+        "rendered": null,
+        "spans": [
+          {
+            "byte_end": 5,
+            "byte_start": 0,
+            "column_end": 6,
+            "column_start": 1,
+            "expansion": null,
+            "file_name": "test.sol",
+            "is_primary": true,
+            "label": null,
+            "line_end": 1,
+            "line_start": 1,
+            "suggested_replacement": "replacement",
+            "suggestion_applicability": "MaybeIncorrect",
+            "text": [
+              {
+                "highlight_end": 6,
+                "highlight_start": 1,
+                "text": "value"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "code": {
+      "code": "test-lint",
+      "explanation": null
+    },
+    "message": "test lint message"
+  },
+  {
+    "children": [
+      {
+        "children": [],
+        "code": null,
+        "level": "help",
+        "message": "consider this example\n\nreplacement\n\n",
+        "rendered": null,
+        "spans": []
+      },
+      {
+        "children": [],
+        "code": null,
+        "level": "help",
+        "message": "use a supported value",
+        "rendered": null,
+        "spans": []
+      },
+      {
+        "children": [],
+        "code": null,
+        "level": "help",
+        "message": "https://example.com/lint",
+        "rendered": null,
+        "spans": []
+      }
+    ],
+    "code": {
+      "code": "test-lint",
+      "explanation": null
+    },
+    "message": "test lint message"
+  }
+]
+"#]]
+            .is_json()
+        );
+    }
+
+    struct FilteringPolicy {
+        enabled: bool,
+        suppressed: bool,
+    }
+
+    impl LintPolicy for FilteringPolicy {
+        fn is_lint_enabled(&self, _id: &str) -> bool {
+            self.enabled
+        }
+
+        fn is_lint_suppressed(&self, _id: &str, _span: Span) -> bool {
+            self.suppressed
+        }
+    }
+
+    #[test]
+    fn diagnostic_help_respects_policy() {
+        for policy in [
+            FilteringPolicy { enabled: false, suppressed: false },
+            FilteringPolicy { enabled: true, suppressed: true },
+        ] {
+            let session = Session::builder().with_buffer_emitter(ColorChoice::Never).build();
+            emit_help_diagnostics(&session, &policy, true);
+            assert_data_eq!(session.dcx.emitted_diagnostics().unwrap().to_string(), str![""]);
+            assert_eq!(session.dcx.warn_count(), 0);
+        }
+    }
+
+    #[test]
+    fn diagnostic_help_defaults_to_none() {
+        assert_eq!(TestLint.diagnostic_help(), None);
+        let session = Session::builder().with_buffer_emitter(ColorChoice::Never).build();
+        session.dcx.set_flags(|flags| flags.track_diagnostics = false);
+        let file =
+            session.source_map().new_source_file(PathBuf::from("test.sol"), "value").unwrap();
+        let span = Span::new(file.start_pos, file.start_pos + BytePos(5));
+        let ctx = LintContext::new(&session, &TestPolicy, true, false, Some(file));
+        ctx.emit(&TestLint, span);
+        assert_data_eq!(
+            session.dcx.emitted_diagnostics().unwrap().to_string(),
+            str![[r#"
+warning[test-lint]: test lint message
+  ╭▸ test.sol:1:1
+  │
+1 │ value
+  │ ━━━━━
+  │
+  ╰ help: https://example.com/lint
+
+
+"#]]
+        );
+    }
+
+    #[test]
+    fn diagnostic_help_keeps_ansi_links_separate() {
+        let (emitter, diagnostics) = InMemoryEmitter::new();
+        let session = Session::builder()
+            .dcx(
+                DiagCtxt::new(Box::new(emitter))
+                    .with_flags(|flags| flags.track_diagnostics = false),
+            )
+            .build();
+        let ctx = LintContext::new(&session, &TestPolicy, true, true, None);
+        ctx.emit(&HelpLint, Span::DUMMY);
+        let diagnostics = diagnostics.read();
+        assert_eq!(diagnostics.len(), 1);
+        let children = &diagnostics[0].children;
+        assert_eq!(children.len(), 2);
+        assert_eq!(children[0].level, Level::Help);
+        assert_eq!(children[0].label(), "use a supported value");
+        assert_eq!(children[1].level, Level::Help);
+        assert_eq!(children[1].label(), hyperlink(TestLint.help()));
+    }
+
+    #[test]
+    fn diagnostic_help_preserves_default_deduplication() {
+        let (emitter, diagnostics) = InMemoryEmitter::new();
+        let session = Session::builder()
+            .dcx(
+                DiagCtxt::new(Box::new(emitter))
+                    .with_flags(|flags| flags.track_diagnostics = false),
+            )
+            .build();
+        let ctx = LintContext::new(&session, &TestPolicy, false, false, None);
+        ctx.emit_with_help(&HelpLint, Span::DUMMY, "first advice");
+        ctx.emit_with_help(&HelpLint, Span::DUMMY, "duplicate advice");
+        ctx.emit(&HelpLint, Span::DUMMY);
+        let second_span = Span::new(BytePos(1), BytePos(2));
+        ctx.emit(&HelpLint, second_span);
+        ctx.emit_with_help(&HelpLint, second_span, "duplicate advice");
+        let diagnostics = diagnostics.read();
+        assert_eq!(diagnostics.len(), 2);
+        for diagnostic in diagnostics.iter() {
+            assert_eq!(diagnostic.label(), "");
+            assert_eq!(diagnostic.children.len(), 2);
+            assert_eq!(diagnostic.children[1].label(), TestLint.help());
+        }
+        assert_eq!(diagnostics[0].children[0].label(), "first advice");
+        assert_eq!(diagnostics[1].children[0].label(), "use a supported value");
+    }
 
     struct TestPolicy;
 

--- a/crates/lint/src/project.rs
+++ b/crates/lint/src/project.rs
@@ -57,6 +57,17 @@ impl<'s, 'gcx> ProjectLintContext<'s, 'gcx> {
         self.source_context(source).emit(lint, span);
     }
 
+    /// Emits a lint's default diagnostic with caller-provided advice using the source's policy.
+    pub fn emit_with_help<L: Lint>(
+        &self,
+        source: &ProjectSource<'_>,
+        lint: &'static L,
+        span: Span,
+        help: impl Into<DiagMsg>,
+    ) {
+        self.source_context(source).emit_with_help(lint, span, help);
+    }
+
     /// Emits a lint diagnostic with a caller-provided message.
     pub fn emit_with_msg<L: Lint>(
         &self,
@@ -66,6 +77,20 @@ impl<'s, 'gcx> ProjectLintContext<'s, 'gcx> {
         msg: impl Into<DiagMsg>,
     ) {
         self.source_context(source).emit_with_msg(lint, span, msg);
+    }
+
+    /// Emits a caller-provided message and advice using the source's suppression policy.
+    ///
+    /// The advice replaces the lint's default advice; its help URL remains attached separately.
+    pub fn emit_with_msg_and_help<L: Lint>(
+        &self,
+        source: &ProjectSource<'_>,
+        lint: &'static L,
+        span: Span,
+        msg: impl Into<DiagMsg>,
+        help: impl Into<DiagMsg>,
+    ) {
+        self.source_context(source).emit_with_msg_and_help(lint, span, msg, help);
     }
 
     fn source_context<'a>(&self, source: &'a ProjectSource<'_>) -> LintContext<'s, 'a>
@@ -79,5 +104,157 @@ impl<'s, 'gcx> ProjectLintContext<'s, 'gcx> {
             self.with_ansi_help,
             Some(source.file.clone()),
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use snapbox::{assert_data_eq, str};
+    use solar_interface::{ColorChoice, diagnostics::Level};
+    use solar_sema::Compiler;
+    use std::ops::ControlFlow;
+
+    struct HelpLint;
+
+    impl Lint for HelpLint {
+        fn id(&self) -> &'static str {
+            "project-help"
+        }
+
+        fn level(&self) -> Level {
+            Level::Warning
+        }
+
+        fn description(&self) -> &'static str {
+            "project lint message"
+        }
+
+        fn help(&self) -> &'static str {
+            "https://example.com/project-lint"
+        }
+
+        fn diagnostic_help(&self) -> Option<&'static str> {
+            Some("review the project declaration")
+        }
+    }
+
+    struct Policy {
+        enabled: bool,
+        suppressed: bool,
+    }
+
+    impl LintPolicy for Policy {
+        fn is_lint_enabled(&self, _id: &str) -> bool {
+            self.enabled
+        }
+
+        fn is_lint_suppressed(&self, _id: &str, _span: Span) -> bool {
+            self.suppressed
+        }
+    }
+
+    fn emit_project_help(policy: Policy) -> String {
+        let session = Session::builder().with_buffer_emitter(ColorChoice::Never).build();
+        session.dcx.set_flags(|flags| flags.track_diagnostics = false);
+        let mut compiler = Compiler::new(session);
+        let path = PathBuf::from("test.sol");
+        compiler.enter_mut(|compiler| {
+            let mut parser = compiler.parse();
+            let file = compiler
+                .sess()
+                .source_map()
+                .new_source_file(path.clone(), "contract Test {}")
+                .unwrap();
+            parser.add_file(file);
+            parser.parse();
+            assert_eq!(compiler.lower_asts(), Ok(ControlFlow::Continue(())));
+            assert_eq!(compiler.analysis(), Ok(ControlFlow::Continue(())));
+        });
+        compiler.enter(|compiler| {
+            let gcx = compiler.gcx();
+            let (_, ast_source) = gcx.get_ast_source(&path).unwrap();
+            let source = ProjectSource {
+                path: path.clone(),
+                file: ast_source.file.clone(),
+                ast: ast_source.ast.as_ref().unwrap(),
+                policy: Arc::new(policy),
+            };
+            let ctx = ProjectLintContext::new(
+                gcx.sess,
+                gcx,
+                Arc::new(Policy { enabled: true, suppressed: false }),
+                true,
+                false,
+            );
+            let span = source.ast.items.first().unwrap().span;
+            ctx.emit(&source, &HelpLint, span);
+            ctx.emit_with_help(&source, &HelpLint, span, "custom project advice");
+            ctx.emit_with_msg(&source, &HelpLint, span, "custom project message");
+            ctx.emit_with_msg_and_help(
+                &source,
+                &HelpLint,
+                span,
+                "conditional project message",
+                "review this declaration instead",
+            );
+        });
+        compiler.dcx().emitted_diagnostics().unwrap().to_string()
+    }
+
+    #[test]
+    fn project_diagnostic_help() {
+        assert_data_eq!(
+            emit_project_help(Policy { enabled: true, suppressed: false }),
+            str![[r#"
+warning[project-help]: project lint message
+  ╭▸ test.sol:1:1
+  │
+1 │ contract Test {}
+  │ ━━━━━━━━━━━━━━━━
+  │
+  ├ help: review the project declaration
+  ╰ help: https://example.com/project-lint
+
+warning[project-help]: project lint message
+  ╭▸ test.sol:1:1
+  │
+1 │ contract Test {}
+  │ ━━━━━━━━━━━━━━━━
+  │
+  ├ help: custom project advice
+  ╰ help: https://example.com/project-lint
+
+warning[project-help]: custom project message
+  ╭▸ test.sol:1:1
+  │
+1 │ contract Test {}
+  │ ━━━━━━━━━━━━━━━━
+  │
+  ├ help: review the project declaration
+  ╰ help: https://example.com/project-lint
+
+warning[project-help]: conditional project message
+  ╭▸ test.sol:1:1
+  │
+1 │ contract Test {}
+  │ ━━━━━━━━━━━━━━━━
+  │
+  ├ help: review this declaration instead
+  ╰ help: https://example.com/project-lint
+
+
+"#]]
+        );
+    }
+
+    #[test]
+    fn project_diagnostic_help_uses_source_policy() {
+        for policy in [
+            Policy { enabled: false, suppressed: false },
+            Policy { enabled: true, suppressed: true },
+        ] {
+            assert_data_eq!(emit_project_help(policy), str![""]);
+        }
     }
 }


### PR DESCRIPTION
Add optional static lint advice and per-diagnostic help overrides so corrective instructions can be emitted separately from the primary message. Preserve source policy, default-message deduplication, documentation links, and existing implementations of the lint trait. Corrective examples now render as help diagnostics.

This supplies the shared API used by the Foundry lint cleanup in https://github.com/foundry-rs/foundry/pull/16754.

Authored and reviewed with Centaur/Codex AI assistance.

Prompted by: @DaniPopes
