### PR TITLE
perf(lsp): cache workspace path index

### DIFF
--- a/crates/lsp/benches/lsp.rs
+++ b/crates/lsp/benches/lsp.rs
@@ -665,6 +665,7 @@ fn workspace_path_queries(c: &mut Criterion) {
     let queries =
         BenchmarkWorkspacePathQueries::new(PATH_INDEX_WORKSPACE_COUNT, PATH_INDEX_QUERY_COUNT);
     assert_ne!(queries.run(), 0);
+    assert_eq!(queries.run(), queries.run_cached());
 
     let mut group = c.benchmark_group("lsp/workspace-path-queries");
     group.throughput(Throughput::Elements(PATH_INDEX_QUERY_COUNT as u64));

--- a/crates/lsp/src/config.rs
+++ b/crates/lsp/src/config.rs
@@ -52,7 +52,7 @@ pub(crate) struct Config {
     selected_profile: Option<String>,
     foundry_workspace_config_source: FoundryWorkspaceConfigSource,
     workspaces: Vec<Workspace>,
-    workspace_path_cache: Arc<OnceLock<Arc<Vec<crate::workspace::WorkspaceImportPathIndexEntry>>>>,
+    workspace_path_cache: Arc<OnceLock<Arc<crate::workspace::WorkspacePathIndexCache>>>,
     manifest_watch_roots: Vec<SourceWatchRoot>,
     git_marker_watch_roots: Vec<PathBuf>,
     index_policy: WorkspaceIndexPolicy,
@@ -351,11 +351,11 @@ impl Config {
     }
 
     fn workspace_path_index(&self) -> WorkspacePathIndex<'_> {
-        let entries = Arc::clone(
+        let cache = Arc::clone(
             self.workspace_path_cache
-                .get_or_init(|| WorkspacePathIndex::new(&self.workspaces).clone_import_entries()),
+                .get_or_init(|| Arc::new(WorkspacePathIndex::cache(&self.workspaces))),
         );
-        WorkspacePathIndex::with_import_entries(&self.workspaces, entries)
+        WorkspacePathIndex::with_cache(&self.workspaces, cache)
     }
 
     pub(crate) fn is_index_import_only_path(&self, path: &Path) -> bool {

--- a/crates/lsp/src/global_state/benchmark.rs
+++ b/crates/lsp/src/global_state/benchmark.rs
@@ -118,7 +118,7 @@ impl BenchmarkError {
 pub struct BenchmarkWorkspacePathQueries {
     workspaces: Vec<Workspace>,
     paths: Vec<PathBuf>,
-    import_entries: Arc<Vec<crate::workspace::WorkspaceImportPathIndexEntry>>,
+    path_cache: Arc<crate::workspace::WorkspacePathIndexCache>,
 }
 
 impl BenchmarkWorkspacePathQueries {
@@ -133,8 +133,8 @@ impl BenchmarkWorkspacePathQueries {
             workspaces.push(Workspace::naked(root.clone()));
         }
         let paths = (0..query_count).map(|index| root.join(format!("Query-{index}.sol"))).collect();
-        let import_entries = WorkspacePathIndex::new(&workspaces).clone_import_entries();
-        Self { workspaces, paths, import_entries }
+        let path_cache = Arc::new(WorkspacePathIndex::cache(&workspaces));
+        Self { workspaces, paths, path_cache }
     }
 
     /// Execute ownership and overlay-recipient queries for every prepared path.
@@ -163,10 +163,7 @@ impl BenchmarkWorkspacePathQueries {
     }
 
     fn run_paths_cached(&self, paths: &[PathBuf]) -> usize {
-        let index = WorkspacePathIndex::with_import_entries(
-            &self.workspaces,
-            Arc::clone(&self.import_entries),
-        );
+        let index = WorkspacePathIndex::with_cache(&self.workspaces, Arc::clone(&self.path_cache));
         self.run_with_index(&index, paths)
     }
 

--- a/crates/lsp/src/workspace/mod.rs
+++ b/crates/lsp/src/workspace/mod.rs
@@ -642,10 +642,21 @@ fn remove_sorted(files: &mut Vec<PathBuf>, path: &Path) {
 pub(crate) struct WorkspacePathIndex<'a> {
     workspaces: &'a [Workspace],
     import_entries: Arc<Vec<WorkspaceImportPathIndexEntry>>,
-    root_index: FxHashMap<PathBuf, SmallVec<[WorkspacePathMatch; 4]>>,
+    root_index: Arc<FxHashMap<PathBuf, SmallVec<[WorkspacePathMatch; 4]>>>,
 }
 
 type WorkspacePathMatch = (usize, usize, u8, usize);
+
+/// Immutable workspace path data shared by short-lived query indexes.
+///
+/// Workspace configuration recreates a borrowed index for each request. Keep the expensive root
+/// map in an owned cache so those indexes only clone two `Arc`s while retaining the workspace
+/// borrow needed for policy checks.
+#[derive(Debug)]
+pub(crate) struct WorkspacePathIndexCache {
+    import_entries: Arc<Vec<WorkspaceImportPathIndexEntry>>,
+    root_index: Arc<FxHashMap<PathBuf, SmallVec<[WorkspacePathMatch; 4]>>>,
+}
 
 pub(crate) struct WorkspacePathQuery {
     matches: SmallVec<[WorkspacePathMatch; 16]>,
@@ -674,15 +685,38 @@ impl<'a> WorkspacePathIndex<'a> {
                 .map(|(idx, workspace)| WorkspaceImportPathIndexEntry::new(idx, workspace))
                 .collect::<Vec<_>>(),
         );
-        let root_index = Self::build_root_index(&import_entries);
+        let root_index = Arc::new(Self::build_root_index(&import_entries));
         Self { workspaces, import_entries, root_index }
+    }
+
+    pub(crate) fn cache(workspaces: &[Workspace]) -> WorkspacePathIndexCache {
+        let import_entries = Arc::new(
+            workspaces
+                .iter()
+                .enumerate()
+                .map(|(idx, workspace)| WorkspaceImportPathIndexEntry::new(idx, workspace))
+                .collect::<Vec<_>>(),
+        );
+        let root_index = Arc::new(Self::build_root_index(&import_entries));
+        WorkspacePathIndexCache { import_entries, root_index }
+    }
+
+    pub(crate) fn with_cache(
+        workspaces: &'a [Workspace],
+        cache: Arc<WorkspacePathIndexCache>,
+    ) -> Self {
+        Self {
+            workspaces,
+            import_entries: Arc::clone(&cache.import_entries),
+            root_index: Arc::clone(&cache.root_index),
+        }
     }
 
     pub(crate) fn with_import_entries(
         workspaces: &'a [Workspace],
         import_entries: Arc<Vec<WorkspaceImportPathIndexEntry>>,
     ) -> Self {
-        let root_index = Self::build_root_index(&import_entries);
+        let root_index = Arc::new(Self::build_root_index(&import_entries));
         Self { workspaces, import_entries, root_index }
     }
 


### PR DESCRIPTION
Towards OSS-738  ,  

Workspace path ownership rebuilt the root lookup map for every request, even though workspace configuration changed much less often than requests arrive.

- Cache the immutable import entries and root lookup map together.
- Reuse the cached index for import resolution, source ownership, and flycheck ownership queries.
- Keep the existing cache invalidation points for workspace discovery and root changes.
- Preserve path precedence and tie handling by reusing the same index construction and matching code.
- Assert that cached and uncached benchmark paths return the same result.

The benchmark uses 16 workspaces and measures one workspace ownership query. The cached path avoids rebuilding the root map on every request.

| Benchmark | Before | After | Change |
| --- | ---: | ---: | ---: |
| Workspace path single query | 18.87 µs | 2.01 µs | -89.3% |
| Previous entries-only cache | 5.95 µs | 2.01 µs | -66.2% |


```text
Workspace path query latency (lower is better)

before  ███████████████████  18.87 µs
after   ██                   2.01 µs
```
