### PR TITLE
perf(lsp): cache CodeLens reference counts

### DIFF
--- a/crates/lsp/README.md
+++ b/crates/lsp/README.md
@@ -57,6 +57,10 @@ The benchmark groups intentionally keep separate timing boundaries:
 - `project-analysis` and `project-analysis-after-edit` measure compiler and symbol-table rebuilds.
 - `project-edit-application` measures UTF-16 document edit application without analysis.
 - `symbol-table-queries` measures synchronous query kernels, not complete LSP request latency.
+- `code-lens` measures repeated queries, including response destruction. The separate
+  `code-lens-first-request` group clones an unqueried analysis snapshot outside timing and
+  includes the first query's reference-count initialization; snapshot and response destruction
+  stay outside timing. Compare each group's results against its own baseline.
 - `open-document-selection-range` measures repeated selection queries through the VFS snapshot,
   including UTF-16 conversion and response construction. It covers start, middle, and end positions
   in an unchanged document and multiple cursors, excluding transport and blocking-pool scheduling.

--- a/crates/lsp/benches/lsp.rs
+++ b/crates/lsp/benches/lsp.rs
@@ -162,11 +162,63 @@ fn code_lens_queries(c: &mut Criterion) {
         fixture.project.unique_anchor("benchmark.sol", "function_0255(1, 2, address(0))").unwrap();
     let analysis = fixture.project.analyze();
     assert_clean(&analysis);
+    let mut first_requests = vec![("256-functions".to_owned(), analysis.clone(), uri.clone())];
     assert!(analysis.code_lenses(&uri).len() >= HOVER_FUNCTION_COUNT);
     let mut group = c.benchmark_group("lsp/code-lens");
     group.bench_function(BenchmarkId::from_parameter("256-functions"), |b| {
         b.iter(|| black_box(analysis.code_lenses(black_box(&uri))));
     });
+
+    for reference_count in [64, 1_024, 16_384] {
+        let mut source = String::from(
+            "contract RepeatedReferences {\nfunction target() internal pure {}\nfunction exercise() public pure {\n",
+        );
+        for _ in 0..reference_count {
+            source.push_str("target();\n");
+        }
+        source.push_str("}\n}\n");
+        let project = BenchmarkProject::from_source(source);
+        let (uri, position) = project.unique_anchor("benchmark.sol", "target() internal").unwrap();
+        let analysis = project.analyze();
+        assert_clean(&analysis);
+        first_requests.push((
+            format!("{reference_count}-references"),
+            analysis.clone(),
+            uri.clone(),
+        ));
+        let lenses = analysis.code_lenses(&uri);
+        assert_eq!(lenses.len(), 4);
+        assert!(lenses.iter().any(|lens| {
+            lens.range.start == position
+                && lens.command.as_ref().unwrap().title == format!("{reference_count} references")
+        }));
+        group.bench_function(
+            BenchmarkId::from_parameter(format!("{reference_count}-references")),
+            |b| b.iter(|| black_box(analysis.code_lenses(black_box(&uri)))),
+        );
+    }
+
+    let project = unifap_project();
+    let (uri, _) = project.unique_anchor(UNIFAP_PAIR, "SELECTOR").unwrap();
+    let analysis = project.analyze();
+    assert_clean(&analysis);
+    first_requests.push(("unifap-v2-pair".to_owned(), analysis.clone(), uri.clone()));
+    assert!(!analysis.code_lenses(&uri).is_empty());
+    group.bench_function(BenchmarkId::from_parameter("unifap-v2-pair"), |b| {
+        b.iter(|| black_box(analysis.code_lenses(black_box(&uri))));
+    });
+    group.finish();
+
+    let mut group = c.benchmark_group("lsp/code-lens-first-request");
+    for (name, analysis, uri) in first_requests {
+        group.bench_function(BenchmarkId::from_parameter(name), |b| {
+            b.iter_batched_ref(
+                || analysis.clone(),
+                |analysis| black_box(analysis.code_lenses(black_box(&uri))),
+                BatchSize::PerIteration,
+            );
+        });
+    }
     group.finish();
 }
 

--- a/crates/lsp/src/code_lens.rs
+++ b/crates/lsp/src/code_lens.rs
@@ -2,7 +2,9 @@
 //!
 //! The semantic analysis context is short-lived, so this module copies only the facts needed to
 //! render CodeLens items. Query-time reference locations remain owned by
-//! [`SymbolTables`](crate::symbols::SymbolTables).
+//! [`SymbolTables`](crate::symbols::SymbolTables). Distinct reference counts are cached lazily
+//! for each requested file, including counts rejected due to conflicting source snapshots.
+//! Rebuilding entries after analysis batches are merged discards those cached counts.
 
 use crate::symbols::{DeclarationSymbol, SymbolId};
 use lsp_types::{Range, Url};
@@ -15,12 +17,19 @@ use solar_sema::{
     Gcx,
     hir::{ItemId, VarKind},
 };
-use std::cmp::Ordering;
+use std::{cmp::Ordering, sync::OnceLock};
 
 #[derive(Clone, Debug, Default)]
 pub(crate) struct CodeLensIndex {
     candidates: Vec<CodeLensCandidate>,
-    entries_by_uri: FxHashMap<Url, Vec<CodeLensEntry>>,
+    entries_by_uri: FxHashMap<Url, CodeLensFile>,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct CodeLensFile {
+    pub(crate) entries: Vec<CodeLensEntry>,
+    /// Initialized only when reference lenses are requested from this immutable analysis.
+    pub(crate) reference_counts: OnceLock<Box<[Option<usize>]>>,
 }
 
 #[derive(Clone, Debug)]
@@ -124,13 +133,16 @@ impl CodeLensIndex {
             }
             if !entries.is_empty() {
                 entries.sort_unstable_by(|lhs, rhs| range_cmp(lhs.range, rhs.range));
-                self.entries_by_uri.insert(uri.clone(), entries);
+                self.entries_by_uri.insert(
+                    uri.clone(),
+                    CodeLensFile { entries, reference_counts: OnceLock::new() },
+                );
             }
         }
     }
 
-    pub(crate) fn entries(&self, uri: &Url) -> &[CodeLensEntry] {
-        self.entries_by_uri.get(uri).map_or(&[], Vec::as_slice)
+    pub(crate) fn file(&self, uri: &Url) -> Option<&CodeLensFile> {
+        self.entries_by_uri.get(uri)
     }
 }
 

--- a/crates/lsp/src/symbols.rs
+++ b/crates/lsp/src/symbols.rs
@@ -503,14 +503,23 @@ impl SymbolTables {
         if !options.enable {
             return Vec::new();
         }
+        let Some(file) = self.code_lens.file(uri) else { return Vec::new() };
+        let reference_counts = options.references.then(|| {
+            file.reference_counts.get_or_init(|| {
+                file.entries.iter().map(|entry| self.reference_count(&entry.symbol_ids)).collect()
+            })
+        });
 
-        let mut lenses = Vec::new();
-        for entry in self.code_lens.entries(uri) {
+        let mut lenses = Vec::with_capacity(
+            file.entries.len()
+                * (options.references as usize
+                    + options.selectors as usize
+                    + if options.inheritance { 2 } else { 0 }),
+        );
+        for (index, entry) in file.entries.iter().enumerate() {
             let position = entry.range.start;
 
-            if options.references
-                && let Some(count) = self.reference_count(&entry.symbol_ids)
-            {
+            if let Some(count) = reference_counts.and_then(|counts| counts[index]) {
                 let title = format_reference_title(count);
                 let (command, arguments) = if count > 0 && options.client_commands {
                     (
@@ -581,7 +590,10 @@ impl SymbolTables {
     }
 
     fn reference_count(&self, targets: &[SymbolId]) -> Option<usize> {
-        let mut locations = FxHashSet::default();
+        // Count the common zero/one-reference cases without allocating a hash set.  A set is
+        // materialized only after the first distinct location is observed.
+        let mut first = None;
+        let mut locations: Option<FxHashSet<(&Url, Range)>> = None;
         for &index in
             targets.iter().filter_map(|target| self.symbol_references.get(target)).flatten()
         {
@@ -589,9 +601,22 @@ impl SymbolTables {
             if self.rename.conflicting_contents().contains(&location.uri) {
                 return None;
             }
-            locations.insert((&location.uri, location.range));
+            let key = (&location.uri, location.range);
+            if let Some(set) = &mut locations {
+                set.insert(key);
+            } else if let Some(previous) = first {
+                if previous != key {
+                    let mut set = FxHashSet::default();
+                    set.reserve(2);
+                    set.insert(previous);
+                    set.insert(key);
+                    locations = Some(set);
+                }
+            } else {
+                first = Some(key);
+            }
         }
-        Some(locations.len())
+        Some(locations.map_or(usize::from(first.is_some()), |set| set.len()))
     }
 
     pub(crate) fn document_links(&self, path: &Path) -> Vec<lsp_types::DocumentLink> {

--- a/crates/lsp/src/tests/code_lens.rs
+++ b/crates/lsp/src/tests/code_lens.rs
@@ -1,5 +1,12 @@
-use super::support::RequestFixture;
-use snapbox::str;
+use super::{AnalysisBatch, analyze, support::RequestFixture};
+use crate::{
+    config::CodeLensConfig,
+    symbols::{SymbolTables, SymbolTablesAggregator},
+    test_support::MarkedProject,
+};
+use lsp_types::{Position, Url};
+use snapbox::{assert_data_eq, str};
+use solar_config::CompileOpts;
 
 #[test]
 fn shows_selectors_and_references() {
@@ -326,6 +333,107 @@ fn merges_reference_counts_for_imported_declarations() {
 }
 
 #[test]
+fn recomputes_warmed_reference_counts_when_merging_batches() {
+    let marked = MarkedProject::from_fixture(
+        r#"
+        //- /Shared.sol
+        library Shared {
+            function $1ping() internal pure {}
+        }
+
+        //- /First.sol
+        import "./Shared.sol";
+        library First {
+            function callFirst() internal pure { Shared.ping(); }
+        }
+
+        //- /Second.sol
+        import "./First.sol";
+        contract Second {
+            function callSecond() external pure {
+                First.callFirst();
+                Shared.ping();
+            }
+        }
+        "#,
+    );
+    let project = marked.project();
+    let analyze_path = |path| {
+        let result = analyze(AnalysisBatch::from_files(
+            CompileOpts::default(),
+            [(project.path(path), project.read_file(path))],
+        ));
+        assert!(result.diagnostics.is_empty(), "{:#?}", result.diagnostics);
+        result.symbol_tables
+    };
+    let first = analyze_path("/First.sol");
+    let second = analyze_path("/Second.sol");
+    let uri = Url::from_file_path(project.path("/Shared.sol")).unwrap();
+    let position = marked.marker("$1").position();
+
+    assert_data_eq!(lens_titles_at(&first, &uri, position), "1 reference\n");
+    assert_data_eq!(lens_titles_at(&second, &uri, position), "2 references\n");
+    for (first, second) in [(first.clone(), second.clone()), (second, first)] {
+        let mut aggregator = SymbolTablesAggregator::default();
+        aggregator.push(first);
+        aggregator.push(second);
+        let tables = aggregator.finish();
+        for _ in 0..2 {
+            // The shared caller appears in both batches, but contributes only one location.
+            assert_data_eq!(lens_titles_at(&tables, &uri, position), "2 references\n");
+        }
+    }
+}
+
+#[test]
+fn suppresses_warmed_reference_counts_after_merging_conflicting_callers() {
+    let marked = MarkedProject::from_fixture(
+        r#"
+        //- /Target.sol
+        library Target {
+            function $1target() external pure {}
+        }
+
+        //- /Caller.sol
+        import "./Target.sol";
+        contract Caller {
+            function callTarget() external pure { Target.target(); }
+        }
+
+        //- /Root.sol
+        import "./Caller.sol";
+        "#,
+    );
+    let project = marked.project();
+    let contents = project.read_file("/Caller.sol");
+    let analyze_path = |path| {
+        let result = analyze(AnalysisBatch::from_files(
+            CompileOpts::default(),
+            [(project.path(path), project.read_file(path))],
+        ));
+        assert!(result.diagnostics.is_empty(), "{:#?}", result.diagnostics);
+        result.symbol_tables
+    };
+    let first = analyze_path("/Caller.sol");
+    project.write_file("/Caller.sol", &contents.replace("Target.target();", "\nTarget.target();"));
+    let second = analyze_path("/Root.sol");
+    let uri = Url::from_file_path(project.path("/Target.sol")).unwrap();
+    let position = marked.marker("$1").position();
+
+    assert_data_eq!(lens_titles_at(&first, &uri, position), "1 reference\n0xd4b83992\n");
+    assert_data_eq!(lens_titles_at(&second, &uri, position), "1 reference\n0xd4b83992\n");
+    for (first, second) in [(first.clone(), second.clone()), (second, first)] {
+        let mut aggregator = SymbolTablesAggregator::default();
+        aggregator.push(first);
+        aggregator.push(second);
+        let tables = aggregator.finish();
+        for _ in 0..2 {
+            assert_data_eq!(lens_titles_at(&tables, &uri, position), "0xd4b83992\n");
+        }
+    }
+}
+
+#[test]
 fn rejects_references_from_conflicting_source_snapshots() {
     let source = r#"
         //- /Target.sol
@@ -494,4 +602,15 @@ fn preserves_titles_without_client_commands() {
 
 "#]],
     );
+}
+
+fn lens_titles_at(tables: &SymbolTables, uri: &Url, position: Position) -> String {
+    let mut output = String::new();
+    for lens in tables.code_lenses(uri, CodeLensConfig::default()) {
+        if lens.range.start == position {
+            output.push_str(&lens.command.unwrap().title);
+            output.push('\n');
+        }
+    }
+    output
 }


### PR DESCRIPTION
Towards OSS-738 , 

CodeLens reference counts were recomputed from the full reference index on every request. For immutable analysis snapshots, that repeated work dominated requests with many references.

Changes:

- Cache one reference-count array per source file with `OnceLock`, so repeated requests reuse counts while still invalidating the cache when merged analysis tables are rebuilt.
- Preserve conflict handling and location deduplication, including conflicting source snapshots and references merged from multiple analysis batches.
- Avoid allocating a hash set for declarations with zero or one distinct reference location.
- Pre-size the response vector from the enabled lens kinds to reduce growth reallocations.
- Add scaling benchmarks for repeated references, first requests, and the Unifap V2 pair, plus regression coverage for warmed caches and merge order.

The implementation is independent of PR #1442. It does not change the CodeLens response contents or the behavior of selector and inheritance lenses. `cargo nextest run --locked -p solar-lsp`, Clippy, formatting, and diff checks pass.

Benchmark evidence from the matched 14-case run (20 Criterion samples per case):

| Case | Before | After | Change |
| --- | ---: | ---: | ---: |
| CodeLens, 1,024 references | 24.362 us | 0.467 us | -98.08% |
| CodeLens, 16,384 references | 428.423 us | 0.463 us | -99.89% |
| CodeLens, 256 functions | 409.559 us | 345.828 us | -15.56% |
| CodeLens, Unifap V2 Pair | 19.750 us | 13.177 us | -33.28% |
| First request, 1,024 references | 24.589 us | 25.602 us | +4.12% |
| First request, 16,384 references | 482.326 us | 517.647 us | +7.32% |
