### PR TITLE
perf(lsp): skip import scans for code completion

### DIFF
--- a/crates/lsp/src/import_resolution.rs
+++ b/crates/lsp/src/import_resolution.rs
@@ -49,6 +49,9 @@ pub(crate) fn import_path_at_for_completion(source: &str, cursor: usize) -> Opti
     if cursor > source.len() || !source.is_char_boundary(cursor) {
         return None;
     }
+    if !may_complete_string(source, cursor) {
+        return None;
+    }
 
     // Import paths are plain string tokens. Avoid parsing the whole file for code completions.
     let string = plain_string_at(source, cursor)?;
@@ -62,6 +65,25 @@ pub(crate) fn import_path_at_for_completion(source: &str, cursor: usize) -> Opti
         return None;
     }
     recover_unterminated_import_path(source, cursor, string)
+}
+
+/// Rejects code lines that cannot contain a completable import string.
+fn may_complete_string(source: &str, cursor: usize) -> bool {
+    let prefix = &source.as_bytes()[..cursor];
+    let line_break = memchr::memrchr2(b'\r', b'\n', prefix);
+    let line_start = line_break.map_or(0, |offset| offset + 1);
+    if matches!(source.as_bytes().get(cursor), Some(b'\'' | b'"'))
+        || memchr::memchr2(b'\'', b'"', &prefix[line_start..]).is_some()
+    {
+        return true;
+    }
+    let Some(mut line_break) = line_break else { return false };
+    if prefix[line_break] == b'\n' && line_break > 0 && prefix[line_break - 1] == b'\r' {
+        line_break -= 1;
+    }
+    // A string from an earlier line must cross this line break. Completion already rejects
+    // unescaped line breaks; possible continuations still use the full lexer and parser.
+    line_break > 0 && prefix[line_break - 1] == b'\\'
 }
 
 fn parse_import_path(source: &str, cursor: usize) -> Option<ImportPathAt> {


### PR DESCRIPTION
Towards OSS-738 ,

- Ordinary completion currently walks tokens from the beginning of the source to determine whether the cursor is inside an import string. At the end of a large file, that scan runs on every request even when the cursor is completing a code identifier.
- Add a conservative check around the current line: if there is no quote up to or at the cursor and the preceding line break cannot be an escaped continuation, return before `plain_string_at`. This removes the repeated scan from normal code completion without adding a cache.
- Keep the existing lexer/parser fallback for quotes and possible escaped line continuations, including CRLF. For example, completing `FullMath.mu` near the end of a file skips the unrelated import-context scan, while completing a quoted import still takes the existing path.

Local `solar-lsp-bench` comparison against `716e9cbcd`, using matching release builds on macOS arm64: 20 fresh paired processes per workload, alternating execution order, 10 warmups and 50 timed stdio JSON-RPC requests per process. Values are the mean of each process's p50/p95; negative changes mean lower latency.

| Workload | Baseline p50 (ms) | PR p50 (ms) | Change | Baseline p95 (ms) | PR p95 (ms) | Change |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| UniswapV3, member completion near EOF | 0.2460 | 0.1273 | -48.25% | 0.3690 | 0.2470 | -33.07% |
| Solady LibClone, ordinary completion near EOF | 0.2134 | 0.1267 | -40.64% | 0.3459 | 0.2524 | -27.03% |
| OpenZeppelin ERC20, ordinary completion near EOF | 0.0632 | 0.0562 | -11.04% | 0.1257 | 0.1046 | -16.75% |
| Synthetic, ordinary completion | 0.0632 | 0.0598 | -5.29% | 0.1348 | 0.1169 | -13.25% |
| UniswapV3, hover | 0.0621 | 0.0589 | -5.20% | 0.1660 | 0.1415 | -14.76% |
| UniswapV3, definition | 0.0752 | 0.0747 | -0.63% | 0.1741 | 0.1647 | -5.38% |


