### PR TITLE
perf(lsp): defer import path parsing

### DIFF
--- a/crates/lsp/src/handlers/reqs.rs
+++ b/crates/lsp/src/handlers/reqs.rs
@@ -561,37 +561,85 @@ pub(crate) fn goto_definition(
         &analysis_revision,
     );
     let config = state.config.clone();
+    let vfs = state.vfs.clone();
     async move {
         let Some(latest_analysis) = latest_analysis else { return Ok(None) };
         let symbol_tables = latest_analysis.await?;
-        if let Some(import_request) = import_request {
-            if !analysis_revision.is_current(import_request.vfs_content_revision) {
+        let symbol_tables = symbol_tables.load();
+        let response = match import_request {
+            None => symbol_tables.goto_definition(&params.text_document.uri, params.position),
+            Some(ImportDefinitionRequest::Current { importer, contents, vfs_content_revision }) => {
+                if !analysis_revision.is_current(vfs_content_revision) {
+                    return Ok(None);
+                }
+                let Some(context) = config.import_resolution_context(&importer) else {
+                    return Ok(
+                        symbol_tables.goto_definition(&params.text_document.uri, params.position)
+                    );
+                };
+                if let Some(response) =
+                    symbol_tables.import_definition(&params.text_document.uri, params.position)
+                {
+                    return Ok(Some(response));
+                }
+                let overlay_paths = vfs
+                    .read()
+                    .iter()
+                    .filter_map(|(path, _)| path.as_path().map(Path::to_path_buf))
+                    .collect();
+                let Some(import_request) = parse_import_definition_request(
+                    importer,
+                    contents,
+                    params.position,
+                    overlay_paths,
+                    vfs_content_revision,
+                ) else {
+                    return Ok(
+                        symbol_tables.goto_definition(&params.text_document.uri, params.position)
+                    );
+                };
+                if let Some(target) = ImportResolver::new(context, &import_request.overlay_paths)
+                    .resolve(&import_request.importer, &import_request.raw_path)
+                    && let Ok(uri) = Url::from_file_path(target)
+                {
+                    let location = lsp_types::Location::new(uri, lsp_types::Range::default());
+                    return Ok(Some(GotoDefinitionResponse::Array(vec![location])));
+                }
+                None
+            }
+            Some(ImportDefinitionRequest::Parsed(import_request)) => {
+                if !analysis_revision.is_current(import_request.vfs_content_revision) {
+                    return Ok(None);
+                }
+                let Some(context) = config.import_resolution_context(&import_request.importer)
+                else {
+                    return Ok(None);
+                };
+                if let Some(response) =
+                    symbol_tables.import_definition(&params.text_document.uri, params.position)
+                {
+                    return Ok(Some(response));
+                }
+                if let Some(target) = ImportResolver::new(context, &import_request.overlay_paths)
+                    .resolve(&import_request.importer, &import_request.raw_path)
+                    && let Ok(uri) = Url::from_file_path(target)
+                {
+                    let location = lsp_types::Location::new(uri, lsp_types::Range::default());
+                    return Ok(Some(GotoDefinitionResponse::Array(vec![location])));
+                }
                 return Ok(None);
             }
-            let Some(context) = config.import_resolution_context(&import_request.importer) else {
-                return Ok(None);
-            };
-            if let Some(response) =
-                symbol_tables.load().import_definition(&params.text_document.uri, params.position)
-            {
-                return Ok(Some(response));
-            }
-            if let Some(target) = ImportResolver::new(context, &import_request.overlay_paths)
-                .resolve(&import_request.importer, &import_request.raw_path)
-                && let Ok(uri) = Url::from_file_path(target)
-            {
-                let location = lsp_types::Location::new(uri, lsp_types::Range::default());
-                return Ok(Some(GotoDefinitionResponse::Array(vec![location])));
-            }
-            return Ok(None);
-        }
-        let response =
-            symbol_tables.load().goto_definition(&params.text_document.uri, params.position);
+        };
         Ok(response)
     }
 }
 
-struct ImportDefinitionRequest {
+enum ImportDefinitionRequest {
+    Current { importer: PathBuf, contents: Rope, vfs_content_revision: u64 },
+    Parsed(ParsedImportDefinitionRequest),
+}
+
+struct ParsedImportDefinitionRequest {
     importer: PathBuf,
     raw_path: String,
     overlay_paths: Vec<PathBuf>,
@@ -619,6 +667,15 @@ fn import_definition_request(
     {
         return None;
     }
+    if let Some(contents) = open_contents.as_ref()
+        && analysis_revision.is_current(vfs_content_revision)
+    {
+        return Some(ImportDefinitionRequest::Current {
+            importer,
+            contents: contents.clone(),
+            vfs_content_revision,
+        });
+    }
     let contents = open_contents.or_else(|| {
         state
             .sess
@@ -628,19 +685,39 @@ fn import_definition_request(
             .ok()
             .map(|contents| Rope::from(contents.as_str()))
     })?;
-    let cursor_offset =
-        crate::proto::checked_text_range(&contents, lsp_types::Range::new(position, position))?
-            .start;
-    let source = contents.to_string();
-    let import = import_path_at(&source, cursor_offset)?;
-    let raw_path = import.raw_path;
     let overlay_paths = state
         .vfs
         .read()
         .iter()
         .filter_map(|(path, _)| path.as_path().map(Path::to_path_buf))
         .collect();
-    Some(ImportDefinitionRequest { importer, raw_path, overlay_paths, vfs_content_revision })
+    Some(ImportDefinitionRequest::Parsed(parse_import_definition_request(
+        importer,
+        contents,
+        position,
+        overlay_paths,
+        vfs_content_revision,
+    )?))
+}
+
+fn parse_import_definition_request(
+    importer: PathBuf,
+    contents: Rope,
+    position: Position,
+    overlay_paths: Vec<PathBuf>,
+    vfs_content_revision: u64,
+) -> Option<ParsedImportDefinitionRequest> {
+    let cursor_offset =
+        crate::proto::checked_text_range(&contents, lsp_types::Range::new(position, position))?
+            .start;
+    let source = contents.to_string();
+    let import = import_path_at(&source, cursor_offset)?;
+    Some(ParsedImportDefinitionRequest {
+        importer,
+        raw_path: import.raw_path,
+        overlay_paths,
+        vfs_content_revision,
+    })
 }
 
 pub(crate) fn goto_type_definition(

--- a/crates/lsp/src/tests/import_definition.rs
+++ b/crates/lsp/src/tests/import_definition.rs
@@ -599,3 +599,37 @@ fn unowned_import_definitions_do_not_use_the_first_workspace_context() {
 
     fixture.check_goto_definition("$1", "<none>\n");
 }
+
+#[tokio::test(flavor = "current_thread")]
+async fn unowned_indexed_import_definitions_do_not_bypass_context() {
+    let fixture = RequestFixture::new_in_batches(
+        r#"
+        //- /owned/foundry.toml
+        [profile.default]
+        auto_detect_remappings = false
+        remappings = ["pkg/=lib/"]
+
+        //- /owned/lib/Target.sol
+        contract Target {}
+
+        //- /unowned/Main.sol open
+        import "../owned/lib/$1Target.sol";
+        "#,
+        &["/unowned/Main.sol", "/owned/lib/Target.sol"],
+    );
+
+    let mut state = fixture.state();
+    let importer = fixture.project_path("/unowned/Main.sol");
+    state.vfs.write().set_file_contents(
+        VfsPath::from(importer.clone()),
+        Some(Rope::from(fixture.project_contents("/unowned/Main.sol"))),
+    );
+    {
+        let mut commit = state.analysis_commit.lock();
+        commit.vfs_content_revision = state.vfs.read().content_revision();
+        commit.symbol_tables_version = state.analysis_version.load(Ordering::Acquire);
+    }
+    let (uri, position) = fixture.marker_location("$1");
+    let response = crate::handlers::goto_definition(&mut state, goto_params(uri, position)).await;
+    assert_eq!(response.unwrap(), None);
+}


### PR DESCRIPTION
Towards OSS-738 , 

Import-literal go-to-definition currently parses the full source buffer before checking the analysis index. For clean open documents, the analyzed `DocumentLinkIndex` already contains the import range and resolved target, so that parsing work is unnecessary.

- Classify clean, fully analyzed open documents separately and query the existing import index first.
- Defer source scanning, `Rope` to `String` conversion, VFS overlay collection, and import resolution to the fallback path.
- Keep dirty buffers, closed files, stale analysis, malformed literals, and unowned workspace requests on their existing behavior.
- Preserve ordinary code-symbol go-to-definition and require an import resolution context before using an indexed import target.

Measured with the production stdio probe on a 5.38 MB source file:

| Case | Baseline p50 | Candidate p50 | Change |
| --- | ---: | ---: | ---: |
| Import-literal go-to-definition | 0.139 ms | 0.038 ms | 72.5% lower |

The response locations matched in both runs. The focused and full `solar-lsp` test suites pass.
