### PR TITLE
perf(lsp): speed up signature help

### DIFF
--- a/crates/lsp/benches/lsp.rs
+++ b/crates/lsp/benches/lsp.rs
@@ -9,9 +9,10 @@ use solar_config::CompileOpts;
 use solar_lsp::{
     BenchmarkAnalysis, BenchmarkDocumentUpdate, BenchmarkFoldingRangeRequests,
     BenchmarkOpenDocuments, BenchmarkProject, BenchmarkRepeatedAnalysis, BenchmarkRequest,
-    BenchmarkResponse, BenchmarkSelectionRangeRequests, BenchmarkWorkspaceDiscovery,
-    BenchmarkWorkspacePathQueries, BenchmarkWorkspaceReports, benchmark_folding_ranges,
-    benchmark_folding_ranges_from_rope, benchmark_import_path_at, benchmark_selection_ranges,
+    BenchmarkResponse, BenchmarkSelectionRangeRequests, BenchmarkSignatureHelpRequests,
+    BenchmarkWorkspaceDiscovery, BenchmarkWorkspacePathQueries, BenchmarkWorkspaceReports,
+    benchmark_folding_ranges, benchmark_folding_ranges_from_rope, benchmark_import_path_at,
+    benchmark_selection_ranges,
 };
 use std::{fmt::Write as _, fs, hint::black_box, path::PathBuf};
 
@@ -210,6 +211,49 @@ fn completion_queries(c: &mut Criterion) {
             });
         });
     }
+    group.finish();
+}
+
+fn signature_help_requests(c: &mut Criterion) {
+    let mut group = c.benchmark_group("lsp/signature-help");
+    for function_count in [64, 256, 1024] {
+        let fixture = benchmark_source(function_count);
+        let anchor = format!("function_{:04}(1, ", function_count - 1);
+        let (uri, mut position) = fixture.project.unique_anchor("benchmark.sol", &anchor).unwrap();
+        position.character += anchor.len() as u32;
+        let mut requests = BenchmarkSignatureHelpRequests::new(fixture.project, uri, position);
+        let response = requests.run().expect("benchmark call should have signature help");
+        assert_eq!(response.active_parameter, Some(1));
+        assert_eq!(response.signatures.len(), 1);
+        assert!(
+            response.signatures[0].label.contains(&format!("function_{:04}", function_count - 1))
+        );
+        group.bench_function(BenchmarkId::from_parameter(function_count), |b| {
+            b.iter(|| black_box(requests.run()));
+        });
+    }
+
+    let project = unifap_project();
+    let (uri, mut position) = project
+        .unique_anchor(UNIFAP_ROUTER, "_safeTransferFrom(tokenB, msg.sender, pair, amountB)")
+        .unwrap();
+    position.character += "_safeTransferFrom(tokenB, ".len() as u32;
+    let mut requests = BenchmarkSignatureHelpRequests::new(project, uri, position);
+    let response = requests.run().expect("router call should have signature help");
+    assert_eq!(response.active_parameter, Some(1));
+    assert_eq!(response.signatures.len(), 1);
+    assert!(response.signatures[0].label.starts_with("function _safeTransferFrom("));
+    group.bench_function(BenchmarkId::from_parameter("unifap-v2-router"), |b| {
+        b.iter(|| black_box(requests.run()));
+    });
+    assert_eq!(requests.after_edit().run(), Some(response));
+    group.bench_function(BenchmarkId::from_parameter("unifap-v2-router-after-edit"), |b| {
+        b.iter_batched_ref(
+            || requests.after_edit(),
+            |requests| black_box(requests.run()),
+            BatchSize::PerIteration,
+        );
+    });
     group.finish();
 }
 
@@ -834,6 +878,7 @@ criterion_group!(
     benches,
     analysis_build,
     completion_queries,
+    signature_help_requests,
     code_lens_queries,
     type_hierarchy_queries,
     call_hierarchy_queries,

--- a/crates/lsp/src/global_state/benchmark.rs
+++ b/crates/lsp/src/global_state/benchmark.rs
@@ -23,7 +23,8 @@ use crop::Rope;
 use lsp_types::{
     CallHierarchyIncomingCall, CodeLens, CompletionItem, Diagnostic, DidChangeTextDocumentParams,
     GotoDefinitionResponse, Hover, HoverContents, Location, Position, PreviousResultId, Range,
-    TextDocumentContentChangeEvent, TypeHierarchyItem, Url, VersionedTextDocumentIdentifier,
+    SignatureHelp, SignatureHelpParams, TextDocumentContentChangeEvent, TextDocumentIdentifier,
+    TextDocumentPositionParams, TypeHierarchyItem, Url, VersionedTextDocumentIdentifier,
     WorkspaceFolder, WorkspaceSymbol,
 };
 use normalize_path::NormalizePath;
@@ -36,6 +37,7 @@ use std::{
     io,
     path::{Component, Path, PathBuf},
     sync::Arc,
+    task::{Context, Poll, Waker},
 };
 
 /// An opaque error returned while preparing an LSP benchmark project.
@@ -609,6 +611,66 @@ pub struct BenchmarkSelectionRangeRequests {
 pub struct BenchmarkFoldingRangeRequests {
     state: super::GlobalState,
     path: VfsPath,
+}
+
+/// A prepared open-document signature-help request using production analysis and its handler.
+#[doc(hidden)]
+pub struct BenchmarkSignatureHelpRequests {
+    state: super::GlobalState,
+    params: SignatureHelpParams,
+}
+
+impl BenchmarkSignatureHelpRequests {
+    /// Analyze a project and open the document containing the requested call argument.
+    pub fn new(project: BenchmarkProject, uri: Url, position: Position) -> Self {
+        let path = uri.to_file_path().expect("signature-help benchmark URI should be a file");
+        let (_, contents) = project
+            .files
+            .iter()
+            .find(|(source_path, _)| *source_path == path)
+            .expect("signature-help benchmark document should belong to the project");
+        let state = super::GlobalState::new(ClientSocket::new_closed());
+        state.vfs.write().set_file_contents_with_version(
+            VfsPath::from(path),
+            Some(Rope::from(contents.as_str())),
+            Some(1),
+        );
+        state.symbol_tables.store(Arc::new(project.analyze().symbol_tables));
+        let params = SignatureHelpParams {
+            text_document_position_params: TextDocumentPositionParams {
+                text_document: TextDocumentIdentifier { uri },
+                position,
+            },
+            work_done_progress_params: Default::default(),
+            context: None,
+        };
+        Self { state, params }
+    }
+
+    /// Prepare an edited document with unchanged analysis, outside the request timing.
+    pub fn after_edit(&self) -> Self {
+        let path =
+            crate::proto::vfs_path(&self.params.text_document_position_params.text_document.uri)
+                .expect("signature-help benchmark URI should be a file");
+        let mut contents = self.state.vfs.read().get_file_contents(&path).unwrap().clone();
+        contents.insert(contents.byte_len(), " ");
+        let state = super::GlobalState::new(ClientSocket::new_closed());
+        state.vfs.write().set_file_contents_with_version(path, Some(contents), Some(2));
+        state.symbol_tables.store(self.state.symbol_tables.load_full());
+        Self { state, params: self.params.clone() }
+    }
+
+    /// Execute one synchronous signature-help request through the production handler.
+    #[inline(never)]
+    pub fn run(&mut self) -> Option<SignatureHelp> {
+        let request = handlers::signature_help(&mut self.state, self.params.clone());
+        let mut request = std::pin::pin!(request);
+        let mut context = Context::from_waker(Waker::noop());
+        let Poll::Ready(response) = request.as_mut().poll(&mut context) else {
+            panic!("signature-help benchmark request should complete immediately");
+        };
+        response.expect("signature-help benchmark request should succeed")
+    }
 }
 
 fn open_benchmark_document(

--- a/crates/lsp/src/handlers/reqs.rs
+++ b/crates/lsp/src/handlers/reqs.rs
@@ -954,11 +954,12 @@ pub(crate) fn signature_help(
 ) -> impl Future<Output = Result<Option<SignatureHelp>, ResponseError>> + use<> {
     let params = params.text_document_position_params;
     let response = crate::proto::vfs_path(&params.text_document.uri).and_then(|path| {
-        let contents = state.vfs.read().get_file_contents(&path)?.clone();
+        let source = state.vfs.read().get_file_source(&path)?;
         state.symbol_tables.load().signature_help(
             &params.text_document.uri,
             params.position,
-            &contents,
+            source.positions(),
+            &source.source(),
             state.config.signature_help_options(),
         )
     });
@@ -973,7 +974,7 @@ pub(crate) fn completion(
         params.context.as_ref().and_then(|context| context.trigger_character.as_deref());
     let params = params.text_document_position;
     let source = crate::proto::vfs_path(&params.text_document.uri)
-        .and_then(|path| state.vfs.read().get_file_completion_source(&path));
+        .and_then(|path| state.vfs.read().get_file_source(&path));
     if let Some(source) = source {
         let contents = source.contents();
         let cursor = source

--- a/crates/lsp/src/handlers/reqs.rs
+++ b/crates/lsp/src/handlers/reqs.rs
@@ -895,10 +895,15 @@ pub(crate) fn completion(
     let trigger_character =
         params.context.as_ref().and_then(|context| context.trigger_character.as_deref());
     let params = params.text_document_position;
-    let contents = crate::proto::vfs_path(&params.text_document.uri)
-        .and_then(|path| state.vfs.read().get_file_contents(&path).cloned());
-    if let Some(contents) = contents {
-        match natspec_completion::target(&contents, params.position) {
+    let source = crate::proto::vfs_path(&params.text_document.uri)
+        .and_then(|path| state.vfs.read().get_file_completion_source(&path));
+    if let Some(source) = source {
+        let contents = source.contents();
+        let cursor = source
+            .positions()
+            .checked_text_range(lsp_types::Range::new(params.position, params.position))
+            .map(|range| range.start);
+        match natspec_completion::target(contents, cursor) {
             NatSpecCompletionResult::Claimed(target) => {
                 let items = target.map_or_else(Vec::new, |target| {
                     let semantics = state
@@ -921,8 +926,14 @@ pub(crate) fn completion(
             }
             NatSpecCompletionResult::NotApplicable => {}
         }
-        if let Some(response) =
-            import_completion(state, &params.text_document.uri, params.position, &contents)
+        if let Some(cursor) = cursor
+            && let Some(response) = import_completion(
+                state,
+                &params.text_document.uri,
+                cursor,
+                contents,
+                &source.source(),
+            )
         {
             return ready(Ok(Some(response)));
         }
@@ -945,15 +956,12 @@ pub(crate) fn completion(
 fn import_completion(
     state: &GlobalState,
     uri: &Url,
-    position: Position,
+    cursor_offset: usize,
     contents: &Rope,
+    source: &str,
 ) -> Option<CompletionResponse> {
     let importer = uri.to_file_path().ok()?;
-    let cursor_offset =
-        crate::proto::checked_text_range(contents, lsp_types::Range::new(position, position))?
-            .start;
-    let source = contents.to_string();
-    let import = import_path_at_for_completion(&source, cursor_offset)?;
+    let import = import_path_at_for_completion(source, cursor_offset)?;
     let prefix_end = cursor_offset.max(import.content_range.start);
     let raw_path_prefix = source.get(import.content_range.start..prefix_end).map(str::to_owned)?;
     let replacement = import.content_range;

--- a/crates/lsp/src/lib.rs
+++ b/crates/lsp/src/lib.rs
@@ -356,8 +356,8 @@ pub use global_state::benchmark::{
     BenchmarkAnalysis, BenchmarkDocumentChange, BenchmarkDocumentUpdate, BenchmarkEdit,
     BenchmarkError, BenchmarkFoldingRangeRequests, BenchmarkOpenDocuments, BenchmarkProject,
     BenchmarkRepeatedAnalysis, BenchmarkRequest, BenchmarkResponse,
-    BenchmarkSelectionRangeRequests, BenchmarkWorkspaceDiscovery, BenchmarkWorkspacePathQueries,
-    BenchmarkWorkspaceReports,
+    BenchmarkSelectionRangeRequests, BenchmarkSignatureHelpRequests, BenchmarkWorkspaceDiscovery,
+    BenchmarkWorkspacePathQueries, BenchmarkWorkspaceReports,
 };
 
 /// Checks whether a source position belongs to a parsed import path.

--- a/crates/lsp/src/natspec_completion.rs
+++ b/crates/lsp/src/natspec_completion.rs
@@ -1,8 +1,7 @@
 use crate::{config::CompletionClientOptions, proto};
 use crop::Rope;
 use lsp_types::{
-    CompletionItem, CompletionItemKind, CompletionTextEdit, InsertTextFormat, Position, Range,
-    TextEdit,
+    CompletionItem, CompletionItemKind, CompletionTextEdit, InsertTextFormat, Range, TextEdit,
 };
 use solar_config::CompileOpts;
 use solar_interface::{Session, source_map::FileName};
@@ -309,10 +308,8 @@ enum CandidateResult {
     Candidate(CommentCandidate),
 }
 
-pub(crate) fn target(contents: &Rope, position: Position) -> NatSpecCompletionResult {
-    let Some(cursor) = proto::checked_text_range(contents, Range::new(position, position))
-        .map(|range| range.start)
-    else {
+pub(crate) fn target(contents: &Rope, cursor: Option<usize>) -> NatSpecCompletionResult {
+    let Some(cursor) = cursor else {
         return NatSpecCompletionResult::Claimed(None);
     };
     if !has_natspec_prefix(contents, cursor) {
@@ -661,6 +658,13 @@ fn is_adjacent_doc_comment(gap: &str, style: CommentStyle) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use lsp_types::Position;
+
+    fn target(contents: &Rope, position: Position) -> NatSpecCompletionResult {
+        let cursor = proto::checked_text_range(contents, Range::new(position, position))
+            .map(|range| range.start);
+        super::target(contents, cursor)
+    }
 
     #[test]
     fn rejects_a_line_doc_comment_separated_by_a_blank_line() {

--- a/crates/lsp/src/signature_help.rs
+++ b/crates/lsp/src/signature_help.rs
@@ -109,27 +109,28 @@ impl SignatureHelpIndex {
         &self,
         uri: &Url,
         position: Position,
-        contents: &Rope,
+        positions: &proto::LspPositionIndex<Rope>,
+        source: &str,
         visible_declarations: impl FnOnce(&str) -> Vec<&'a Location>,
         options: SignatureHelpClientOptions,
     ) -> Option<SignatureHelp> {
-        let positions = proto::LspPositionIndex::new(contents);
+        let contents = positions.rope();
         let cursor = positions.text_range(Range::new(position, position)).start;
-        let text = contents.byte_slice(..cursor).to_string();
-        let context = call_context(&text)?;
+        let context = call_context(&source[..cursor])?;
         let call = self.calls.get(uri).and_then(|calls| {
             calls.iter().find(|call| {
-                valid_text_position(contents, call.range.start)
-                    && positions.text_range(Range::new(call.range.start, call.range.start)).start
-                        == context.open
+                // Reject unrelated callables before converting their source positions.
+                call.form == context.form
                     && call
                         .callee_tokens
                         .last()
                         .map(String::as_str)
                         .filter(|token| is_identifier(token))
                         == context.callee_name
-                    && call.form == context.form
-                    && call.matches_current_callee(&positions)
+                    && valid_text_position(contents, call.range.start)
+                    && positions.text_range(Range::new(call.range.start, call.range.start)).start
+                        == context.open
+                    && call.matches_current_callee(positions)
             })
         });
         let (mut signatures, fallback): (Vec<&CallSignature>, _) = if let Some(call) = call {
@@ -278,7 +279,7 @@ impl SignatureHelpIndex {
 }
 
 impl CallSite {
-    fn matches_current_callee(&self, positions: &proto::LspPositionIndex<&Rope>) -> bool {
+    fn matches_current_callee(&self, positions: &proto::LspPositionIndex<Rope>) -> bool {
         let contents = positions.rope();
         if !valid_text_position(contents, self.callee_range.start)
             || !valid_text_position(contents, self.callee_range.end)
@@ -1132,7 +1133,9 @@ mod tests {
             signatures: Vec::new(),
         };
 
-        assert!(!call.matches_current_callee(&proto::LspPositionIndex::new(&Rope::from("😀f"))));
+        assert!(
+            !call.matches_current_callee(&proto::LspPositionIndex::from_rope(Rope::from("😀f")))
+        );
     }
 
     #[test]
@@ -1145,6 +1148,6 @@ mod tests {
             signatures: Vec::new(),
         };
 
-        assert!(!call.matches_current_callee(&proto::LspPositionIndex::new(&Rope::from("f"))));
+        assert!(!call.matches_current_callee(&proto::LspPositionIndex::from_rope(Rope::from("f"))));
     }
 }

--- a/crates/lsp/src/symbols.rs
+++ b/crates/lsp/src/symbols.rs
@@ -633,13 +633,15 @@ impl SymbolTables {
         &self,
         uri: &Url,
         position: Position,
-        contents: &crop::Rope,
+        positions: &proto::LspPositionIndex<crop::Rope>,
+        source: &str,
         options: crate::config::SignatureHelpClientOptions,
     ) -> Option<lsp_types::SignatureHelp> {
         self.signature_help.signature_help(
             uri,
             position,
-            contents,
+            positions,
+            source,
             |name| self.visible_declaration_locations(uri, position, name),
             options,
         )

--- a/crates/lsp/src/tests/signature_help.rs
+++ b/crates/lsp/src/tests/signature_help.rs
@@ -1,6 +1,30 @@
-use super::support::RequestFixture;
-use lsp_types::Documentation;
+use super::{GlobalState, expect_ready, support::RequestFixture};
+use crate::{handlers, vfs::VfsPath};
+use crop::Rope;
+use lsp_types::{
+    Documentation, Position, SignatureHelp, SignatureHelpParams, TextDocumentIdentifier,
+    TextDocumentPositionParams, Url,
+};
 use snapbox::str;
+
+fn request_signature_help(
+    state: &mut GlobalState,
+    uri: Url,
+    position: Position,
+) -> Option<SignatureHelp> {
+    expect_ready(handlers::signature_help(
+        state,
+        SignatureHelpParams {
+            text_document_position_params: TextDocumentPositionParams {
+                text_document: TextDocumentIdentifier { uri },
+                position,
+            },
+            work_done_progress_params: Default::default(),
+            context: None,
+        },
+    ))
+    .unwrap()
+}
 
 #[test]
 fn shows_function_signature_and_active_parameter() {
@@ -358,6 +382,86 @@ fn does_not_reuse_a_stale_member_call_after_the_receiver_changes() {
     let changed = fixture.project_contents("/Signature.sol").replace("a.f( 1);", "b.f( 1;");
 
     fixture.check_signature_help_after_change("$1", "/Signature.sol", &changed, "<none>\n");
+}
+
+#[test]
+fn warmed_requests_reject_a_changed_receiver_before_reanalysis() {
+    let fixture = RequestFixture::new(
+        r#"
+        //- /Signature.sol open
+        contract A {
+            function f(uint256 value) external pure {}
+        }
+
+        contract B {
+            function f(address value) external pure {}
+        }
+
+        contract C {
+            function use(A a, B b) public pure {
+                a.f($1 1);
+            }
+        }
+        "#,
+        "/Signature.sol",
+    );
+    let mut state = fixture.state();
+    let (uri, position) = fixture.marker_location("$1");
+    let original = request_signature_help(&mut state, uri.clone(), position).unwrap();
+    assert_eq!(request_signature_help(&mut state, uri.clone(), position), Some(original.clone()));
+
+    // Keep the original analysis while an edit changes only the receiver, leaving the terminal
+    // name and opening-parenthesis position unchanged.
+    let contents = fixture.project_contents("/Signature.sol");
+    let changed = contents.replace("a.f(", "b.f(");
+    let path = VfsPath::from(fixture.project_path("/Signature.sol"));
+    state.vfs.write().set_file_contents(path.clone(), Some(Rope::from(changed)));
+    assert_eq!(request_signature_help(&mut state, uri.clone(), position), None);
+
+    state.vfs.write().set_file_contents(path, Some(Rope::from(contents)));
+    assert_eq!(request_signature_help(&mut state, uri, position), Some(original));
+}
+
+#[test]
+fn warmed_requests_use_changed_lines_and_utf16_columns_before_reanalysis() {
+    let fixture = RequestFixture::new(
+        r#"
+        //- /Signature.sol open
+        contract C {
+            function set(string memory text, uint256 value) public pure {}
+
+            function use() public pure {
+                set(unicode"😀", $1 2);
+
+            }
+        }
+        "#,
+        "/Signature.sol",
+    );
+    let mut state = fixture.state();
+    let (uri, position) = fixture.marker_location("$1");
+    let original = request_signature_help(&mut state, uri.clone(), position).unwrap();
+    assert_eq!(original.active_parameter, Some(1));
+    assert_eq!(request_signature_help(&mut state, uri.clone(), position), Some(original.clone()));
+
+    // Move the call onto a new line with changed UTF-16 columns and CRLF endings while keeping
+    // the previous analysis. The lexical fallback must use the current document.
+    let changed = fixture
+        .project_contents("/Signature.sol")
+        .replace("set(unicode\"😀\",", "\n        /* 😀 */ set(unicode\"😀中\",")
+        .replace('\n', "\r\n");
+    let cursor = changed.find(" 2);").unwrap();
+    let prefix = &changed[..cursor];
+    let position = Position::new(
+        prefix.bytes().filter(|&byte| byte == b'\n').count() as u32,
+        prefix.rsplit('\n').next().unwrap().encode_utf16().count() as u32,
+    );
+    state.vfs.write().set_file_contents(
+        VfsPath::from(fixture.project_path("/Signature.sol")),
+        Some(Rope::from(changed)),
+    );
+    assert_eq!(request_signature_help(&mut state, uri.clone(), position), Some(original.clone()));
+    assert_eq!(request_signature_help(&mut state, uri, position), Some(original));
 }
 
 #[test]

--- a/crates/lsp/src/vfs/fs.rs
+++ b/crates/lsp/src/vfs/fs.rs
@@ -26,6 +26,7 @@ use super::VfsPath;
 use crate::{
     file_operations::{FileMoveBatch, FileMoveError},
     folding_range,
+    proto::LspPositionIndex,
     selection_range::SelectionRangeIndex,
 };
 use crop::Rope;
@@ -41,6 +42,7 @@ use std::{
 struct VfsFile {
     contents: Rope,
     analysis_source: OnceLock<Arc<String>>,
+    positions: OnceLock<LspPositionIndex<Rope>>,
     selection_range_index: OnceLock<SelectionRangeIndex>,
     folding_ranges: OnceLock<Vec<lsp_types::FoldingRange>>,
 }
@@ -50,6 +52,7 @@ impl VfsFile {
         Self {
             contents,
             analysis_source: OnceLock::new(),
+            positions: OnceLock::new(),
             selection_range_index: OnceLock::new(),
             folding_ranges: OnceLock::new(),
         }
@@ -59,6 +62,24 @@ impl VfsFile {
         self.analysis_source
             .get_or_init(|| Arc::new(crate::utils::rope_to_string(&self.contents)))
             .clone()
+    }
+}
+
+/// An exact-content handle for sharing completion's source text and position index.
+#[derive(Clone)]
+pub(crate) struct CompletionSource(Arc<VfsFile>);
+
+impl CompletionSource {
+    pub(crate) fn contents(&self) -> &Rope {
+        &self.0.contents
+    }
+
+    pub(crate) fn positions(&self) -> &LspPositionIndex<Rope> {
+        self.0.positions.get_or_init(|| LspPositionIndex::from_rope(self.0.contents.clone()))
+    }
+
+    pub(crate) fn source(&self) -> Arc<String> {
+        self.0.analysis_source()
     }
 }
 
@@ -154,6 +175,10 @@ impl Vfs {
     /// Returns a shared contiguous source for compiler analysis.
     pub(crate) fn get_file_analysis_source(&self, path: &VfsPath) -> Option<Arc<String>> {
         self.data.get(path).map(|file| file.analysis_source())
+    }
+
+    pub(crate) fn get_file_completion_source(&self, path: &VfsPath) -> Option<CompletionSource> {
+        self.data.get(path).cloned().map(CompletionSource)
     }
 
     /// Returns an exact-content handle whose derived index can initialize outside the VFS lock.
@@ -372,6 +397,54 @@ mod tests {
         let changed = vfs.get_file_analysis_source(&file).unwrap();
         assert!(!Arc::ptr_eq(&first, &changed));
         assert_eq!(changed.as_str(), "contract Changed {}");
+    }
+
+    #[test]
+    fn completion_sources_keep_text_and_positions_from_the_same_contents() {
+        let mut vfs = Vfs::default();
+        let file = path("/workspace/Test.sol");
+        insert(&mut vfs, "/workspace/Test.sol", "α😀\r\nnext\rtail\n", 1);
+        let original = vfs.get_file_completion_source(&file).unwrap();
+        let at = |source: &CompletionSource, line, character| {
+            let position = Position::new(line, character);
+            source.positions().checked_text_range(lsp_types::Range::new(position, position))
+        };
+        assert_eq!(at(&original, 0, 2), None);
+        assert_eq!(at(&original, 0, 99), Some(6..6));
+        assert_eq!(at(&original, 1, 2), Some(10..10));
+        assert_eq!(at(&original, 2, 4), Some(17..17));
+        assert_eq!(at(&original, 3, 0), Some(18..18));
+        assert_eq!(at(&original, 4, 0), None);
+
+        assert!(!vfs.set_file_contents_with_version(
+            file.clone(),
+            Some(original.contents().clone()),
+            Some(2),
+        ));
+        let unchanged = vfs.get_file_completion_source(&file).unwrap();
+        assert!(std::ptr::eq(original.positions(), unchanged.positions()));
+        assert!(Arc::ptr_eq(&original.source(), &unchanged.source()));
+
+        insert(&mut vfs, "/workspace/Test.sol", "x\n😀z\n", 3);
+        let changed = vfs.get_file_completion_source(&file).unwrap();
+        assert_eq!(at(&changed, 1, 2), Some(6..6));
+        assert_eq!(at(&changed, 2, 0), Some(8..8));
+        assert_eq!(changed.source().as_str(), "x\n😀z\n");
+        assert_eq!(at(&original, 1, 2), Some(10..10));
+        assert_eq!(original.source().as_str(), "α😀\r\nnext\rtail\n");
+
+        let moved = path("/workspace/Moved.sol");
+        vfs.rename_file_prefixes(&moves([(
+            PathBuf::from("/workspace/Test.sol"),
+            PathBuf::from("/workspace/Moved.sol"),
+        )]))
+        .unwrap();
+        assert!(vfs.get_file_completion_source(&file).is_none());
+        let renamed = vfs.get_file_completion_source(&moved).unwrap();
+        assert!(std::ptr::eq(changed.positions(), renamed.positions()));
+        assert_eq!(at(&renamed, 1, 2), Some(6..6));
+        vfs.set_file_contents(moved, None);
+        assert_eq!(renamed.source().as_str(), "x\n😀z\n");
     }
 
     #[test]

--- a/crates/lsp/src/vfs/fs.rs
+++ b/crates/lsp/src/vfs/fs.rs
@@ -65,11 +65,11 @@ impl VfsFile {
     }
 }
 
-/// An exact-content handle for sharing completion's source text and position index.
+/// An exact-content handle for sharing source text and its position index.
 #[derive(Clone)]
-pub(crate) struct CompletionSource(Arc<VfsFile>);
+pub(crate) struct DocumentSource(Arc<VfsFile>);
 
-impl CompletionSource {
+impl DocumentSource {
     pub(crate) fn contents(&self) -> &Rope {
         &self.0.contents
     }
@@ -177,8 +177,8 @@ impl Vfs {
         self.data.get(path).map(|file| file.analysis_source())
     }
 
-    pub(crate) fn get_file_completion_source(&self, path: &VfsPath) -> Option<CompletionSource> {
-        self.data.get(path).cloned().map(CompletionSource)
+    pub(crate) fn get_file_source(&self, path: &VfsPath) -> Option<DocumentSource> {
+        self.data.get(path).cloned().map(DocumentSource)
     }
 
     /// Returns an exact-content handle whose derived index can initialize outside the VFS lock.
@@ -400,12 +400,12 @@ mod tests {
     }
 
     #[test]
-    fn completion_sources_keep_text_and_positions_from_the_same_contents() {
+    fn document_sources_keep_text_and_positions_from_the_same_contents() {
         let mut vfs = Vfs::default();
         let file = path("/workspace/Test.sol");
         insert(&mut vfs, "/workspace/Test.sol", "α😀\r\nnext\rtail\n", 1);
-        let original = vfs.get_file_completion_source(&file).unwrap();
-        let at = |source: &CompletionSource, line, character| {
+        let original = vfs.get_file_source(&file).unwrap();
+        let at = |source: &DocumentSource, line, character| {
             let position = Position::new(line, character);
             source.positions().checked_text_range(lsp_types::Range::new(position, position))
         };
@@ -421,12 +421,12 @@ mod tests {
             Some(original.contents().clone()),
             Some(2),
         ));
-        let unchanged = vfs.get_file_completion_source(&file).unwrap();
+        let unchanged = vfs.get_file_source(&file).unwrap();
         assert!(std::ptr::eq(original.positions(), unchanged.positions()));
         assert!(Arc::ptr_eq(&original.source(), &unchanged.source()));
 
         insert(&mut vfs, "/workspace/Test.sol", "x\n😀z\n", 3);
-        let changed = vfs.get_file_completion_source(&file).unwrap();
+        let changed = vfs.get_file_source(&file).unwrap();
         assert_eq!(at(&changed, 1, 2), Some(6..6));
         assert_eq!(at(&changed, 2, 0), Some(8..8));
         assert_eq!(changed.source().as_str(), "x\n😀z\n");
@@ -439,8 +439,8 @@ mod tests {
             PathBuf::from("/workspace/Moved.sol"),
         )]))
         .unwrap();
-        assert!(vfs.get_file_completion_source(&file).is_none());
-        let renamed = vfs.get_file_completion_source(&moved).unwrap();
+        assert!(vfs.get_file_source(&file).is_none());
+        let renamed = vfs.get_file_source(&moved).unwrap();
         assert!(std::ptr::eq(changed.positions(), renamed.positions()));
         assert_eq!(at(&renamed, 1, 2), Some(6..6));
         vfs.set_file_contents(moved, None);

--- a/tools/lsp-bench/README.md
+++ b/tools/lsp-bench/README.md
@@ -39,6 +39,13 @@ an exact `expected_label`, and a zero-based `expected_active_parameter`. They
 check the active signature, including a per-signature active parameter when
 provided, before accepting a request timing.
 
+The full profile includes `synthetic-warm-signature-help` for an imported library
+call and `v4-core-warm-signature-help` for the final argument of an internal call
+near the end of `PoolManager.sol`. The latter also checks that a preceding nested
+call does not change the selected signature or active parameter. Select these
+workloads with `--profile full` and the repeatable `--workload` filter; servers
+that do not advertise signature help are reported as unsupported.
+
 ## Requirements
 
 Run commands from the repository root. Preparation requires Git, curl, tar,

--- a/tools/lsp-bench/benchmark.yaml
+++ b/tools/lsp-bench/benchmark.yaml
@@ -137,6 +137,21 @@ scenarios:
           min_count: 3
           expected_name: Main
 
+  - id: synthetic-warm-signature-help
+    fixture: synthetic
+    methods:
+      - textDocument/signatureHelp
+    steps:
+      - kind: open
+        path: Main.sol
+      - kind: warm
+        probe:
+          kind: signature-help
+          path: Main.sol
+          anchor: signature-double
+          expected_label: function double(uint256 value) internal pure returns (uint256)
+          expected_active_parameter: 0
+
   - id: synthetic-incremental-edit-save
     fixture: synthetic
     methods:
@@ -384,6 +399,21 @@ scenarios:
           path: src/PoolManager.sol
           min_count: 5
           expected_name: PoolManager
+
+  - id: v4-core-warm-signature-help
+    fixture: v4-core
+    methods:
+      - textDocument/signatureHelp
+    steps:
+      - kind: open
+        path: src/PoolManager.sol
+      - kind: warm
+        probe:
+          kind: signature-help
+          path: src/PoolManager.sol
+          anchor: pool-manager-signature
+          expected_label: function _accountDelta(Currency currency, int128 delta, address target) internal
+          expected_active_parameter: 2
 
   - id: v4-core-incremental-edit-save
     fixture: v4-core

--- a/tools/lsp-bench/fixtures.lock.yaml
+++ b/tools/lsp-bench/fixtures.lock.yaml
@@ -36,6 +36,10 @@ fixtures:
         path: Main.sol
         needle: return Math.
         offset: 12
+      signature-double:
+        path: Main.sol
+        needle: Math.double(input)
+        offset: 12
       math-double:
         path: Math.sol
         needle: function double
@@ -94,6 +98,10 @@ fixtures:
         path: src/PoolManager.sol
         needle: key.hooks.beforeInitialize
         offset: 10
+      pool-manager-signature:
+        path: src/PoolManager.sol
+        needle: _accountDelta(key.currency1, delta.amount1(), target)
+        offset: 46
     corpus: Uniswap v4-core
     required: true
 


### PR DESCRIPTION
Towards OSS-738  

Depends on #1431.

Signature help still rebuilds the document's position index and copies the source prefix on every request. It also converts positions for callsites before checking whether their function names match.

- Check the call form and callee name first, so calls to unrelated functions skip the position conversions.
- Reuse the VFS position index introduced in #1431. Completion and signature help share one index for the same document contents.
- Borrow the prefix from the cached contiguous source instead of copying it from the Rope on every request. Content changes replace the document snapshot and its caches together; the existing stale-callee checks still run.
- Add handler benchmarks for 64, 256, and 1,024 callsites, a real router, and its first request after an edit. Add full-profile stdio workloads for an imported library call and the final argument of a v4-core call following a nested call. Regression tests cover warmed requests across receiver edits, changed lines, and UTF-16 positions while analysis is still stale.

The baseline is `afdd3a1c` with #1431 (`9c9dd9134`) applied, so the table measures the additional gains from this PR. Both binaries used the same release build flags on the same macOS arm64 host. Times are warm request latencies over stdio, in milliseconds; lower is better.

| Request | p50 before → after | Change [95% CI] | p95 before → after | Change [95% CI] |
| --- | ---: | ---: | ---: | ---: |
| Uniswap V3 `deploy` signature | 0.315604 → 0.172369 | -45.38% [-47.67, -43.95] | 0.437425 → 0.215419 | -50.75% [-52.74, -48.79] |
| Uniswap V3 `mulDiv` signature | 0.289190 → 0.161867 | -44.03% [-44.47, -43.59] | 0.406015 → 0.200356 | -50.65% [-52.35, -48.98] |
| v4-core `_accountDelta` signature | 0.091179 → 0.061469 | -32.58% [-33.57, -31.51] | 0.118469 → 0.077787 | -34.34% [-38.13, -30.33] |
| Synthetic `double` signature | 0.057411 → 0.058521 | +1.93% [-2.60, +7.92] | 0.071769 → 0.073231 | +2.04% [-3.34, +8.74] |
| Synthetic hover (control) | 0.056000 → 0.057833 | +3.27% [-1.03, +7.41] | 0.070133 → 0.070413 | +0.40% [-5.00, +6.37] |
| Uniswap V3 member completion (control) | 0.049437 → 0.049508 | +0.14% [-0.90, +1.20] | 0.062479 → 0.062427 | -0.08% [-4.16, +4.91] |
| Synthetic import completion (control) | 0.113264 → 0.115098 | +1.62% [-1.20, +4.54] | 0.139965 → 0.139788 | -0.13% [-4.41, +4.30] |

