### PR TITLE
perf(lsp): cut update and completion overhead

### DIFF
--- a/crates/lsp/src/config.rs
+++ b/crates/lsp/src/config.rs
@@ -350,7 +350,7 @@ impl Config {
         self.workspace_path_cache = Arc::new(OnceLock::new());
     }
 
-    fn workspace_path_index(&self) -> WorkspacePathIndex<'_> {
+    pub(crate) fn workspace_path_index(&self) -> WorkspacePathIndex<'_> {
         let cache = Arc::clone(
             self.workspace_path_cache
                 .get_or_init(|| Arc::new(WorkspacePathIndex::cache(&self.workspaces))),

--- a/crates/lsp/src/global_state.rs
+++ b/crates/lsp/src/global_state.rs
@@ -2401,7 +2401,12 @@ impl GlobalStateSnapshot {
             files
         };
         let workspaces = self.analysis_workspaces();
-        let workspace_path_index = WorkspacePathIndex::new(&workspaces);
+        // Reuse the configured workspaces' immutable path index between analysis epochs.
+        let workspace_path_index = if self.config.workspaces().is_empty() {
+            WorkspacePathIndex::new(&workspaces)
+        } else {
+            self.config.workspace_path_index()
+        };
         let mut batches = workspaces
             .iter()
             .map(|workspace| AnalysisBatch::new(workspace.compile_opts().clone()))

--- a/crates/lsp/src/handlers/notifs.rs
+++ b/crates/lsp/src/handlers/notifs.rs
@@ -2,7 +2,7 @@ use crate::{
     NotifyResult,
     global_state::{GlobalState, SourceFileEventDisposition},
     proto,
-    utils::apply_document_changes,
+    utils::{apply_document_changes, rope_eq_str},
 };
 use crop::Rope;
 use lsp_types::{
@@ -44,6 +44,30 @@ pub(crate) fn did_change_text_document(
 ) -> NotifyResult {
     if let Some(path) = proto::vfs_path(&params.text_document.uri) {
         let disk_path = path.as_path().map(ToOwned::to_owned);
+        // A full-document update with identical text only changes the client version.
+        // Avoid constructing a replacement Rope and comparing the entire document again.
+        if params.content_changes.len() == 1
+            && let Some(change) = params.content_changes.first()
+            && change.range.is_none()
+        {
+            let unchanged = {
+                let vfs = state.vfs.read();
+                let Some(contents) = vfs.get_file_contents(&path) else {
+                    error!(?path, "orphan DidChangeTextDocument");
+                    return ControlFlow::Continue(());
+                };
+                rope_eq_str(contents, &change.text)
+            };
+            if unchanged {
+                state.vfs.write().set_file_version(path, params.text_document.version);
+                state.update_analyzed_document_version(
+                    params.text_document.uri,
+                    params.text_document.version,
+                );
+                state.reindex_if_invalidated();
+                return ControlFlow::Continue(());
+            }
+        }
         let new_contents = {
             let _guard = state.vfs.read();
             let Some(contents) = _guard.get_file_contents(&path) else {

--- a/crates/lsp/src/symbols.rs
+++ b/crates/lsp/src/symbols.rs
@@ -2608,6 +2608,14 @@ fn completion_filter_prefix(prefix: &str) -> Option<String> {
 }
 
 fn fuzzy_completion_match(prefix: &str, label: &str) -> bool {
+    // Match ASCII names byte by byte, retaining Unicode case folding for other labels.
+    if prefix.is_ascii() && label.is_ascii() {
+        let mut label = label.bytes();
+        return prefix.bytes().all(|prefix_byte| {
+            label.by_ref().any(|label_byte| label_byte.eq_ignore_ascii_case(&prefix_byte))
+        });
+    }
+
     let mut label_chars = label.chars().flat_map(char::to_lowercase);
     prefix
         .chars()
@@ -2728,6 +2736,14 @@ fn is_generated_item(gcx: Gcx<'_>, item_id: ItemId) -> bool {
 mod tests {
     use super::{push_symbol_for_test as push, *};
     use lsp_types::Position;
+
+    #[test]
+    fn fuzzy_completion_match_handles_ascii_and_unicode() {
+        assert!(fuzzy_completion_match("FN", "FunctionName"));
+        assert!(fuzzy_completion_match("fnn", "FunctionName"));
+        assert!(!fuzzy_completion_match("fz", "FunctionName"));
+        assert!(fuzzy_completion_match("é", "Éclair"));
+    }
 
     #[test]
     fn document_symbols_are_nested_by_parent_and_ordered_by_source() {

--- a/crates/lsp/src/utils.rs
+++ b/crates/lsp/src/utils.rs
@@ -26,6 +26,24 @@ pub(crate) fn apply_document_changes(
     text
 }
 
+/// Compare a rope's UTF-8 bytes with a contiguous string without flattening the rope.
+#[inline]
+pub(crate) fn rope_eq_str(contents: &Rope, text: &str) -> bool {
+    if contents.byte_len() != text.len() {
+        return false;
+    }
+
+    let mut offset = 0;
+    for chunk in contents.chunks() {
+        let end = offset + chunk.len();
+        if text.get(offset..end) != Some(chunk) {
+            return false;
+        }
+        offset = end;
+    }
+    true
+}
+
 pub(crate) fn rope_to_string(rope: &Rope) -> String {
     let mut source = String::with_capacity(rope.byte_len());
     for chunk in rope.chunks() {
@@ -36,9 +54,17 @@ pub(crate) fn rope_to_string(rope: &Rope) -> String {
 
 #[cfg(test)]
 mod tests {
-    use crate::utils::apply_document_changes;
+    use crate::utils::{apply_document_changes, rope_eq_str};
     use crop::Rope;
     use lsp_types::{Position, Range, TextDocumentContentChangeEvent};
+
+    #[test]
+    fn rope_eq_str_compares_chunked_utf8() {
+        let rope = Rope::from("alpha\nβeta😀");
+        assert!(rope_eq_str(&rope, "alpha\nβeta😀"));
+        assert!(!rope_eq_str(&rope, "alpha\nβeta"));
+        assert!(!rope_eq_str(&rope, "alpha\nβeta😃"));
+    }
 
     #[test]
     fn test_apply_document_changes() {

--- a/crates/lsp/src/vfs/fs.rs
+++ b/crates/lsp/src/vfs/fs.rs
@@ -168,6 +168,13 @@ impl Vfs {
         }
     }
 
+    /// Update an existing file's client version without replacing its contents.
+    pub(crate) fn set_file_version(&mut self, path: VfsPath, version: i32) {
+        debug_assert!(self.data.contains_key(&path));
+        self.versions.insert(path, version);
+        self.dirty = true;
+    }
+
     pub(crate) fn get_file_contents(&self, path: &VfsPath) -> Option<&Rope> {
         self.data.get(path).map(|file| &file.contents)
     }


### PR DESCRIPTION
Towards OSS-738 , 

Full-document updates rebuilt a Rope even when the text was unchanged, and completion filtering ran Unicode case folding over ASCII names.

- Compare identical full-document updates against the existing Rope's chunks and update the document version directly. The `Optimism.sol` update benchmark drops from 1.257 ms to 0.266 ms (78.8% less time).
- Match ASCII completion names byte by byte, keeping the existing Unicode path for other labels. Selective completion drops from 5.803 µs to 3.508 µs (39.6%); no-match completion drops from 4.082 µs to 2.629 µs (35.6%).
- Reuse the workspace path index from #1436 when building analysis batches. This removes another index rebuild per analysis epoch; the unconfigured workspace still constructs its own index.

The chart compares official main `2c47185cc` with `c016afaf5`, run sequentially in the same checkout on macOS arm64 using the Cargo bench profile: 30 samples, 1 s warmup and 1 s requested measurement time. These are local Criterion update/query timings; error bars show 95% confidence intervals. Empty-prefix completion is included as a control. Analysis-batch cache reuse is not separately timed here.

[Raw samples, estimates and run logs](https://github.com/0xKarl98/solar/tree/d6c14b0777ccf8e625ba32ce94594b20924a74a4).

![LSP update and completion benchmark comparison](https://raw.githubusercontent.com/0xKarl98/solar/d6c14b0777ccf8e625ba32ce94594b20924a74a4/lsp-performance.png)
