### PR TITLE
perf(lsp): speed up document highlights

### DIFF
--- a/crates/lsp/src/symbols.rs
+++ b/crates/lsp/src/symbols.rs
@@ -939,15 +939,33 @@ impl SymbolTables {
             .collect::<Vec<_>>();
 
         if let Some(references) = self.file_references.get(uri) {
-            highlights.extend(references.iter().filter_map(|&index| {
-                let reference = &self.references[index];
-                reference.targets.iter().any(|target| targets.contains(target)).then_some(
-                    DocumentHighlight {
+            let target_references = match targets.as_slice() {
+                [target] => Some(self.symbol_references.get(target).map_or(&[][..], Vec::as_slice)),
+                _ => None,
+            };
+            // Prefer the smaller index for a single target. Reference indices retain insertion
+            // order, preserving the file index's tie order after the stable range sort below.
+            if let Some(indices) = target_references
+                && indices.len() < references.entries.len()
+            {
+                highlights.extend(indices.iter().filter_map(|&index| {
+                    let reference = &self.references[index];
+                    (&reference.location.uri == uri).then_some(DocumentHighlight {
                         range: reference.location.range,
                         kind: Some(reference.kind),
-                    },
-                )
-            }));
+                    })
+                }));
+            } else {
+                highlights.extend(references.iter().filter_map(|&index| {
+                    let reference = &self.references[index];
+                    reference.targets.iter().any(|target| targets.contains(target)).then_some(
+                        DocumentHighlight {
+                            range: reference.location.range,
+                            kind: Some(reference.kind),
+                        },
+                    )
+                }));
+            }
         }
 
         highlights.sort_by_key(|highlight| (highlight.range.start, highlight.range.end));

--- a/crates/lsp/src/tests/document_highlight.rs
+++ b/crates/lsp/src/tests/document_highlight.rs
@@ -137,6 +137,44 @@ fn scopes_semantic_matches_to_the_requested_document() {
 }
 
 #[test]
+fn single_target_index_filters_references_from_other_files() {
+    let fixture = RequestFixture::new(
+        r#"
+        //- /Base.sol
+        contract Base {
+            uint256 shared;
+
+            function baseRead() public view returns (uint256) {
+                return shared;
+            }
+        }
+
+        //- /Use.sol
+        import "./Base.sol";
+        contract Use is Base {
+            uint256 local;
+
+            function use() public {
+                $1shared = 1;
+                local = local + local;
+                local = local + local;
+                local = local + local;
+            }
+        }
+        "#,
+        "/Use.sol",
+    );
+
+    fixture.check_document_highlights(
+        "$1",
+        str![[r#"
+4:8-4:14 WRITE
+
+"#]],
+    );
+}
+
+#[test]
 fn preserves_ambiguous_reference_targets() {
     let fixture = RequestFixture::new_allowing_diagnostics(
         r#"


### PR DESCRIPTION
Towards OSS-738 , 

Document highlights scan every reference in the current file even when the requested symbol has a smaller reverse index.

- Reuse the existing symbol-to-reference index for single-target queries when it is cheaper than scanning the file index.
- Filter indexed references by the requested URI; keep the file-scan fallback for multi-target and common symbols.
- Preserve stable range ordering and declaration `WRITE` precedence.
- Add regression coverage so references from other documents cannot leak into the response.

| Workload | p50 before → after | Change | p95 before → after | Change |
| --- | ---: | ---: | ---: | ---: |
| Optimism (5.38 MB) | 188.76 → 22.93 µs | -87.85% | 264.76 → 31.56 µs | -88.08% |
| Uniswap | 27.92 → 24.31 µs | -12.91% | 34.12 → 30.25 µs | -11.33% |
| Solady | 23.89 → 21.73 µs | -9.04% | 28.82 → 27.03 µs | -6.21% |
| Synthetic small file | 13.92 → 13.85 µs | -0.48% | 20.44 → 17.85 µs | -12.63% |

```text
Warm documentHighlight p50 latency (lower is better)

Optimism  before  ████████████████████ 188.76 µs
          after   ██                    22.93 µs
Uniswap   before  ███                    27.92 µs
          after   ██                     24.31 µs
Solady    before  ███                    23.89 µs
          after   ██                     21.73 µs
Synthetic before  ██                     13.92 µs
          after   ██                     13.85 µs
```
