### PR TITLE
perf(lsp): speed up member and position queries

### DIFF
--- a/crates/lsp/benches/lsp.rs
+++ b/crates/lsp/benches/lsp.rs
@@ -214,6 +214,37 @@ fn completion_queries(c: &mut Criterion) {
     group.finish();
 }
 
+fn member_completion_queries(c: &mut Criterion) {
+    let mut group = c.benchmark_group("lsp/member-completion");
+    for access_count in [64, 256, 1024] {
+        let mut source = String::from(
+            "contract Benchmark {\nstruct Value { uint256 field; }\nfunction exercise(Value memory value) public pure returns (uint256 result) {\n",
+        );
+        for index in 0..access_count {
+            writeln!(source, "    result += value.field; // {index}").unwrap();
+        }
+        source.push_str("}\n}\n");
+        let project = BenchmarkProject::from_source(source);
+        let anchor = format!("value.field; // {}", access_count - 1);
+        let (uri, mut position) = project.unique_anchor("benchmark.sol", &anchor).unwrap();
+        position.character += "value.field".len() as u32;
+        let analysis = project.analyze();
+        assert_clean(&analysis);
+        let items = analysis.completions(&uri, position, "field");
+        assert_eq!(items.iter().map(|item| item.label.as_str()).collect::<Vec<_>>(), ["field"]);
+        group.bench_function(BenchmarkId::from_parameter(access_count), |b| {
+            b.iter(|| {
+                black_box(analysis.completions(
+                    black_box(&uri),
+                    black_box(position),
+                    black_box("field"),
+                ))
+            });
+        });
+    }
+    group.finish();
+}
+
 fn signature_help_requests(c: &mut Criterion) {
     let mut group = c.benchmark_group("lsp/signature-help");
     for function_count in [64, 256, 1024] {
@@ -571,6 +602,42 @@ fn open_document_selection_range(c: &mut Criterion) {
     }
     group.finish();
 
+    let mut lines = c.benchmark_group("lsp/open-document-selection-range-line-layout");
+    for (name, separator, comment) in [
+        ("minified-ascii", " ", ""),
+        ("minified-unicode", " ", "/* 😀 */"),
+        ("multiline", "\n", ""),
+    ] {
+        let mut source = String::from("contract LineLayout {");
+        for index in 0..1024 {
+            write!(
+                source,
+                "{separator}{comment}function f{index}() external pure returns(uint){{return 123456;}}"
+            )
+            .unwrap();
+        }
+        source.push('}');
+        let literal_start = source.rfind("123456").unwrap();
+        let positions = [position_at(&source, literal_start + 2)];
+        let expected = benchmark_selection_ranges(source.clone(), &positions)
+            .expect("the benchmark position should be valid");
+        assert_eq!(
+            expected[0].range,
+            lsp_types::Range::new(
+                position_at(&source, literal_start),
+                position_at(&source, literal_start + "123456".len()),
+            )
+        );
+        assert!(expected[0].parent.is_some());
+        lines.throughput(Throughput::Bytes(source.len() as u64));
+        let requests = BenchmarkSelectionRangeRequests::new(source, positions);
+        assert_eq!(requests.run(), Some(expected));
+        lines.bench_function(BenchmarkId::from_parameter(name), |b| {
+            b.iter(|| black_box(black_box(&requests).run()));
+        });
+    }
+    lines.finish();
+
     let mut cold = c.benchmark_group("lsp/open-document-selection-range-cold");
     cold.throughput(Throughput::Bytes(OPTIMISM_SOURCE.len() as u64));
     cold.bench_function(BenchmarkId::from_parameter("optimism"), |b| {
@@ -879,6 +946,7 @@ criterion_group!(
     benches,
     analysis_build,
     completion_queries,
+    member_completion_queries,
     signature_help_requests,
     code_lens_queries,
     type_hierarchy_queries,

--- a/crates/lsp/src/proto.rs
+++ b/crates/lsp/src/proto.rs
@@ -171,7 +171,7 @@ impl<R: Borrow<Rope>> LspPositionIndex<R> {
         range: lsp_types::Range,
     ) -> Option<std::ops::Range<usize>> {
         let start = self.byte_position(range.start)?;
-        let end = self.byte_position(range.end)?;
+        let end = if range.start == range.end { start } else { self.byte_position(range.end)? };
         (start <= end).then_some(start..end)
     }
 
@@ -197,9 +197,14 @@ impl<R: Borrow<Rope>> LspPositionIndex<R> {
         let start = *self.line_starts.get(line)?;
         let end = self.line_end(line);
         let target = usize::try_from(position.character).ok()?;
+        let contents = rope.byte_slice(start..end);
+        // ASCII lines use one UTF-16 code unit per byte.
+        if contents.byte_len() == contents.utf16_len() {
+            return Some(start + target.min(contents.byte_len()));
+        }
         let mut utf16 = 0;
         let mut byte = start;
-        for ch in rope.byte_slice(start..end).chars() {
+        for ch in contents.chars() {
             if utf16 == target {
                 return Some(byte);
             }
@@ -217,8 +222,7 @@ impl<R: Borrow<Rope>> LspPositionIndex<R> {
         let rope = self.rope();
         let line = self.line_at_byte(byte)?;
         let start = self.line_starts[line];
-        let character =
-            rope.byte_slice(start..byte).chars().map(|ch| ch.len_utf16()).sum::<usize>();
+        let character = rope.byte_slice(start..byte).utf16_len();
         Some(lsp_types::Position::new(u32::try_from(line).ok()?, u32::try_from(character).ok()?))
     }
 
@@ -733,6 +737,10 @@ mod tests {
             checked_text_range(&rope, Range::new(Position::new(1, 0), Position::new(1, 0)),)
                 .is_none()
         );
+        assert!(
+            checked_text_range(&rope, Range::new(Position::new(0, 1), Position::new(0, 1)),)
+                .is_none()
+        );
     }
 
     #[test]
@@ -745,6 +753,39 @@ mod tests {
                     Range::new(Position::new(0, character), Position::new(0, character)),
                 ),
                 Some(5..5)
+            );
+        }
+    }
+
+    #[test]
+    fn checked_text_range_handles_ascii_lines_after_unicode() {
+        let ascii = "value ".repeat(1024);
+        for ending in ["\n", "\r\n", "\r"] {
+            let prefix = format!("😀{ending}");
+            let source = format!("{prefix}{ascii}{ending}");
+            let rope = Rope::from(source.as_str());
+            let index = super::LspPositionIndex::new(&rope);
+            for character in [0, 1, 1023, ascii.len() as u32, u32::MAX] {
+                let position = Position::new(1, character);
+                let byte = prefix.len() + (character as usize).min(ascii.len());
+                assert_eq!(
+                    index.checked_text_range(Range::new(position, position)),
+                    Some(byte..byte)
+                );
+            }
+            assert_eq!(
+                index.checked_text_range(Range::new(Position::new(1, 1), Position::new(1, 5))),
+                Some(prefix.len() + 1..prefix.len() + 5)
+            );
+            assert!(
+                index
+                    .checked_text_range(Range::new(Position::new(1, 5), Position::new(1, 1)))
+                    .is_none()
+            );
+            assert!(
+                index
+                    .checked_text_range(Range::new(Position::new(1, 0), Position::new(3, 0)))
+                    .is_none()
             );
         }
     }
@@ -818,6 +859,31 @@ mod tests {
         assert!(position_at_byte(&rope, 2).is_none());
         assert!(position_at_byte(&rope, 9).is_none());
         assert!(position_at_byte(&rope, rope.byte_len() + 1).is_none());
+    }
+
+    #[test]
+    fn position_at_byte_matches_utf16_columns_across_rope_chunks() {
+        let long_line = "xé中😀".repeat(512);
+        for ending in ["\n", "\r\n", "\r"] {
+            let lines = ["preceding😀", long_line.as_str(), ""];
+            let source = lines.join(ending);
+            let rope = Rope::from(source.as_str());
+            let index = super::LspPositionIndex::new(&rope);
+            let mut start = 0;
+            for (line, text) in lines.into_iter().enumerate() {
+                for byte in 0..=text.len() {
+                    let expected = text.get(..byte).map(|prefix| {
+                        Position::new(line as u32, prefix.encode_utf16().count() as u32)
+                    });
+                    assert_eq!(index.position_at_byte(start + byte), expected);
+                }
+                if ending == "\r\n" && line + 1 < lines.len() {
+                    assert!(index.position_at_byte(start + text.len() + 1).is_none());
+                }
+                start += text.len() + ending.len();
+            }
+            assert!(index.position_at_byte(source.len() + 1).is_none());
+        }
     }
 
     #[test]

--- a/crates/lsp/src/symbols.rs
+++ b/crates/lsp/src/symbols.rs
@@ -62,7 +62,7 @@ pub(crate) struct SymbolTables {
     builtin_member_completions: FxHashMap<String, Vec<CompletionItem>>,
     receiver_member_completions: FxHashMap<SymbolId, Arc<[CompletionItem]>>,
     member_completions: Vec<MemberCompletionScope>,
-    file_member_completions: FxHashMap<Url, Vec<usize>>,
+    file_member_completions: FxHashMap<Url, PositionIndex<usize>>,
     file_scopes: FxHashMap<Url, Vec<ScopeId>>,
     references: Vec<SymbolReference>,
     file_references: FxHashMap<Url, PositionIndex<usize>>,
@@ -268,6 +268,15 @@ impl<T: Copy> PositionIndex<T> {
         position: Position,
         range: impl Fn(T) -> Range + Copy + 'a,
     ) -> impl Iterator<Item = T> + 'a {
+        self.candidates_at_with(position, range, proto::range_contains)
+    }
+
+    fn candidates_at_with<'a>(
+        &'a self,
+        position: Position,
+        range: impl Fn(T) -> Range + Copy + 'a,
+        contains: impl Fn(Range, Position) -> bool + 'a,
+    ) -> impl Iterator<Item = T> + 'a {
         let end = self.entries.partition_point(|&entry| range(entry).start <= position);
         self.entries[..end]
             .iter()
@@ -275,7 +284,7 @@ impl<T: Copy> PositionIndex<T> {
             .zip(self.prefix_max_end[..end].iter().copied())
             .rev()
             .take_while(move |(_, prefix_max_end)| *prefix_max_end >= position)
-            .filter(move |&(entry, _)| proto::range_contains(range(entry), position))
+            .filter(move |&(entry, _)| contains(range(entry), position))
             .map(|(entry, _)| entry)
     }
 }
@@ -1000,7 +1009,9 @@ impl SymbolTables {
         position: Position,
         context: CompletionContext<'_>,
     ) -> Vec<CompletionItem> {
-        if let Some(items) = self.member_completion_items(uri, position) {
+        if !self.member_completions.is_empty()
+            && let Some(items) = self.member_completion_items(uri, position)
+        {
             return filtered_completion_items(items, context.prefix);
         }
         if let Some(items) = self.builtin_member_completion_items(context.member_receiver) {
@@ -1588,16 +1599,29 @@ impl SymbolTables {
     }
 
     fn member_completion_items(&self, uri: &Url, position: Position) -> Option<&[CompletionItem]> {
-        let completion = self
-            .file_member_completions
-            .get(uri)?
-            .iter()
-            .filter_map(|&index| {
-                let completion = &self.member_completions[index];
-                completion_range_contains(completion.range, position).then_some(completion)
-            })
-            .min_by_key(|completion| proto::range_size_key(completion.range))?;
-        Some(&completion.items)
+        let completions = self.file_member_completions.get(uri)?;
+        self.member_completion_items_at(completions, position)
+    }
+
+    // Keep interval traversal and its stack state out of the map-lookup wrapper.
+    #[inline(never)]
+    fn member_completion_items_at(
+        &self,
+        completions: &PositionIndex<usize>,
+        position: Position,
+    ) -> Option<&[CompletionItem]> {
+        let index = completions
+            .candidates_at_with(
+                position,
+                |index| self.member_completions[index].range,
+                completion_range_contains,
+            )
+            .min_by_key(|&index| {
+                let range = self.member_completions[index].range;
+                // Preserve the stable source order when equally small ranges overlap.
+                (proto::range_size_key(range), range.start, range.end, index)
+            })?;
+        Some(&self.member_completions[index].items)
     }
 
     fn builtin_member_completion_items(&self, receiver: Option<&str>) -> Option<&[CompletionItem]> {
@@ -1729,10 +1753,7 @@ impl SymbolTables {
             self.file_member_completions.entry(completion.uri.clone()).or_default().push(index);
         }
         for completions in self.file_member_completions.values_mut() {
-            completions.sort_by_key(|&index| {
-                let range = self.member_completions[index].range;
-                (range.start.line, range.start.character, range.end.line, range.end.character)
-            });
+            completions.rebuild(|index| self.member_completions[index].range);
         }
 
         self.file_references.clear();
@@ -2892,6 +2913,55 @@ mod tests {
             tables.reference_at_position(&uri, Position::new(4, 2)).unwrap().targets,
             ReferenceTargets::from_buf([point])
         );
+    }
+
+    #[test]
+    fn member_completion_lookups_preserve_endpoints_and_overlap_order() {
+        let uri = parse_uri("file:///workspace/src/Contract.sol");
+        let mut tables = SymbolTables::default();
+        for (label, range) in [
+            ("later", range(1, 2, 1, 6)),
+            ("outer", range(0, 0, 4, 0)),
+            ("earlier", range(1, 0, 1, 4)),
+            ("point", range(2, 3, 2, 3)),
+        ] {
+            tables.member_completions.push(MemberCompletionScope {
+                uri: uri.clone(),
+                range,
+                items: Arc::from([CompletionItem { label: label.into(), ..Default::default() }]),
+            });
+        }
+        tables.rebuild_indexes();
+
+        let mut duplicate = SymbolTables::default();
+        duplicate.member_completions.push(MemberCompletionScope {
+            uri: uri.clone(),
+            range: range(1, 0, 1, 4),
+            items: Arc::from([CompletionItem { label: "duplicate".into(), ..Default::default() }]),
+        });
+        duplicate.rebuild_indexes();
+        let mut aggregator = SymbolTablesAggregator::default();
+        aggregator.push(tables);
+        aggregator.push(duplicate);
+        let tables = aggregator.finish();
+
+        for (position, expected) in [
+            (Position::new(0, 0), Some("outer")),
+            (Position::new(1, 0), Some("earlier")),
+            (Position::new(1, 3), Some("earlier")),
+            (Position::new(1, 4), Some("earlier")),
+            (Position::new(1, 5), Some("later")),
+            (Position::new(1, 6), Some("later")),
+            (Position::new(2, 3), Some("point")),
+            (Position::new(4, 0), Some("outer")),
+            (Position::new(4, 1), None),
+        ] {
+            assert_eq!(
+                tables.member_completion_items(&uri, position).map(|items| items[0].label.as_str()),
+                expected,
+                "{position:?}",
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
Towards OSS-738 , 

- Index member completion ranges so a query can skip unrelated accesses in the file. Keep inclusive endpoints and the existing ordering for overlapping ranges.
- Use the rope's UTF-16 counts for position conversion. ASCII lines use byte offsets directly, and empty ranges convert the cursor once.
- Add member-access scaling benchmarks and ASCII/Unicode long-line fixtures, with regression coverage for range boundaries and split surrogates.


[Raw samples, confidence intervals and run logs](https://github.com/0xKarl98/solar/tree/4431dcfc446136e76e4ab87b8d02cb0efa9c4718).

![LSP query benchmarks](https://raw.githubusercontent.com/0xKarl98/solar/4431dcfc446136e76e4ab87b8d02cb0efa9c4718/lsp-performance.png)
