### PR TITLE
feat(bench): expand codegen workloads

### DIFF
--- a/benches/runtime/README.md
+++ b/benches/runtime/README.md
@@ -1,6 +1,7 @@
 # Codegen benchmark corpus
 
-This directory contains fixtures and workload documentation for the codegen benchmark. The shared
+This directory contains the codegen benchmark runner and workload documentation. Local
+benchmark contracts live in `../../testdata/runtime/`. The shared
 project archives live in `../../testdata/projects/`; archives group cases from the same upstream
 project. The default `runtime` mode selects each entrypoint's transitive Solidity import closure and
 omits the heavy full-project cases. The `compile-time` mode measures those cases by passing full
@@ -104,6 +105,8 @@ runtime observations.
 | `lilweb3-flashloan` | `m1guelpf/lil-web3` plus `transmissions11/solmate` | `7346bd28c2586da3b07102d5290175a276949b15`, `e802bcf2fb24dda2bf7e513bea86d15c48b57486` | 2 |
 | `lilweb3-fractional` | `m1guelpf/lil-web3` plus `transmissions11/solmate` | `7346bd28c2586da3b07102d5290175a276949b15`, `e802bcf2fb24dda2bf7e513bea86d15c48b57486` | 3 |
 | `maple-erc20` | `maple-labs/erc20` | `baf791a9f894b0b319a2d42d5b9f8d30349ebaad` | 2 |
+| `solady-encoding` | `Vectorized/solady` plus `Encoding.sol` | `solady-0.1.26` archive | 3 |
+| `solady-algorithms` | `Vectorized/solady` plus `Algorithms.sol` | `solady-0.1.26` archive | 5 |
 
 The OpenZeppelin cases share the canonical
 `../../testdata/projects/openzeppelin-5.6.1.json.gz` archive; the file counts above are the sliced
@@ -116,9 +119,78 @@ are the sliced closure for each case.
 The large OpenZeppelin and Solady cases use the pinned archives in `../../testdata/projects/`. The
 normal benchmark suite also reads those archives from there.
 
+Governor measures empty proposals and proposals with one, two, and eight elements.
+The nonempty cases exercise address cleanup, word-array copies, and nested bytes
+tails of 0, 1, 31, 32, and 33 bytes. Each workload also checks the returned proposal
+hash against solc. Keep per-call results visible: empty proposals do not exercise
+encoder loops, and transaction gas floors can hide execution-cost changes on
+inputs with substantial calldata.
+
+LibString also exercises byte-to-hex conversion, every possible single-byte ASCII
+input, and rune counting for empty, one-byte, 31/32/33-byte ASCII, and longer
+multibyte UTF-8 strings. These pinned upstream tests assert their own results,
+including comparison against reference implementations. Keep these workloads
+alongside replacement and conversion calls: they expose loop and bounds-check
+costs that the original six-function profile missed.
+
+The byte conversion workloads also cover empty input and lengths 1, 31, 32, 33,
+64, and 65 with both prefix modes. ASCII differential calls exercise high-bit
+bytes at the first byte, a word boundary, and the final byte. These upstream
+checks dirty surrounding memory and verify that the helper restores its temporary
+writes. Their gas includes the upstream memory-brutalization and assertion setup,
+so it does not measure the encoder in isolation. The brutalizer seeds a pseudorandom
+memory offset from `gas()` and also copies `codesize()` bytes; changing generated code
+can select a more expensive stress path even when the library itself gets cheaper.
+Keep those per-call changes visible instead of treating their sum as isolated library
+cost. They are separate from the fixed
+hex and exhaustive single-byte workloads, so aggregate results cannot hide the
+original gaps.
+
+`solady-algorithms` uses [`Algorithms.sol`](../../testdata/runtime/Algorithms.sol) with unchanged pinned
+LibString, LibSort and Base64 sources. Its 85 calls cover unsigned decimal digit
+boundaries, signed limits, insertion and quicksort lengths around their cutoff,
+sorted/reversed/equal/nonuniform arrays, and padded Base64 tails. Return values
+are checked separately from gas measurements; the wrappers contain no assertions
+or gas-dependent memory stress.
+
+`solady-encoding` uses [`Encoding.sol`](../../testdata/runtime/Encoding.sol) with the same pinned Solady
+library and ordinary ABI calls. It measures both hex prefix modes and ASCII
+classification over nonuniform inputs of 0, 1, 15, 16, 31, 32, 33, 63, 64, 65,
+and 256 bytes, plus high-bit bytes at the beginning, word boundary, and end.
+Additional boundaries extend through 1024 bytes, including long all-ASCII scans
+and high-bit bytes near both ends. All 153 calls compare their returned values
+against solc. This isolates encoding
+and ABI costs from upstream assertions and memory brutalization; keep both cases
+in reports, since they exercise different behavior.
+
 The three additional micro contracts (`../../testdata/Arithmetic.sol`,
 `../../testdata/Factorial.sol`, and `../../testdata/SumArray.sol`) came from the benchmark repository at the commit above. The
 runtime suite reuses the existing `../../testdata/Counter.sol` source from the normal benchmark
 suite. The Aave harness is embedded in `../../testdata/projects/aave-l2-encoder.json.gz`.
 `fixtures/runtime/RuntimeFixtures.sol` provides local Apache-2.0 helpers with the same interfaces
 used by the cold-path workloads. Embedded Solidity sources retain their SPDX identifiers.
+
+`verified-words` is a synthetic workload in `../../testdata/runtime/VerifiedWords.sol`
+for the SMT-checked word rules. It measures mixed bitwise expressions and signed
+negation in hot loops, with edge-value return checks. Report its results
+separately from the pinned project corpus; it demonstrates targeted reductions,
+not a general advantage over solc.
+
+`compiler-optimizations` uses the local
+`../../testdata/runtime/CompilerOptimizations.sol` workload to exercise aggregate SSA
+across branches and loops, joined bounds, shared constant-argument helpers,
+packed storage updates, and overwrites on both branch arms. It measures both
+fresh and repeated writes and checks returned values and final storage against
+solc. It is a focused regression workload; retain the project corpus comparison
+when evaluating its improvements.
+
+`word-recipes` uses `../../testdata/runtime/WordRecipes.sol` to measure mixed arithmetic,
+common-mask factoring, packed-byte extraction and a deployment/runtime tradeoff
+for a large comparison constant. Keep its targeted hot-loop results separate from
+the pinned projects and compare both optimization objectives.
+
+`seeded-words` uses `../../testdata/runtime/SeededWords.sol` for mixed bitwise
+subtraction, complemented arithmetic and mask absorption discovered from the
+offline seed trees. It checks zero iterations and
+wrapping inputs as well as hot loops. These targeted results are separate from
+the pinned project corpus and do not establish general superiority over solc.

--- a/benches/runtime/benchmark.py
+++ b/benches/runtime/benchmark.py
@@ -307,6 +307,7 @@ def compiler_input(
                 test_case.source,
                 test_case.contract_name,
                 test_case.settings_profile,
+                test_case.source_code,
             )
             timeout = 180
     else:
@@ -447,10 +448,20 @@ def write_artifacts(
 
 
 def project_standard_json_input(
-    project_file: str, source: str, contract_name: str, settings_profile: str = ""
+    project_file: str,
+    source: str,
+    contract_name: str,
+    settings_profile: str = "",
+    source_code: str | None = None,
 ) -> str:
     path = PROJECTS_ROOT / project_file
     project = load_project(path)
+    if source_code is not None:
+        # Keep the pinned archive cache intact when adding a benchmark wrapper.
+        project = {
+            **project,
+            "sources": {**project["sources"], source: {"content": source_code}},
+        }
     if settings_profile == "runtime":
         project_settings = project["settings"]
         settings = {

--- a/benches/runtime/cases.py
+++ b/benches/runtime/cases.py
@@ -22,6 +22,84 @@ EDGE_BYTES32 = "0x" + "ff" * 31 + "f0"
 MIXED_BYTES32 = "0x" + "ff" * 30 + "0000"
 SIGNED_HASH = "0x7d768af957ef8cbf6219a37e743d5546d911dae3e46449d8a5810522db2ef65e"
 
+# Exercise both array iteration and bytes tails around the ABI word boundary.
+GOVERNOR_PROPOSALS = tuple(
+    (
+        f"hash-proposal-{length}-elements",
+        (
+            "[" + ",".join(f"0x{i + 1:040x}" for i in range(length)) + "]",
+            "[" + ",".join(str(i) for i in range(length)) + "]",
+            "["
+            + ",".join("0x" + "42" * (0, 1, 31, 32, 33)[i % 5] for i in range(length))
+            + "]",
+            "0x" + "42" * 32,
+        ),
+    )
+    for length in (1, 2, 8)
+)
+
+
+# Nonuniform bytes exercise both nibbles and the ABI/loop word boundaries.
+ENCODING_INPUTS = tuple(
+    (f"mixed-{length}", "0x" + bytes((i * 37 + 11) % 256 for i in range(length)).hex())
+    for length in (0, 1, 15, 16, 31, 32, 33, 63, 64, 65, 256)
+) + (
+    ("ascii-65", "0x" + "41" * 65),
+    ("high-first", "0x80" + "41" * 64),
+    ("high-boundary", "0x" + "41" * 31 + "80" + "41" * 33),
+    ("high-tail", "0x" + "41" * 64 + "80"),
+)
+# Additional boundaries and long scans are checked independently of the original
+# short-input tuning set, using a different nonuniform byte pattern.
+ENCODING_INPUTS += tuple(
+    (f"boundary-{length}", "0x" + bytes((i * 73 + 19) % 256 for i in range(length)).hex())
+    for length in (2, 7, 8, 17, 47, 95, 127, 128, 129, 255, 257, 511, 512, 513, 1023, 1024)
+) + tuple(
+    (f"ascii-{length}", "0x" + "41" * length)
+    for length in (0, 1, 2, 31, 32, 33, 63, 64, 127, 128, 129, 256, 257, 1024)
+) + tuple(
+    (f"high-{position}-{length}", "0x" + "41" * offset + "80" + "41" * (length - offset - 1))
+    for length in (257, 1024)
+    for position, offset in (("first", 0), ("boundary", 31), ("tail", length - 1))
+)
+
+
+# Isolated decimal and sorting calls avoid upstream assertions and gas-dependent
+# memory stress. Use the same inputs for timing and return-value comparison.
+ALGORITHM_INPUTS = tuple(
+    (f"decimal-{value}", "decimal(uint256)", "string", str(value))
+    for value in (
+        0, 1, 9, 10, 99, 100, (1 << 64) - 1, 10**31 - 1, 10**31,
+        (1 << 255) - 1, (1 << 256) - 1,
+    )
+) + tuple(
+    (f"signed-{value}", "signedDecimal(int256)", "string", str(value))
+    for value in (-1, -10, -(1 << 255), 0, 1, (1 << 255) - 1)
+) + tuple(
+    (
+        f"{method}-{pattern}-{length}",
+        f"{method}(uint256[])",
+        "uint256[]",
+        "[" + ",".join(map(str, values)) + "]",
+    )
+    for length in (0, 1, 2, 4, 12, 13, 32, 64)
+    for pattern, values in (
+        ("sorted", range(length)),
+        ("reversed", range(length - 1, -1, -1)),
+        ("equal", [1] * length),
+        ("mixed", [(i * 73 + 7) % 37 for i in range(length)]),
+    )
+    for method in ("insertion", "sort")
+) + tuple(
+    (label, "decode(string)", "bytes", value)
+    for label, value in (
+        ("base64-empty", ""),
+        ("base64-one", "YQ=="),
+        ("base64-three", "YWJj"),
+        ("base64-long", "YWJj" * 32),
+    )
+)
+
 
 @dataclass(frozen=True)
 class RuntimeCheck:
@@ -124,6 +202,93 @@ TEST_CASES: Sequence[TestCase] = (
         ),
         source_name="Arithmetic.sol",
         runtime_checks=(RuntimeCheck("value", "value()(uint256)"),),
+    ),
+    TestCase(
+        test_id="verified-words",
+        description="Synthetic bitwise and signed arithmetic loops for verified rules",
+        source_code=(TESTDATA_ROOT / "runtime/VerifiedWords.sol").read_text(),
+        source_name="VerifiedWords.sol",
+        contract_name="VerifiedWords",
+        gas_calls=(
+            GasCall("mix", "mix(uint256,uint256,uint256)", ("32769", "65408", "64")),
+            GasCall("merge", "merge(uint256,uint256,uint256)", ("32769", "65408", "64")),
+            GasCall("negate", "negate(uint256,uint256)", (str(1 << 255), "64")),
+        ),
+        runtime_checks=(
+            RuntimeCheck("mix", "mix(uint256,uint256,uint256)(uint256)", ("32769", "65408", "64")),
+            RuntimeCheck("merge", "merge(uint256,uint256,uint256)(uint256)", ("32769", "65408", "64")),
+            RuntimeCheck("negate", "negate(uint256,uint256)(uint256)", (str(1 << 255), "64")),
+            RuntimeCheck("zero-rounds", "mix(uint256,uint256,uint256)(uint256)", (MAX_UINT256, "1", "0")),
+        ),
+    ),
+    TestCase(
+        test_id="word-recipes",
+        description="Synthetic arithmetic, factoring, byte extraction and bounded comparisons",
+        source_code=(TESTDATA_ROOT / "runtime/WordRecipes.sol").read_text(),
+        source_name="WordRecipes.sol",
+        contract_name="WordRecipes",
+        gas_calls=(
+            GasCall("mixed", "mixed(uint256,uint256,uint256)", ("32769", "65408", "64")),
+            GasCall("factored", "factored(uint256,uint256,uint256,uint256)", ("32769", "65408", MAX_UINT256, "64")),
+            GasCall("packed", "packed(uint256,uint256)", (MAX_UINT256, "64")),
+            GasCall("bounded", "bounded(uint256)", (str((1 << 160) - 1),)),
+        ),
+        runtime_checks=(
+            RuntimeCheck("mixed", "mixed(uint256,uint256,uint256)(uint256)", ("32769", "65408", "64")),
+            RuntimeCheck("factored", "factored(uint256,uint256,uint256,uint256)(uint256)", ("32769", "65408", MAX_UINT256, "64")),
+            RuntimeCheck("packed", "packed(uint256,uint256)(uint256)", (MAX_UINT256, "64")),
+            RuntimeCheck("bounded-max", "bounded(uint256)(bool)", (str((1 << 160) - 1),)),
+            RuntimeCheck("bounded-overflow", "bounded(uint256)(bool)", (str(1 << 160),)),
+        ),
+    ),
+    TestCase(
+        test_id="seeded-words",
+        description="Synthetic mixed-word reductions found by seeded discovery",
+        source_code=(TESTDATA_ROOT / "runtime/SeededWords.sol").read_text(),
+        source_name="SeededWords.sol",
+        contract_name="SeededWords",
+        gas_calls=tuple(
+            GasCall(name, f"{name}(uint256,uint256,uint256)", ("32769", "65408", "64"))
+            for name in ("difference", "sumDifference", "complement", "absorb")
+        ),
+        runtime_checks=tuple(
+            RuntimeCheck(f"{name}-{label}", f"{name}(uint256,uint256,uint256)(uint256)", args)
+            for name in ("difference", "sumDifference", "complement", "absorb")
+            for label, args in (
+                ("loop", ("32769", "65408", "64")),
+                ("wrap", (MAX_UINT256, "1", "64")),
+                ("zero", ("0", "0", "0")),
+            )
+        ),
+    ),
+    TestCase(
+        test_id="compiler-optimizations",
+        description="CFG scalars, range proofs, shared constants, and storage writes",
+        source_code=(TESTDATA_ROOT / "runtime/CompilerOptimizations.sol").read_text(),
+        source_name="CompilerOptimizations.sol",
+        contract_name="CompilerOptimizations",
+        gas_calls=(
+            GasCall("aggregate-true", "aggregate(bool,uint256)", ("true", "30"), repeat=2),
+            GasCall("aggregate-false", "aggregate(bool,uint256)", ("false", "30"), repeat=2),
+            GasCall("bounds-left", "bounds(bool,uint256,uint256)", ("true", "99", "79")),
+            GasCall("bounds-right", "bounds(bool,uint256,uint256)", ("false", "99", "79")),
+            GasCall("packed", "packed(uint8,uint8)", ("255", "128"), repeat=3),
+            GasCall("overwrite", "overwrite(bool,uint256)", ("true", "37"), repeat=3),
+            GasCall("stack-equal", "stackShape(uint256,uint256)", ("7", "7"), repeat=2),
+            GasCall("stack-different", "stackShape(uint256,uint256)", ("9", "4"), repeat=2),
+            GasCall("shared-first", "first(uint256)", ("17",)),
+            GasCall("shared-second", "second(uint256)", ("23",)),
+            GasCall("shared-third", "third(uint256)", ("31",)),
+        ),
+        runtime_checks=(
+            RuntimeCheck("aggregate", "aggregate(bool,uint256)(uint256)", ("true", "30")),
+            RuntimeCheck("bounds", "bounds(bool,uint256,uint256)(uint256)", ("false", "99", "79")),
+            RuntimeCheck("stack-shape", "stackShape(uint256,uint256)(uint256,uint256,bool)", ("9", "4")),
+            RuntimeCheck("generic", "generic(bool,uint256)(uint256)", ("true", "3")),
+            RuntimeCheck("word", "word()(uint256)"),
+            RuntimeCheck("low", "low()(uint8)"),
+            RuntimeCheck("high", "high()(uint8)"),
+        ),
     ),
     TestCase(
         test_id="uniswap-v2-pair",
@@ -746,6 +911,15 @@ TEST_CASES: Sequence[TestCase] = (
             ),
             GasCall("name", "name()", repeat=3),
             GasCall("version", "version()", repeat=3),
+            *(
+                GasCall(
+                    label,
+                    "hashProposal(address[],uint256[],bytes[],bytes32)",
+                    args,
+                    repeat=3,
+                )
+                for label, args in GOVERNOR_PROPOSALS
+            ),
         ),
         runtime_checks=(
             RuntimeCheck("name", "name()(string)"),
@@ -754,6 +928,14 @@ TEST_CASES: Sequence[TestCase] = (
                 "hash-proposal-empty",
                 "hashProposal(address[],uint256[],bytes[],bytes32)(uint256)",
                 ("[]", "[]", "[]", "0x" + "00" * 32),
+            ),
+            *(
+                RuntimeCheck(
+                    label,
+                    "hashProposal(address[],uint256[],bytes[],bytes32)(uint256)",
+                    args,
+                )
+                for label, args in GOVERNOR_PROPOSALS
             ),
         ),
         suite="large",
@@ -816,6 +998,42 @@ TEST_CASES: Sequence[TestCase] = (
             ),
             GasCall("replace-medium", "testStringReplaceMedium()", repeat=3),
             GasCall("replace-long", "testStringReplaceLong()", repeat=3),
+            GasCall("hex-bytes-no-prefix", "testBytesToHexStringNoPrefix()", repeat=3),
+            GasCall("hex-bytes", "testBytesToHexString()", repeat=3),
+            GasCall("ascii-all-bytes", "testStringIs7BitASCII()", repeat=3),
+            *(
+                GasCall(f"hex-tail-{length}", "testBytesToHexStringNoPrefix(bytes)", ("0x" + "42" * length,))
+                for length in (0, 1, 31, 32, 33, 64, 65)
+            ),
+            *(
+                GasCall(f"hex-prefixed-tail-{length}", "testBytesToHexString(bytes)", ("0x" + "ff" * length,))
+                for length in (0, 1, 31, 32, 33, 64, 65)
+            ),
+            *(
+                GasCall(label, "testStringIs7BitASCIIDifferential(bytes)", (value,))
+                for label, value in (
+                    ("ascii-empty", "0x"),
+                    ("ascii-31", "0x" + "41" * 31),
+                    ("ascii-32", "0x" + "41" * 32),
+                    ("ascii-33", "0x" + "41" * 33),
+                    ("ascii-65", "0x" + "41" * 65),
+                    ("ascii-high-first", "0x80" + "41" * 64),
+                    ("ascii-high-boundary", "0x" + "41" * 31 + "80" + "41" * 33),
+                    ("ascii-high-tail", "0x" + "41" * 64 + "80"),
+                )
+            ),
+            *(
+                GasCall(label, "testStringRuneCountDifferential(string)", (value,), repeat=3)
+                for label, value in (
+                    ("runes-empty", ""),
+                    ("runes-one", "A"),
+                    ("runes-31", "A" * 31),
+                    ("runes-32", "A" * 32),
+                    ("runes-33", "A" * 33),
+                    ("runes-utf8-two-byte", "\u03bb" * 64),
+                    ("runes-utf8-four-byte", "\U0001f600" * 64),
+                )
+            ),
         ),
         runtime_checks=(
             RuntimeCheck("serial-number", "checkIsSN(string)(bool)", ("123456789",)),
@@ -830,6 +1048,52 @@ TEST_CASES: Sequence[TestCase] = (
             ),
         ),
         suite="large",
+    ),
+    TestCase(
+        test_id="solady-encoding",
+        description="Solady hex and ASCII with ordinary ABI calls",
+        min_solc="0.8.20",
+        project="solady-0.1.26",
+        project_file="solady-0.1.26.json.gz",
+        source="Encoding.sol",
+        source_code=(TESTDATA_ROOT / "runtime/Encoding.sol").read_text(),
+        contract_name="Encoding",
+        settings_profile="runtime",
+        gas_calls=tuple(
+            GasCall(f"{name}-{label}", f"{name}(bytes)", (value,))
+            for name in ("hexNoPrefix", "hexPrefixed", "ascii")
+            for label, value in ENCODING_INPUTS
+        ),
+        runtime_checks=tuple(
+            RuntimeCheck(f"{name}-{label}", f"{name}(bytes)({result})", (value,))
+            for name, result in (
+                ("hexNoPrefix", "string"),
+                ("hexPrefixed", "string"),
+                ("ascii", "bool"),
+            )
+            for label, value in ENCODING_INPUTS
+        ),
+        suite="repository",
+    ),
+    TestCase(
+        test_id="solady-algorithms",
+        description="Solady decimal conversion, sorting and Base64 decoding",
+        min_solc="0.8.20",
+        project="solady-0.1.26",
+        project_file="solady-0.1.26.json.gz",
+        source="Algorithms.sol",
+        source_code=(TESTDATA_ROOT / "runtime/Algorithms.sol").read_text(),
+        contract_name="Algorithms",
+        settings_profile="runtime",
+        gas_calls=tuple(
+            GasCall(label, signature, (value,))
+            for label, signature, _, value in ALGORITHM_INPUTS
+        ),
+        runtime_checks=tuple(
+            RuntimeCheck(label, f"{signature}({result})", (value,))
+            for label, signature, result, value in ALGORITHM_INPUTS
+        ),
+        suite="repository",
     ),
     TestCase(
         test_id="seaport-1.6-project",

--- a/benches/runtime/test_benchmark.py
+++ b/benches/runtime/test_benchmark.py
@@ -17,11 +17,11 @@ SPEC.loader.exec_module(benchmark)
 
 class CorpusTests(unittest.TestCase):
     def test_vendored_cases_and_projects_exist(self) -> None:
-        self.assertEqual(len(benchmark.TEST_CASES), 25)
+        self.assertEqual(len(benchmark.TEST_CASES), 31)
         repository_cases = [
             case for case in benchmark.TEST_CASES if case.suite == "repository"
         ]
-        self.assertEqual(len(repository_cases), 9)
+        self.assertEqual(len(repository_cases), 11)
         heavy_cases = [case for case in benchmark.TEST_CASES if case.suite == "heavy"]
         self.assertEqual(len(heavy_cases), 9)
         for case in heavy_cases:
@@ -38,6 +38,8 @@ class CorpusTests(unittest.TestCase):
             "lilweb3-flashloan": 2,
             "lilweb3-fractional": 3,
             "maple-erc20": 2,
+            "solady-encoding": 3,
+            "solady-algorithms": 5,
         }
         for case in repository_cases:
             self.assertTrue(case.project_path.is_file(), case.test_id)
@@ -47,6 +49,7 @@ class CorpusTests(unittest.TestCase):
                     case.source,
                     case.contract_name,
                     case.settings_profile,
+                    case.source_code,
                 )
             )
             self.assertIn(case.source, payload["sources"], case.test_id)
@@ -58,6 +61,30 @@ class CorpusTests(unittest.TestCase):
                 payload["settings"]["metadata"],
                 {"appendCBOR": False, "bytecodeHash": "none"},
             )
+
+    def test_benchmark_wrapper_preserves_pinned_sources(self) -> None:
+        for test_id, count in (("solady-encoding", 153), ("solady-algorithms", 85)):
+            with self.subTest(test_id=test_id):
+                case = next(
+                    case for case in benchmark.TEST_CASES if case.test_id == test_id
+                )
+                project = benchmark.load_project(case.project_path)
+                self.assertNotIn(case.source, project["sources"])
+                payload = json.loads(benchmark.compiler_input(case, None)[0])
+                self.assertEqual(payload["sources"][case.source]["content"], case.source_code)
+                self.assertIn("src/utils/LibString.sol", payload["sources"])
+                self.assertNotIn("test/LibString.t.sol", payload["sources"])
+                for source, contents in payload["sources"].items():
+                    if source != case.source:
+                        self.assertEqual(contents, project["sources"][source])
+                self.assertNotIn(
+                    case.source, benchmark.load_project(case.project_path)["sources"]
+                )
+                self.assertEqual(len(case.gas_calls), count)
+                self.assertEqual(len(case.runtime_checks), count)
+                labels = [call.label for call in case.gas_calls]
+                self.assertEqual(len(set(labels)), count)
+                self.assertEqual(labels, [call.label for call in case.runtime_checks])
 
     def test_runtime_projects_are_loaded_by_codspeed(self) -> None:
         criterion_sources = (

--- a/testdata/runtime/Algorithms.sol
+++ b/testdata/runtime/Algorithms.sol
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+import {LibString} from "src/utils/LibString.sol";
+import {LibSort} from "src/utils/LibSort.sol";
+import {Base64} from "src/utils/Base64.sol";
+// Ordinary ABI calls isolate library work from upstream test assertions.
+contract Algorithms {
+    function decimal(uint256 x) external pure returns (string memory) {
+        return LibString.toString(x);
+    }
+
+    function signedDecimal(int256 x) external pure returns (string memory) {
+        return LibString.toString(x);
+    }
+
+    function insertion(uint256[] memory a) external pure returns (uint256[] memory) {
+        LibSort.insertionSort(a);
+        return a;
+    }
+
+    function sort(uint256[] memory a) external pure returns (uint256[] memory) {
+        LibSort.sort(a);
+        return a;
+    }
+
+    function decode(string memory x) external pure returns (bytes memory) {
+        return Base64.decode(x);
+    }
+
+}

--- a/testdata/runtime/CompilerOptimizations.sol
+++ b/testdata/runtime/CompilerOptimizations.sol
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.0;
+
+// Regression workload for scalar replacement, joined bounds, shared helpers,
+// expression scheduling, and packed/full-word storage forwarding.
+contract CompilerOptimizations {
+    struct Pair { uint256 x; uint256 y; }
+    uint256 public word;
+    uint8 public low;
+    uint8 public high;
+
+    function aggregate(bool choice, uint256 n) external pure returns (uint256) {
+        Pair memory p;
+        if (choice) p.x = 7; else p.x = 11;
+        for (uint256 i; i < n; ++i) { p.x += i; p.y += p.x; }
+        return p.y;
+    }
+
+    function bounds(bool choice, uint256 a, uint256 b) external pure returns (uint256) {
+        uint256 x;
+        if (choice) { require(a < 100); x = a; }
+        else { require(b < 80); x = b; }
+        require(x < 100);
+        return x + 1;
+    }
+
+    function packed(uint8 a, uint8 b) external {
+        low = a;
+        high = b;
+    }
+
+    function overwrite(bool choice, uint256 x) external {
+        word = x;
+        if (choice) word = x + 1; else word = x + 2;
+    }
+
+    function stackShape(uint256 a, uint256 b) external pure returns (uint256 d, uint256 next, bool equal) {
+        unchecked { d = a - b; next = d + 1; }
+        equal = a == b;
+    }
+
+    function first(uint256 x) external pure returns (uint256) { return helper(false, x); }
+    function second(uint256 x) external pure returns (uint256) { return helper(false, x); }
+    function third(uint256 x) external pure returns (uint256) { return helper(false, x); }
+    function generic(bool mode, uint256 x) external pure returns (uint256) { return helper(mode, x); }
+
+    function helper(bool mode, uint256 x) internal pure returns (uint256) {
+        if (mode) return x * x * x * x;
+        return x + 7;
+    }
+}

--- a/testdata/runtime/Encoding.sol
+++ b/testdata/runtime/Encoding.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {LibString} from "src/utils/LibString.sol";
+
+// Isolate normal ABI decoding, library execution, and return encoding from the
+// upstream test contract's assertions and deliberate memory brutalization.
+contract Encoding {
+    function hexNoPrefix(bytes memory input) external pure returns (string memory) {
+        return LibString.toHexStringNoPrefix(input);
+    }
+
+    function hexPrefixed(bytes memory input) external pure returns (string memory) {
+        return LibString.toHexString(input);
+    }
+
+    function ascii(bytes memory input) external pure returns (bool) {
+        return LibString.is7BitASCII(string(input));
+    }
+}

--- a/testdata/runtime/SeededWords.sol
+++ b/testdata/runtime/SeededWords.sol
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.0;
+
+// Targeted loops for seeded discovery; measure project workloads separately.
+contract SeededWords {
+    function difference(uint256 x, uint256 y, uint256 rounds) external pure returns (uint256) {
+        assembly {
+            for { let i := 0 } lt(i, rounds) { i := add(i, 1) } {
+                x := sub(or(x, y), and(x, y))
+                y := add(y, i)
+            }
+        }
+        return x;
+    }
+
+    function sumDifference(uint256 x, uint256 y, uint256 rounds) external pure returns (uint256) {
+        assembly {
+            for { let i := 0 } lt(i, rounds) { i := add(i, 1) } {
+                x := sub(add(x, y), or(x, y))
+                y := add(y, i)
+            }
+        }
+        return x;
+    }
+
+    function complement(uint256 x, uint256 y, uint256 rounds) external pure returns (uint256) {
+        assembly {
+            for { let i := 0 } lt(i, rounds) { i := add(i, 1) } {
+                x := not(add(x, not(y)))
+                y := add(y, i)
+            }
+        }
+        return x;
+    }
+
+    function absorb(uint256 x, uint256 y, uint256 rounds) external pure returns (uint256) {
+        assembly {
+            for { let i := 0 } lt(i, rounds) { i := add(i, 1) } {
+                x := and(x, not(and(x, y)))
+                y := add(y, i)
+            }
+        }
+        return x;
+    }
+}

--- a/testdata/runtime/VerifiedWords.sol
+++ b/testdata/runtime/VerifiedWords.sol
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.0;
+
+// Synthetic hot loops for the source-verified word rules. Keep this separate
+// from project workloads so a targeted rule win cannot hide corpus regressions.
+contract VerifiedWords {
+    function mix(uint256 x, uint256 y, uint256 rounds) external pure returns (uint256) {
+        assembly {
+            for { let i := 0 } lt(i, rounds) { i := add(i, 1) } {
+                x := xor(or(x, y), and(x, y))
+                y := add(y, 0x9e3779b9)
+            }
+        }
+        return x;
+    }
+
+    function merge(uint256 x, uint256 y, uint256 rounds) external pure returns (uint256) {
+        assembly {
+            for { let i := 0 } lt(i, rounds) { i := add(i, 1) } {
+                x := xor(and(x, y), xor(x, y))
+                y := add(shl(1, y), i)
+            }
+        }
+        return x;
+    }
+
+    function negate(uint256 x, uint256 rounds) external pure returns (uint256) {
+        assembly {
+            for { let i := 0 } lt(i, rounds) { i := add(i, 1) } {
+                x := add(sdiv(x, not(0)), i)
+            }
+        }
+        return x;
+    }
+}

--- a/testdata/runtime/WordRecipes.sol
+++ b/testdata/runtime/WordRecipes.sol
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.0;
+
+// Keep these targeted loops separate from the pinned project corpus.
+contract WordRecipes {
+    function mixed(uint256 x, uint256 y, uint256 rounds) external pure returns (uint256) {
+        assembly {
+            for { let i := 0 } lt(i, rounds) { i := add(i, 1) } {
+                x := add(and(x, y), or(x, y))
+                y := add(y, 0x9e3779b9)
+            }
+        }
+        return x;
+    }
+
+    function factored(uint256 x, uint256 y, uint256 mask, uint256 rounds) external pure returns (uint256) {
+        assembly {
+            for { let i := 0 } lt(i, rounds) { i := add(i, 1) } {
+                x := or(and(x, mask), and(y, mask))
+                y := add(y, i)
+                mask := xor(mask, x)
+            }
+        }
+        return x;
+    }
+
+    function packed(uint256 x, uint256 rounds) external pure returns (uint256 result) {
+        assembly {
+            for { let i := 0 } lt(i, rounds) { i := add(i, 1) } {
+                result := add(result, and(shr(160, x), 255))
+                x := add(shl(1, x), i)
+            }
+        }
+    }
+
+    function bounded(uint256 x) external pure returns (bool) { return x < 1 << 160; }
+}


### PR DESCRIPTION
Add isolated Solady encoding and algorithm calls, synthetic word and storage cases, and Governor and LibString boundary workloads. Keep the local Solidity fixtures in testdata/runtime and reuse pinned upstream archives without modifying their sources.

Separate these workloads from optimizer changes so gas comparisons use the same calls on both revisions. Preserve per-call checks for both ordinary ABI inputs and upstream memory stress cases.