### PR TITLE
chore: update Solidity to 0.8.37

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -20,13 +20,13 @@ on:
       solc_version:
         description: solc release used by the codegen runtime benchmark
         required: true
-        default: 0.8.36
+        default: 0.8.37
         type: string
 
 env:
   CARGO_TERM_COLOR: always
   RUSTC_WRAPPER: "sccache"
-  SOLC_VERSION: ${{ inputs.solc_version || '0.8.36' }}
+  SOLC_VERSION: ${{ inputs.solc_version || '0.8.37' }}
   SOLX_VERSION: '0.1.8'
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
 env:
   CARGO_TERM_COLOR: always
   RUSTC_WRAPPER: "sccache"
-  SOLC_VERSION: 0.8.36
+  SOLC_VERSION: 0.8.37
   FANDANGO_VERSION: 1.1.1
 
 jobs:

--- a/.github/workflows/lsp-bench-cross-server-command.yml
+++ b/.github/workflows/lsp-bench-cross-server-command.yml
@@ -169,9 +169,9 @@ jobs:
           cargo build --locked --release -p solar-lsp-bench
           cargo build --locked --release -p solar-compiler --bin solar
 
-      - name: Prepare core4 and synthetic fixture
+      - name: Prepare servers and synthetic fixture
         run: >-
-          target/release/solar-lsp-bench prepare --fixture synthetic --server solar --server asyncswap --server nomic-foundation --server solc
+          target/release/solar-lsp-bench prepare --fixture synthetic --server solar --server asyncswap --server nomic-foundation
 
       - name: Run cross-server PR smoke comparison
         shell: bash
@@ -181,7 +181,7 @@ jobs:
           set -euo pipefail
           target/release/solar-lsp-bench run \
             --profile pr-smoke \
-            --server solar --server asyncswap --server nomic-foundation --server solc \
+            --server solar --server asyncswap --server nomic-foundation \
             --output target/lsp-bench/pr-smoke \
             --allow-failures \
             --solar-binary target/release/solar \

--- a/.github/workflows/lsp-bench.yml
+++ b/.github/workflows/lsp-bench.yml
@@ -83,9 +83,9 @@ jobs:
           cargo build --locked --release -p solar-lsp-bench
           cargo build --locked --release -p solar-compiler --bin solar
 
-      - name: Prepare core4 and synthetic fixture
+      - name: Prepare servers and synthetic fixture
         run: >-
-          target/release/solar-lsp-bench prepare --fixture synthetic --server solar --server asyncswap --server nomic-foundation --server solc
+          target/release/solar-lsp-bench prepare --fixture synthetic --server solar --server asyncswap --server nomic-foundation
 
       - name: Record provenance
         shell: bash
@@ -133,7 +133,7 @@ jobs:
           set -euo pipefail
           target/release/solar-lsp-bench run \
             --profile pr-smoke \
-            --server solar --server asyncswap --server nomic-foundation --server solc \
+            --server solar --server asyncswap --server nomic-foundation \
             --output target/lsp-bench/pr-smoke \
             --allow-failures \
             --solar-binary target/release/solar \
@@ -259,9 +259,9 @@ jobs:
           cargo build --locked --release -p solar-lsp-bench
           cargo build --locked --release -p solar-compiler --bin solar
 
-      - name: Prepare core4 and all fixtures
+      - name: Prepare servers and all fixtures
         run: >-
-          target/release/solar-lsp-bench prepare --server solar --server asyncswap --server nomic-foundation --server solc
+          target/release/solar-lsp-bench prepare --server solar --server asyncswap --server nomic-foundation
 
       - name: Record provenance
         shell: bash
@@ -293,7 +293,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          target/release/solar-lsp-bench doctor --server solar --server asyncswap --server nomic-foundation --server solc \
+          target/release/solar-lsp-bench doctor --server solar --server asyncswap --server nomic-foundation \
             | tee target/lsp-bench/doctor.txt
 
       - name: Run full comparison
@@ -302,7 +302,7 @@ jobs:
           set -euo pipefail
           target/release/solar-lsp-bench run \
             --profile full \
-            --server solar --server asyncswap --server nomic-foundation --server solc \
+            --server solar --server asyncswap --server nomic-foundation \
             --output target/lsp-bench/full \
             --solar-binary target/release/solar \
             --solar-revision "$(git rev-parse HEAD)"

--- a/benches/lsp/README.md
+++ b/benches/lsp/README.md
@@ -26,7 +26,7 @@ executes a PR revision would give untrusted build code access to the default
 branch's Actions cache authority. The comment-triggered path keeps every job
 that builds or executes PR code separate from the trusted renderer.
 
-The cross-server workflow runs the `pr-smoke` core4/synthetic benchmark on every
+The cross-server workflow runs the `pr-smoke` synthetic benchmark on every
 pull request. To rerun that benchmark manually, add an exact `/bench
 cross-server` comment to the pull request. Its read-only benchmark job checks
 out the frozen PR head, while a separate job with comment permissions publishes

--- a/benches/lsp/test_cross_server_workflow.py
+++ b/benches/lsp/test_cross_server_workflow.py
@@ -27,9 +27,7 @@ UPLOAD_ACTION = "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0
 STICKY_COMMENT_ACTION = (
     "marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88"
 )
-SERVER_ARGS = (
-    "--server solar --server asyncswap --server nomic-foundation --server solc"
-)
+SERVER_ARGS = "--server solar --server asyncswap --server nomic-foundation"
 
 
 def workflow() -> str:
@@ -268,7 +266,7 @@ class CrossServerWorkflowTests(unittest.TestCase):
         self.assertNotIn("github-script", text)
         self.assertIn("name: Verify checked out test merge", text)
 
-    def test_pr_smoke_runs_core4_synthetic_with_failure_tolerance(self) -> None:
+    def test_pr_smoke_runs_cross_server_synthetic_with_failure_tolerance(self) -> None:
         pr = job_block("pr-smoke")
         run = step_block(pr, "Run PR smoke comparison")
 
@@ -333,7 +331,7 @@ class CrossServerWorkflowTests(unittest.TestCase):
         self.assertIn("target/lsp-bench/pr-comment/", upload)
         self.assertNotIn(f"uses: {STICKY_COMMENT_ACTION}", pr)
 
-    def test_manual_full_runs_strict_core4_matrix(self) -> None:
+    def test_manual_full_runs_strict_cross_server_matrix(self) -> None:
         full = job_block("full")
         run = step_block(full, "Run full comparison")
 

--- a/crates/config/build.rs
+++ b/crates/config/build.rs
@@ -2,7 +2,7 @@
 use std::{env, io::Read, path::Path};
 
 #[cfg(feature = "version")]
-const SOLC_VERSION_FALLBACK: &str = "0.8.36";
+const SOLC_VERSION_FALLBACK: &str = "0.8.37";
 #[cfg(feature = "version")]
 const VERSION_UNKNOWN: &str = "unknown";
 #[cfg(feature = "version")]

--- a/scripts/bench_switch_lowering.py
+++ b/scripts/bench_switch_lowering.py
@@ -25,7 +25,7 @@ from pathlib import Path
 from typing import Any, TextIO
 
 DEFAULT_PIN = "01209d2b8ac81645b92e3ef801b5bcdfd61bfd69"
-DEFAULT_SOLC_VERSION = "0.8.36"
+DEFAULT_SOLC_VERSION = "0.8.37"
 DEFAULT_METHODS = ("auto", "linear", "binary", "buckets", "dense", "perfect")
 SYNTHETIC_FIXTURE_VERSION = 6
 ANVIL_HARDFORK = "osaka"

--- a/tools/lsp-bench/README.md
+++ b/tools/lsp-bench/README.md
@@ -6,8 +6,8 @@ runtime correctness before its sample contributes to latency or resource
 statistics, so an unsupported or incorrect response cannot appear fast by
 doing less work.
 
-The v1 inventory is the **core4** set: Solar, Asyncswap, Nomic Foundation, and
-official `solc --lsp`. All servers use stdio. `servers.lock.yaml` records their
+The inventory includes Solar, Asyncswap, and Nomic Foundation.
+All servers use stdio. `servers.lock.yaml` records their
 versions, source revisions, installation commands, and artifact digests. The
 `solar` entry points at the workspace compiler binary; a workflow run
 supplies that exact binary, source revision, and executable digest as provenance.
@@ -79,10 +79,10 @@ The profiles in `benchmark.yaml` are:
 | --- | ---: | ---: | ---: | ---: | --- |
 | `smoke` | 1 | 2 | 1 | 1 | local synthetic subset |
 | `pr-smoke` | 5 | 20 | 4 | 4 | synthetic scenarios |
-| `full` | 10 | 100 | 8 | 8 | all scenarios for all core4 fixtures |
+| `full` | 10 | 100 | 8 | 8 | all scenarios for all fixtures |
 
 The CLI defaults `run` to `pr-smoke`; pass `--profile full` for the complete
-core4 matrix. A run publishes all result views in one operation:
+server matrix. A run publishes all result views in one operation:
 
 ```bash
 target/debug/solar-lsp-bench run \
@@ -91,7 +91,7 @@ target/debug/solar-lsp-bench run \
 
 target/debug/solar-lsp-bench run \
   --profile pr-smoke \
-  --server solar --server asyncswap --server nomic-foundation --server solc \
+  --server solar --server asyncswap --server nomic-foundation \
   --output target/lsp-bench/pr-smoke
 
 target/debug/solar-lsp-bench run \
@@ -115,7 +115,7 @@ target/debug/solar-lsp-bench report \
 
 ## CI
 
-`.github/workflows/lsp-bench.yml` runs `pr-smoke` against core4 and the
+`.github/workflows/lsp-bench.yml` runs `pr-smoke` against all servers and the
 synthetic fixture for pull requests. The PR job is reference-only and tolerates
 sample failures. A manual `full` dispatch on `main` runs the complete matrix
 strictly. Both jobs build the harness and compiler from the checked-out commit,

--- a/tools/lsp-bench/benchmark.yaml
+++ b/tools/lsp-bench/benchmark.yaml
@@ -18,7 +18,7 @@ profiles:
       - synthetic-warm-document-symbol
       - synthetic-incremental-edit-save
   pr-smoke:
-    # Fast, capability-portable reference signal for comparing core4 on the
+    # Fast, capability-portable reference signal for comparing servers on the
     # tracked synthetic fixture in PR CI.
     warmup: 5
     samples: 20

--- a/tools/lsp-bench/fixtures.lock.yaml
+++ b/tools/lsp-bench/fixtures.lock.yaml
@@ -5,13 +5,13 @@ fixtures:
     source_roots:
       - .
     solc:
-      version: 0.8.36
-      native: ../../target/lsp-bench/artifacts/solc/0.8.36/solc-static-linux
-      native_url: https://binaries.soliditylang.org/linux-amd64/solc-linux-amd64-v0.8.36+commit.8a079791
-      native_sha256: c8d35afdddc3cd2743ee88b8f25e0fecd16e2bdd5f2120f37e52cd9cc45ae0e6
-      soljson: ../../target/lsp-bench/artifacts/solc/0.8.36/soljson.js
-      soljson_url: https://binaries.soliditylang.org/wasm/soljson-v0.8.36+commit.8a079791.js
-      soljson_sha256: 704877a592467d7de651ec5377ea6e3c676ae71d31f325401957d41bedfaa0d8
+      version: 0.8.37
+      native: ../../target/lsp-bench/artifacts/solc/0.8.37/solc-static-linux
+      native_url: https://github.com/argotorg/solidity/releases/download/v0.8.37/solc-static-linux
+      native_sha256: 5de843c2c93563cc66425c99a4fb13fdbf32b4c4ae07469480faaf126e14404a
+      soljson: ../../target/lsp-bench/artifacts/solc/0.8.37/soljson.js
+      soljson_url: https://github.com/argotorg/solidity/releases/download/v0.8.37/soljson.js
+      soljson_sha256: d73fead3cbc860438f56f4d1723677499cdef212d0f8890241748d2d5afc1c5f
     foundry:
       version: 1.7.1
       native: ../../target/lsp-bench/artifacts/foundry/1.7.1/forge

--- a/tools/lsp-bench/servers.lock.yaml
+++ b/tools/lsp-bench/servers.lock.yaml
@@ -49,23 +49,3 @@ servers:
       path: ../../target/lsp-bench/servers/nomic-foundation/node_modules/@nomicfoundation/solidity-language-server
       sha256: ac6618fb7360f633cefa6e646b3f47c98a09d12ce1ec2dd601314c9e9ea8673c
     required: true
-
-  - id: solc
-    label: Official solc 0.8.36
-    command: ../../target/lsp-bench/servers/solc/solc-static-linux
-    args:
-      - --experimental
-      - --lsp
-    version_args:
-      - --version
-    locked_version: "0.8.36"
-    source:
-      url: https://github.com/ethereum/solidity.git
-      revision: 8a079791d9cca7a6c03fd6a8429b93aa3bddefed
-    install:
-      kind: binary
-      url: https://github.com/argotorg/solidity/releases/download/v0.8.36/solc-static-linux
-    artifact:
-      path: ../../target/lsp-bench/servers/solc/solc-static-linux
-      sha256: c8d35afdddc3cd2743ee88b8f25e0fecd16e2bdd5f2120f37e52cd9cc45ae0e6
-    required: true

--- a/tools/lsp-bench/src/lifecycle.rs
+++ b/tools/lsp-bench/src/lifecycle.rs
@@ -1461,15 +1461,15 @@ mod tests {
     #[test]
     fn locked_server_version_must_appear_in_probe_output() {
         let mut server = server_spec();
-        server.locked_version = Some("0.8.36".into());
+        server.locked_version = Some("1.2.3".into());
         assert!(
             verify_server_version_output(
                 &server,
-                "solc, the solidity compiler commandline interface\nVersion: 0.8.36+commit.8a079791"
+                "Test language server\nVersion: 1.2.3+commit.abcdef12"
             )
             .is_ok()
         );
-        assert!(verify_server_version_output(&server, "Version: 0.8.35").is_err());
+        assert!(verify_server_version_output(&server, "Version: 1.2.2").is_err());
     }
 
     #[cfg(unix)]

--- a/tools/tester/src/solc/solidity.rs
+++ b/tools/tester/src/solc/solidity.rs
@@ -88,6 +88,10 @@ pub(crate) fn should_skip(path: &Path) -> Result<(), &'static str> {
         // Mapping key types are checked in sema.
         | "mapping_nonelementary_key_1"
         | "mapping_nonelementary_key_4"
+
+        // We allow named modifier and base-constructor arguments, which solc rejects.
+        | "inherited_constructor_named_parameters"
+        | "named_parameters_invocation"
     ) {
         return Err("manually skipped");
     };


### PR DESCRIPTION
Update the Solidity submodule to [v0.8.37](https://github.com/argotorg/solidity/releases/tag/v0.8.37), along with compiler pins and fixture artifact checksums. Remove solc from the LSP benchmark inventory and workflows because this release removes LSP mode.

Skip two new upstream tests that reject named modifier and base-constructor arguments, which we already allow.
