### PR TITLE
fix: normalize Windows CLI usage in UI tests

### DIFF
--- a/tests/ui/standard-json/debug/cli-emit-conflict.jsonc
+++ b/tests/ui/standard-json/debug/cli-emit-conflict.jsonc
@@ -4,6 +4,6 @@
 //@[resources] compile-flags: --emit=ethdebug-resources
 //@[srcmap] compile-flags: --emit=srcmap
 //@ failure-status: 2
-//@ normalize-stderr-test: "solar\\.exe" -> "solar"
+//@ normalize-stderr-test: "solar\.exe" -> "solar"
 // Clap rejects conflicting modes before compiler diagnostics are initialized.
 {}


### PR DESCRIPTION
The four `cli-emit-conflict` revisions fail on Windows because the stderr normalization regex is double-escaped and does not match `solar.exe`. Remove the extra backslash so the Windows usage line matches the existing snapshots.

Fixes the [Windows CI failure](https://github.com/paradigmxyz/solar/actions/runs/34382289532/job/102569842863).

Prompted by: @DaniPopes
