### PR TITLE
perf(lsp): cache completion positions

### DIFF
--- a/crates/lsp/src/handlers/reqs.rs
+++ b/crates/lsp/src/handlers/reqs.rs
@@ -895,10 +895,15 @@ pub(crate) fn completion(
     let trigger_character =
         params.context.as_ref().and_then(|context| context.trigger_character.as_deref());
     let params = params.text_document_position;
-    let contents = crate::proto::vfs_path(&params.text_document.uri)
-        .and_then(|path| state.vfs.read().get_file_contents(&path).cloned());
-    if let Some(contents) = contents {
-        match natspec_completion::target(&contents, params.position) {
+    let source = crate::proto::vfs_path(&params.text_document.uri)
+        .and_then(|path| state.vfs.read().get_file_completion_source(&path));
+    if let Some(source) = source {
+        let contents = source.contents();
+        let cursor = source
+            .positions()
+            .checked_text_range(lsp_types::Range::new(params.position, params.position))
+            .map(|range| range.start);
+        match natspec_completion::target(contents, cursor) {
             NatSpecCompletionResult::Claimed(target) => {
                 let items = target.map_or_else(Vec::new, |target| {
                     let semantics = state
@@ -921,8 +926,14 @@ pub(crate) fn completion(
             }
             NatSpecCompletionResult::NotApplicable => {}
         }
-        if let Some(response) =
-            import_completion(state, &params.text_document.uri, params.position, &contents)
+        if let Some(cursor) = cursor
+            && let Some(response) = import_completion(
+                state,
+                &params.text_document.uri,
+                cursor,
+                contents,
+                &source.source(),
+            )
         {
             return ready(Ok(Some(response)));
         }
@@ -945,15 +956,12 @@ pub(crate) fn completion(
 fn import_completion(
     state: &GlobalState,
     uri: &Url,
-    position: Position,
+    cursor_offset: usize,
     contents: &Rope,
+    source: &str,
 ) -> Option<CompletionResponse> {
     let importer = uri.to_file_path().ok()?;
-    let cursor_offset =
-        crate::proto::checked_text_range(contents, lsp_types::Range::new(position, position))?
-            .start;
-    let source = contents.to_string();
-    let import = import_path_at_for_completion(&source, cursor_offset)?;
+    let import = import_path_at_for_completion(source, cursor_offset)?;
     let prefix_end = cursor_offset.max(import.content_range.start);
     let raw_path_prefix = source.get(import.content_range.start..prefix_end).map(str::to_owned)?;
     let replacement = import.content_range;

--- a/crates/lsp/src/natspec_completion.rs
+++ b/crates/lsp/src/natspec_completion.rs
@@ -1,8 +1,7 @@
 use crate::{config::CompletionClientOptions, proto};
 use crop::Rope;
 use lsp_types::{
-    CompletionItem, CompletionItemKind, CompletionTextEdit, InsertTextFormat, Position, Range,
-    TextEdit,
+    CompletionItem, CompletionItemKind, CompletionTextEdit, InsertTextFormat, Range, TextEdit,
 };
 use solar_config::CompileOpts;
 use solar_interface::{Session, source_map::FileName};
@@ -309,10 +308,8 @@ enum CandidateResult {
     Candidate(CommentCandidate),
 }
 
-pub(crate) fn target(contents: &Rope, position: Position) -> NatSpecCompletionResult {
-    let Some(cursor) = proto::checked_text_range(contents, Range::new(position, position))
-        .map(|range| range.start)
-    else {
+pub(crate) fn target(contents: &Rope, cursor: Option<usize>) -> NatSpecCompletionResult {
+    let Some(cursor) = cursor else {
         return NatSpecCompletionResult::Claimed(None);
     };
     if !has_natspec_prefix(contents, cursor) {
@@ -661,6 +658,13 @@ fn is_adjacent_doc_comment(gap: &str, style: CommentStyle) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use lsp_types::Position;
+
+    fn target(contents: &Rope, position: Position) -> NatSpecCompletionResult {
+        let cursor = proto::checked_text_range(contents, Range::new(position, position))
+            .map(|range| range.start);
+        super::target(contents, cursor)
+    }
 
     #[test]
     fn rejects_a_line_doc_comment_separated_by_a_blank_line() {

--- a/crates/lsp/src/vfs/fs.rs
+++ b/crates/lsp/src/vfs/fs.rs
@@ -26,6 +26,7 @@ use super::VfsPath;
 use crate::{
     file_operations::{FileMoveBatch, FileMoveError},
     folding_range,
+    proto::LspPositionIndex,
     selection_range::SelectionRangeIndex,
 };
 use crop::Rope;
@@ -41,6 +42,7 @@ use std::{
 struct VfsFile {
     contents: Rope,
     analysis_source: OnceLock<Arc<String>>,
+    positions: OnceLock<LspPositionIndex<Rope>>,
     selection_range_index: OnceLock<SelectionRangeIndex>,
     folding_ranges: OnceLock<Vec<lsp_types::FoldingRange>>,
 }
@@ -50,6 +52,7 @@ impl VfsFile {
         Self {
             contents,
             analysis_source: OnceLock::new(),
+            positions: OnceLock::new(),
             selection_range_index: OnceLock::new(),
             folding_ranges: OnceLock::new(),
         }
@@ -59,6 +62,24 @@ impl VfsFile {
         self.analysis_source
             .get_or_init(|| Arc::new(crate::utils::rope_to_string(&self.contents)))
             .clone()
+    }
+}
+
+/// An exact-content handle for sharing completion's source text and position index.
+#[derive(Clone)]
+pub(crate) struct CompletionSource(Arc<VfsFile>);
+
+impl CompletionSource {
+    pub(crate) fn contents(&self) -> &Rope {
+        &self.0.contents
+    }
+
+    pub(crate) fn positions(&self) -> &LspPositionIndex<Rope> {
+        self.0.positions.get_or_init(|| LspPositionIndex::from_rope(self.0.contents.clone()))
+    }
+
+    pub(crate) fn source(&self) -> Arc<String> {
+        self.0.analysis_source()
     }
 }
 
@@ -154,6 +175,10 @@ impl Vfs {
     /// Returns a shared contiguous source for compiler analysis.
     pub(crate) fn get_file_analysis_source(&self, path: &VfsPath) -> Option<Arc<String>> {
         self.data.get(path).map(|file| file.analysis_source())
+    }
+
+    pub(crate) fn get_file_completion_source(&self, path: &VfsPath) -> Option<CompletionSource> {
+        self.data.get(path).cloned().map(CompletionSource)
     }
 
     /// Returns an exact-content handle whose derived index can initialize outside the VFS lock.
@@ -372,6 +397,54 @@ mod tests {
         let changed = vfs.get_file_analysis_source(&file).unwrap();
         assert!(!Arc::ptr_eq(&first, &changed));
         assert_eq!(changed.as_str(), "contract Changed {}");
+    }
+
+    #[test]
+    fn completion_sources_keep_text_and_positions_from_the_same_contents() {
+        let mut vfs = Vfs::default();
+        let file = path("/workspace/Test.sol");
+        insert(&mut vfs, "/workspace/Test.sol", "α😀\r\nnext\rtail\n", 1);
+        let original = vfs.get_file_completion_source(&file).unwrap();
+        let at = |source: &CompletionSource, line, character| {
+            let position = Position::new(line, character);
+            source.positions().checked_text_range(lsp_types::Range::new(position, position))
+        };
+        assert_eq!(at(&original, 0, 2), None);
+        assert_eq!(at(&original, 0, 99), Some(6..6));
+        assert_eq!(at(&original, 1, 2), Some(10..10));
+        assert_eq!(at(&original, 2, 4), Some(17..17));
+        assert_eq!(at(&original, 3, 0), Some(18..18));
+        assert_eq!(at(&original, 4, 0), None);
+
+        assert!(!vfs.set_file_contents_with_version(
+            file.clone(),
+            Some(original.contents().clone()),
+            Some(2),
+        ));
+        let unchanged = vfs.get_file_completion_source(&file).unwrap();
+        assert!(std::ptr::eq(original.positions(), unchanged.positions()));
+        assert!(Arc::ptr_eq(&original.source(), &unchanged.source()));
+
+        insert(&mut vfs, "/workspace/Test.sol", "x\n😀z\n", 3);
+        let changed = vfs.get_file_completion_source(&file).unwrap();
+        assert_eq!(at(&changed, 1, 2), Some(6..6));
+        assert_eq!(at(&changed, 2, 0), Some(8..8));
+        assert_eq!(changed.source().as_str(), "x\n😀z\n");
+        assert_eq!(at(&original, 1, 2), Some(10..10));
+        assert_eq!(original.source().as_str(), "α😀\r\nnext\rtail\n");
+
+        let moved = path("/workspace/Moved.sol");
+        vfs.rename_file_prefixes(&moves([(
+            PathBuf::from("/workspace/Test.sol"),
+            PathBuf::from("/workspace/Moved.sol"),
+        )]))
+        .unwrap();
+        assert!(vfs.get_file_completion_source(&file).is_none());
+        let renamed = vfs.get_file_completion_source(&moved).unwrap();
+        assert!(std::ptr::eq(changed.positions(), renamed.positions()));
+        assert_eq!(at(&renamed, 1, 2), Some(6..6));
+        vfs.set_file_contents(moved, None);
+        assert_eq!(renamed.source().as_str(), "x\n😀z\n");
     }
 
     #[test]


### PR DESCRIPTION
Towards OSS-738 , 

Large Solidity files currently pay the full document-position and source-materialization cost on every completion request, even when the open document has not changed. This adds repeated line-index scans and Rope-to-String copies to the warm completion path.

- Add an exact-content `CompletionSource` backed by the existing immutable `Arc<VfsFile>`.
- Lazily cache one `LspPositionIndex<Rope>` per VFS file content and reuse the existing contiguous analysis source.
- Compute the checked cursor offset once per completion request and share it between NatSpec and import completion.
- Preserve cache safety through the existing VFS lifecycle: content edits replace the file object; unchanged version updates and renames retain it.
- Add regression coverage for UTF-16 boundaries, CR/LF/CRLF, trailing lines, content replacement, version-only updates, rename, and removal.


| Workload | p50 baseline → candidate (ms) | p50 change (95% CI) | p95 baseline → candidate (ms) | p95 change (95% CI) |
| --- | ---: | ---: | ---: | ---: |
| Uniswap member completion | 0.098958 → 0.048129 | −51.36% [−51.74%, −50.99%] | 0.129650 → 0.059806 | −53.87% [−55.99%, −51.43%] |
| Solady ordinary completion | 0.096827 → 0.050719 | −47.62% [−48.24%, −47.02%] | 0.127067 → 0.064388 | −49.33% [−52.71%, −45.42%] |

