### PR TITLE
perf(lsp): index document symbol children

### DIFF
--- a/crates/lsp/benches/lsp.rs
+++ b/crates/lsp/benches/lsp.rs
@@ -170,6 +170,27 @@ fn code_lens_queries(c: &mut Criterion) {
     group.finish();
 }
 
+fn document_symbol_queries(c: &mut Criterion) {
+    let mut group = c.benchmark_group("lsp/document-symbol");
+    for function_count in [256, 1_024] {
+        let fixture = benchmark_source(function_count);
+        let (uri, _) = fixture
+            .project
+            .unique_anchor("benchmark.sol", "contract Benchmark")
+            .expect("the document-symbol anchor should be unique");
+        let analysis = fixture.project.analyze();
+        assert_clean(&analysis);
+        let symbols = analysis.document_symbols(&uri);
+        assert_eq!(symbols.len(), 1);
+        assert_eq!(symbols[0].children.as_ref().map_or(0, Vec::len), function_count + 1);
+        group.throughput(Throughput::Elements(function_count as u64));
+        group.bench_function(BenchmarkId::from_parameter(function_count), |b| {
+            b.iter(|| black_box(analysis.document_symbols(black_box(&uri))));
+        });
+    }
+    group.finish();
+}
+
 fn import_path_queries(c: &mut Criterion) {
     let mut group = c.benchmark_group("lsp/import-path");
     let cursor = OPTIMISM_SOURCE.rfind('}').unwrap();
@@ -881,6 +902,7 @@ criterion_group!(
     completion_queries,
     signature_help_requests,
     code_lens_queries,
+    document_symbol_queries,
     type_hierarchy_queries,
     call_hierarchy_queries,
     import_path_queries,

--- a/crates/lsp/src/global_state/benchmark.rs
+++ b/crates/lsp/src/global_state/benchmark.rs
@@ -22,10 +22,10 @@ use async_lsp::ClientSocket;
 use crop::Rope;
 use lsp_types::{
     CallHierarchyIncomingCall, CodeLens, CompletionItem, Diagnostic, DidChangeTextDocumentParams,
-    GotoDefinitionResponse, Hover, HoverContents, Location, Position, PreviousResultId, Range,
-    SignatureHelp, SignatureHelpParams, TextDocumentContentChangeEvent, TextDocumentIdentifier,
-    TextDocumentPositionParams, TypeHierarchyItem, Url, VersionedTextDocumentIdentifier,
-    WorkspaceFolder, WorkspaceSymbol,
+    DocumentSymbol, GotoDefinitionResponse, Hover, HoverContents, Location, Position,
+    PreviousResultId, Range, SignatureHelp, SignatureHelpParams, TextDocumentContentChangeEvent,
+    TextDocumentIdentifier, TextDocumentPositionParams, TypeHierarchyItem, Url,
+    VersionedTextDocumentIdentifier, WorkspaceFolder, WorkspaceSymbol,
 };
 use normalize_path::NormalizePath;
 use solar_config::{CompileOpts, Threads};
@@ -957,6 +957,12 @@ impl BenchmarkAnalysis {
             uri,
             crate::config::CodeLensConfig { client_commands: true, ..Default::default() },
         )
+    }
+
+    /// Build hierarchical document symbols for one analyzed source file.
+    #[inline(never)]
+    pub fn document_symbols(&self, uri: &Url) -> Vec<DocumentSymbol> {
+        self.symbol_tables.document_symbols(uri)
     }
 
     /// Complete names at a source position without protocol transport or parsing.

--- a/crates/lsp/src/symbols.rs
+++ b/crates/lsp/src/symbols.rs
@@ -55,6 +55,7 @@ pub(crate) struct SymbolTables {
     type_definitions: FxHashMap<SymbolId, TypeDefinitionTargets>,
     files: FxHashMap<Url, Vec<SymbolId>>,
     file_declaration_positions: FxHashMap<Url, PositionIndex<SymbolId>>,
+    document_symbol_children: IndexVec<SymbolId, Vec<SymbolId>>,
     workspace_symbol_ids: Vec<SymbolId>,
     symbols_by_key: FxHashMap<SymbolKey, SymbolId>,
     scopes: IndexVec<ScopeId, Scope>,
@@ -652,18 +653,6 @@ impl SymbolTables {
             return Vec::new();
         };
 
-        let mut child_symbols = FxHashMap::<SymbolId, Vec<SymbolId>>::with_capacity_and_hasher(
-            file_symbol_ids.len(),
-            Default::default(),
-        );
-        for &symbol_id in file_symbol_ids {
-            if let Some(parent) = self.declarations[symbol_id].parent
-                && self.declarations[parent].location.uri == *uri
-            {
-                child_symbols.entry(parent).or_default().push(symbol_id);
-            }
-        }
-
         file_symbol_ids
             .iter()
             .copied()
@@ -672,7 +661,7 @@ impl SymbolTables {
                     .parent
                     .is_none_or(|parent| self.declarations[parent].location.uri != *uri)
             })
-            .map(|symbol_id| self.document_symbol(symbol_id, &child_symbols))
+            .map(|symbol_id| self.document_symbol(symbol_id))
             .collect()
     }
 
@@ -1392,14 +1381,14 @@ impl SymbolTables {
         pushed_id
     }
 
-    fn document_symbol(
-        &self,
-        symbol_id: SymbolId,
-        child_symbols: &FxHashMap<SymbolId, Vec<SymbolId>>,
-    ) -> DocumentSymbol {
+    fn document_symbol(&self, symbol_id: SymbolId) -> DocumentSymbol {
         let symbol = &self.declarations[symbol_id];
-        let children = child_symbols.get(&symbol_id).map(|children| {
-            children.iter().map(|&child| self.document_symbol(child, child_symbols)).collect()
+        let children = (!self.document_symbol_children[symbol_id].is_empty()).then(|| {
+            self.document_symbol_children[symbol_id]
+                .iter()
+                .copied()
+                .map(|child| self.document_symbol(child))
+                .collect()
         });
 
         DocumentSymbol {
@@ -1705,6 +1694,22 @@ impl SymbolTables {
             positions.entries.extend(symbols.iter().copied());
             positions.rebuild(|symbol_id| self.declarations[symbol_id].name_range);
             self.file_declaration_positions.insert(uri.clone(), positions);
+        }
+
+        self.document_symbol_children.clear();
+        self.document_symbol_children.reserve(self.declarations.len());
+        for _ in self.declarations.indices() {
+            self.document_symbol_children.push(Vec::new());
+        }
+        for symbols in self.files.values() {
+            for &symbol_id in symbols {
+                if let Some(parent) = self.declarations[symbol_id].parent
+                    && self.declarations[parent].location.uri
+                        == self.declarations[symbol_id].location.uri
+                {
+                    self.document_symbol_children[parent].push(symbol_id);
+                }
+            }
         }
 
         self.workspace_symbol_ids.clear();


### PR DESCRIPTION
Towards OSS-738 , 

`textDocument/documentSymbol` rebuilt its parent-to-children map on every request. This change builds that relationship once when the symbol tables are rebuilt, so repeated document-symbol queries only walk the indexed children.

- Precompute same-file child lists in `SymbolTables::rebuild_indexes` with an `IndexVec<SymbolId, Vec<SymbolId>>`.
- Remove the per-request `FxHashMap` allocation and lookup path while preserving nesting, ordering, and cross-file parent filtering.
- Add a benchmark entry point and focused Criterion cases for 256 and 1,024 symbols.
- Keep the cost bounded to index rebuilds: the index adds one child vector per symbol and an O(N) rebuild step, while query-time work becomes a direct traversal.

The in-process benchmark on macOS arm64 shows:

- 256 symbols: 63.065 µs → 39.451 µs (−37.4%)
- 1,024 symbols: 234.31 µs → 159.91 µs (−31.8%)

A warm Uniswap document-symbol run moved from 4.35 ms to 4.30 ms at p50. That cross-server harness is marked non-authoritative, and protocol/JSON serialization dominates the end-to-end request, so the focused query benchmark is the relevant signal for this change.

Benchmark evidence:

![LSP documentSymbol benchmark](https://raw.githubusercontent.com/0xKarl98/solar/89c233f7ba7f5a6615e097e0bd98f6a15bea44a5/benchmarks/lsp-document-symbol-index.png)
