### PR TITLE
perf(lsp): index point queries

### DIFF
--- a/benches/lsp/lsp-point-query-benchmark.svg
+++ b/benches/lsp/lsp-point-query-benchmark.svg
@@ -1,0 +1,55 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1000" height="560" viewBox="0 0 1000 560">
+<rect width="100%" height="100%" fill="white"/>
+<style>text{font-family:Arial,sans-serif;fill:#1f2937} .grid{stroke:#d1d5db;stroke-width:1} .axis{stroke:#374151;stroke-width:1.5}</style>
+<text x="500" y="32" text-anchor="middle" font-size="22" font-weight="bold">LSP point-query benchmark</text>
+<text x="500" y="53" text-anchor="middle" font-size="13">main vs indexed implementation · median latency (µs, logarithmic scale)</text>
+<line class="grid" x1="90" x2="950" y1="450.0" y2="450.0"/>
+<text x="78" y="454.0" text-anchor="end" font-size="12">10^-2</text>
+<line class="grid" x1="90" x2="950" y1="385.0" y2="385.0"/>
+<text x="78" y="389.0" text-anchor="end" font-size="12">10^-1</text>
+<line class="grid" x1="90" x2="950" y1="320.0" y2="320.0"/>
+<text x="78" y="324.0" text-anchor="end" font-size="12">10^0</text>
+<line class="grid" x1="90" x2="950" y1="255.0" y2="255.0"/>
+<text x="78" y="259.0" text-anchor="end" font-size="12">10^1</text>
+<line class="grid" x1="90" x2="950" y1="190.0" y2="190.0"/>
+<text x="78" y="194.0" text-anchor="end" font-size="12">10^2</text>
+<line class="grid" x1="90" x2="950" y1="125.0" y2="125.0"/>
+<text x="78" y="129.0" text-anchor="end" font-size="12">10^3</text>
+<line class="grid" x1="90" x2="950" y1="60.0" y2="60.0"/>
+<text x="78" y="64.0" text-anchor="end" font-size="12">10^4</text>
+<line class="axis" x1="90" x2="90" y1="60" y2="450"/>
+<line class="axis" x1="90" x2="950" y1="450" y2="450"/>
+<rect x="130.7" y="188.4" width="28" height="261.6" fill="#9ca3af"/>
+<rect x="164.7" y="190.4" width="28" height="259.6" fill="#2563eb"/>
+<text x="144.7" y="181.4" text-anchor="middle" font-size="10" transform="rotate(-55 144.7,181.4)">105.81</text>
+<text x="178.7" y="183.4" text-anchor="middle" font-size="10" transform="rotate(-55 178.7,183.4)">98.69</text>
+<text x="161.7" y="474" text-anchor="middle" font-size="11">Rename hit</text>
+<rect x="274.0" y="76.4" width="28" height="373.6" fill="#9ca3af"/>
+<rect x="308.0" y="419.8" width="28" height="30.2" fill="#2563eb"/>
+<text x="288.0" y="70.0" text-anchor="middle" font-size="10" transform="rotate(-55 288.0,70.0)">5594</text>
+<text x="322.0" y="412.8" text-anchor="middle" font-size="10" transform="rotate(-55 322.0,412.8)">0.029151</text>
+<text x="305.0" y="474" text-anchor="middle" font-size="11">Rename miss</text>
+<rect x="417.3" y="162.8" width="28" height="287.2" fill="#9ca3af"/>
+<rect x="451.3" y="180.0" width="28" height="270.0" fill="#2563eb"/>
+<text x="431.3" y="155.8" text-anchor="middle" font-size="10" transform="rotate(-55 431.3,155.8)">262.2</text>
+<text x="465.3" y="173.0" text-anchor="middle" font-size="10" transform="rotate(-55 465.3,173.0)">142.31</text>
+<text x="448.3" y="474" text-anchor="middle" font-size="11">Prepare body (128)</text>
+<rect x="560.7" y="102.4" width="28" height="347.6" fill="#9ca3af"/>
+<rect x="594.7" y="175.3" width="28" height="274.7" fill="#2563eb"/>
+<text x="574.7" y="95.4" text-anchor="middle" font-size="10" transform="rotate(-55 574.7,95.4)">2230.1</text>
+<text x="608.7" y="168.3" text-anchor="middle" font-size="10" transform="rotate(-55 608.7,168.3)">168.14</text>
+<text x="591.7" y="474" text-anchor="middle" font-size="11">Prepare body (2048)</text>
+<rect x="704.0" y="162.5" width="28" height="287.5" fill="#9ca3af"/>
+<rect x="738.0" y="176.8" width="28" height="273.2" fill="#2563eb"/>
+<text x="718.0" y="155.5" text-anchor="middle" font-size="10" transform="rotate(-55 718.0,155.5)">265.17</text>
+<text x="752.0" y="169.8" text-anchor="middle" font-size="10" transform="rotate(-55 752.0,169.8)">159.81</text>
+<text x="735.0" y="474" text-anchor="middle" font-size="11">Prepare site (128)</text>
+<rect x="847.3" y="102.5" width="28" height="347.5" fill="#9ca3af"/>
+<rect x="881.3" y="172.5" width="28" height="277.5" fill="#2563eb"/>
+<text x="861.3" y="95.5" text-anchor="middle" font-size="10" transform="rotate(-55 861.3,95.5)">2219.7</text>
+<text x="895.3" y="165.5" text-anchor="middle" font-size="10" transform="rotate(-55 895.3,165.5)">186.14</text>
+<text x="878.3" y="474" text-anchor="middle" font-size="11">Prepare site (2048)</text>
+<rect x="760" y="75" width="16" height="16" fill="#9ca3af"/><text x="782" y="88" font-size="12">main</text>
+<rect x="830" y="75" width="16" height="16" fill="#2563eb"/><text x="852" y="88" font-size="12">indexed</text>
+<text x="500" y="540" text-anchor="middle" font-size="11">Values: µs except displayed sub-µs rename miss (0.029151 µs)</text>
+</svg>

--- a/crates/lsp/benches/lsp.rs
+++ b/crates/lsp/benches/lsp.rs
@@ -121,19 +121,104 @@ fn analysis_build(c: &mut Criterion) {
 }
 
 fn call_hierarchy_queries(c: &mut Criterion) {
+    let mut group = c.benchmark_group("lsp/call-hierarchy");
+    for caller_count in [128, 2_048] {
+        let mut source = String::from("contract Root { function target() internal {}\n");
+        for index in 0..caller_count {
+            writeln!(source, "function caller{index}() public {{ target(); }}").unwrap();
+        }
+        source.push_str("}\n");
+        let project = BenchmarkProject::from_source(source);
+        let (uri, target_position) =
+            project.unique_anchor("benchmark.sol", "target() internal").unwrap();
+        let analysis = project.clone().analyze();
+        assert_clean(&analysis);
+        assert_eq!(analysis.incoming_calls(&uri, target_position).len(), caller_count);
+        group.bench_function(BenchmarkId::from_parameter(format!("{caller_count}-callers")), |b| {
+            b.iter(|| {
+                black_box(analysis.incoming_calls(black_box(&uri), black_box(target_position)))
+            });
+        });
+
+        let caller_line = format!("function caller{}() public {{ target(); }}", caller_count - 1);
+        let (body_uri, line_start) = project.unique_anchor("benchmark.sol", &caller_line).unwrap();
+        let body_position =
+            Position::new(line_start.line, line_start.character + "function ".len() as u32);
+        assert_eq!(analysis.prepare_call_hierarchy(&body_uri, body_position).unwrap().len(), 1);
+        group.bench_function(
+            BenchmarkId::from_parameter(format!("{caller_count}-callers-prepare-body")),
+            |b| {
+                b.iter(|| {
+                    black_box(
+                        analysis
+                            .prepare_call_hierarchy(black_box(&body_uri), black_box(body_position)),
+                    )
+                })
+            },
+        );
+
+        let call_position = Position::new(
+            line_start.line,
+            line_start.character
+                + format!("function caller{}() public {{ ", caller_count - 1).len() as u32,
+        );
+        assert_eq!(analysis.prepare_call_hierarchy(&body_uri, call_position).unwrap().len(), 1);
+        group.bench_function(
+            BenchmarkId::from_parameter(format!("{caller_count}-callers-prepare-callsite")),
+            |b| {
+                b.iter(|| {
+                    black_box(
+                        analysis
+                            .prepare_call_hierarchy(black_box(&body_uri), black_box(call_position)),
+                    )
+                })
+            },
+        );
+
+        group.bench_function(
+            BenchmarkId::from_parameter(format!("{caller_count}-callers-prepare-cold")),
+            |b| {
+                b.iter_batched(
+                    || analysis.clone(),
+                    |cold| black_box(cold.prepare_call_hierarchy(&body_uri, call_position)),
+                    BatchSize::PerIteration,
+                )
+            },
+        );
+    }
+    group.finish();
+}
+
+fn rename_candidate_queries(c: &mut Criterion) {
     let mut source = String::from("contract Root { function target() internal {}\n");
-    for index in 0..128 {
+    for index in 0..2_048 {
         writeln!(source, "function caller{index}() public {{ target(); }}").unwrap();
     }
     source.push_str("}\n");
     let project = BenchmarkProject::from_source(source);
-    let (uri, position) = project.unique_anchor("benchmark.sol", "target() internal").unwrap();
-    let analysis = project.analyze();
+    let (uri, eof_anchor) = project
+        .unique_anchor("benchmark.sol", "function caller2047() public { target(); }")
+        .unwrap();
+    let hit_position = Position::new(
+        eof_anchor.line,
+        eof_anchor.character + "function caller2047() public { ".len() as u32,
+    );
+    let analysis = project.clone().analyze();
     assert_clean(&analysis);
-    assert_eq!(analysis.incoming_calls(&uri, position).len(), 128);
-    let mut group = c.benchmark_group("lsp/call-hierarchy");
-    group.bench_function(BenchmarkId::from_parameter("128-callers"), |b| {
-        b.iter(|| black_box(analysis.incoming_calls(black_box(&uri), black_box(position))));
+    let Some((range, edit_count)) = analysis.rename_candidate(&uri, hit_position) else {
+        panic!("rename candidate should resolve at the final call site");
+    };
+    assert_eq!(edit_count, 2_049);
+    assert!(range.start <= hit_position && hit_position < range.end);
+    let miss_position = Position::new(eof_anchor.line + 1, 0);
+    assert!(analysis.rename_candidate(&uri, miss_position).is_none());
+
+    let mut group = c.benchmark_group("lsp/rename-candidate");
+    group.bench_function(BenchmarkId::from_parameter("2048-callers-hit-near-eof"), |b| {
+        b.iter(|| black_box(analysis.rename_candidate(black_box(&uri), black_box(hit_position))))
+    });
+    group.bench_function(BenchmarkId::from_parameter("2048-callers-miss-near-eof"), |b| {
+        b.iter(|| black_box(analysis.rename_candidate(black_box(&uri), black_box(miss_position))))
     });
     group.finish();
 }
@@ -966,6 +1051,7 @@ fn unifap_benches(c: &mut Criterion) {
 criterion_group!(
     benches,
     analysis_build,
+    rename_candidate_queries,
     completion_queries,
     member_completion_queries,
     signature_help_requests,

--- a/crates/lsp/src/call_hierarchy.rs
+++ b/crates/lsp/src/call_hierarchy.rs
@@ -61,11 +61,57 @@ struct QueryIndex {
     incoming_by_key: CallRelations,
     incomplete_outgoing: FxHashSet<CallableKey>,
     incomplete_incoming: FxHashSet<CallableKey>,
-    call_sites_by_uri: FxHashMap<Arc<Url>, Vec<CallSite>>,
-    bodies_by_uri: FxHashMap<Arc<Url>, Vec<CallableBody>>,
+    call_sites_by_uri: FxHashMap<Arc<Url>, IndexedRanges<CallSite>>,
+    bodies_by_uri: FxHashMap<Arc<Url>, IndexedRanges<CallableBody>>,
 }
 
 type CallRelations = FxHashMap<CallableKey, FxHashMap<CallableKey, Vec<Range>>>;
+
+/// Entries sorted by start position with a prefix maximum end, allowing point queries to
+/// skip entries that end before the cursor while retaining the original range tie order.
+#[derive(Clone, Debug)]
+struct IndexedRanges<T> {
+    entries: Vec<T>,
+    prefix_max_end: Vec<Position>,
+}
+
+impl<T> Default for IndexedRanges<T> {
+    fn default() -> Self {
+        Self { entries: Vec::new(), prefix_max_end: Vec::new() }
+    }
+}
+
+impl<T> IndexedRanges<T> {
+    fn push(&mut self, entry: T) {
+        self.entries.push(entry);
+    }
+
+    fn rebuild(&mut self, range: impl Fn(&T) -> Range) {
+        self.prefix_max_end.clear();
+        self.prefix_max_end.reserve(self.entries.len());
+        let mut max_end = Position::default();
+        for entry in &self.entries {
+            let end = range(entry).end;
+            max_end = max_end.max(end);
+            self.prefix_max_end.push(max_end);
+        }
+    }
+
+    fn candidates_at<'a>(
+        &'a self,
+        position: Position,
+        range: impl Fn(&T) -> Range + Copy + 'a,
+    ) -> impl Iterator<Item = &'a T> + 'a {
+        let end = self.entries.partition_point(|entry| range(entry).start <= position);
+        self.entries[..end]
+            .iter()
+            .zip(self.prefix_max_end[..end].iter().copied())
+            .rev()
+            .take_while(move |(_, prefix_max_end)| *prefix_max_end >= position)
+            .filter(move |(entry, _)| proto::range_contains(range(entry), position))
+            .map(|(entry, _)| entry)
+    }
+}
 
 #[derive(Clone, Copy, Debug)]
 struct DirectCall {
@@ -301,12 +347,13 @@ impl QueryIndex {
         normalize_relations(&mut self.outgoing_by_key);
         normalize_relations(&mut self.incoming_by_key);
         for sites in self.call_sites_by_uri.values_mut() {
-            sites.sort_by(|a, b| {
+            sites.entries.sort_by(|a, b| {
                 proto::range_key(a.range)
                     .cmp(&proto::range_key(b.range))
                     .then_with(|| a.callee.cmp(&b.callee))
             });
-            sites.dedup();
+            sites.entries.dedup();
+            sites.rebuild(|site| site.range);
         }
 
         for (key, &symbol) in &self.canonical_symbol_by_key {
@@ -318,12 +365,13 @@ impl QueryIndex {
             }
         }
         for bodies in self.bodies_by_uri.values_mut() {
-            bodies.sort_by(|a, b| {
+            bodies.entries.sort_by(|a, b| {
                 proto::range_key(a.range)
                     .cmp(&proto::range_key(b.range))
                     .then_with(|| a.callable.cmp(&b.callable))
             });
-            bodies.dedup();
+            bodies.entries.dedup();
+            bodies.rebuild(|body| body.range);
         }
     }
 
@@ -393,17 +441,25 @@ impl QueryIndex {
     fn call_site(&self, uri: &Url, position: Position) -> Option<&CallSite> {
         self.call_sites_by_uri
             .get(uri)?
-            .iter()
-            .filter(|site| proto::range_contains(site.range, position))
-            .min_by_key(|site| (proto::range_size_key(site.range), proto::range_key(site.range)))
+            .candidates_at(position, |site| site.range)
+            // Include the callee key to preserve the pre-index order for equal ranges.
+            .min_by_key(|site| {
+                (
+                    proto::range_size_key(site.range),
+                    proto::range_key(site.range),
+                    site.callee.as_ref(),
+                )
+            })
     }
 
     fn enclosing_body_key(&self, uri: &Url, position: Position) -> Option<&CallableKey> {
         self.bodies_by_uri
             .get(uri)?
-            .iter()
-            .filter(|body| proto::range_contains(body.range, position))
-            .min_by_key(|body| (proto::range_size_key(body.range), proto::range_key(body.range)))
+            .candidates_at(position, |body| body.range)
+            // Include the callable key to preserve the pre-index order for equal ranges.
+            .min_by_key(|body| {
+                (proto::range_size_key(body.range), proto::range_key(body.range), &body.callable)
+            })
             .map(|body| &body.callable)
     }
 
@@ -569,5 +625,82 @@ fn normalize_relations(relations: &mut CallRelations) {
             ranges.sort_by_key(|&range| proto::range_key(range));
             ranges.dedup();
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Clone, Copy)]
+    struct Entry {
+        id: u8,
+        range: Range,
+    }
+
+    #[test]
+    fn indexed_ranges_match_linear_point_queries() {
+        let mut indexed = IndexedRanges::default();
+        for entry in [
+            Entry { id: 3, range: Range::new(Position::new(2, 0), Position::new(2, 0)) },
+            Entry { id: 1, range: Range::new(Position::new(0, 0), Position::new(4, 0)) },
+            Entry { id: 4, range: Range::new(Position::new(1, 2), Position::new(1, 2)) },
+            Entry { id: 2, range: Range::new(Position::new(1, 0), Position::new(3, 0)) },
+        ] {
+            indexed.push(entry);
+        }
+        indexed.entries.sort_by_key(|entry| proto::range_key(entry.range));
+        indexed.rebuild(|entry| entry.range);
+
+        for position in [
+            Position::new(0, 0),
+            Position::new(1, 1),
+            Position::new(1, 2),
+            Position::new(2, 0),
+            Position::new(3, 0),
+            Position::new(4, 0),
+        ] {
+            let mut expected = indexed
+                .entries
+                .iter()
+                .filter(|entry| proto::range_contains(entry.range, position))
+                .map(|entry| entry.id)
+                .collect::<Vec<_>>();
+            let mut actual = indexed
+                .candidates_at(position, |entry| entry.range)
+                .map(|entry| entry.id)
+                .collect::<Vec<_>>();
+            expected.sort_unstable();
+            actual.sort_unstable();
+            assert_eq!(actual, expected, "{position:?}");
+        }
+    }
+
+    #[test]
+    fn equal_call_ranges_use_callee_order_after_reverse_scan() {
+        let uri = Arc::new(Url::parse("file:///Calls.sol").unwrap());
+        let range = Range::new(Position::new(1, 2), Position::new(1, 7));
+        let low = CallableKey {
+            uri: uri.clone(),
+            selection_range: Range::new(Position::new(0, 0), Position::new(0, 1)),
+        };
+        let high = CallableKey {
+            uri,
+            selection_range: Range::new(Position::new(0, 2), Position::new(0, 3)),
+        };
+        let mut sites = IndexedRanges::default();
+        sites.push(CallSite { range, callee: Some(high) });
+        sites.push(CallSite { range, callee: Some(low.clone()) });
+        sites.entries.sort_by(|a, b| {
+            proto::range_key(a.range)
+                .cmp(&proto::range_key(b.range))
+                .then_with(|| a.callee.cmp(&b.callee))
+        });
+        sites.rebuild(|site| site.range);
+        let mut query = QueryIndex::default();
+        let key_uri = sites.entries[0].callee.as_ref().unwrap().uri.clone();
+        query.call_sites_by_uri.insert(key_uri.clone(), sites);
+        let selected = query.call_site(key_uri.as_ref(), Position::new(1, 3));
+        assert_eq!(selected.and_then(|site| site.callee.as_ref()), Some(&low));
     }
 }

--- a/crates/lsp/src/global_state/benchmark.rs
+++ b/crates/lsp/src/global_state/benchmark.rs
@@ -21,11 +21,11 @@ use crate::{
 use async_lsp::ClientSocket;
 use crop::Rope;
 use lsp_types::{
-    CallHierarchyIncomingCall, CodeLens, CompletionItem, Diagnostic, DidChangeTextDocumentParams,
-    DocumentSymbol, GotoDefinitionResponse, Hover, HoverContents, Location, Position,
-    PreviousResultId, Range, SignatureHelp, SignatureHelpParams, TextDocumentContentChangeEvent,
-    TextDocumentIdentifier, TextDocumentPositionParams, TypeHierarchyItem, Url,
-    VersionedTextDocumentIdentifier, WorkspaceFolder, WorkspaceSymbol,
+    CallHierarchyIncomingCall, CallHierarchyItem, CodeLens, CompletionItem, Diagnostic,
+    DidChangeTextDocumentParams, DocumentSymbol, GotoDefinitionResponse, Hover, HoverContents,
+    Location, Position, PreviousResultId, Range, SignatureHelp, SignatureHelpParams,
+    TextDocumentContentChangeEvent, TextDocumentIdentifier, TextDocumentPositionParams,
+    TypeHierarchyItem, Url, VersionedTextDocumentIdentifier, WorkspaceFolder, WorkspaceSymbol,
 };
 use normalize_path::NormalizePath;
 use solar_config::{CompileOpts, Threads};
@@ -941,6 +941,24 @@ impl BenchmarkAnalysis {
     pub fn incoming_calls(&self, uri: &Url, position: Position) -> Vec<CallHierarchyIncomingCall> {
         let items = self.symbol_tables.prepare_call_hierarchy(uri, position).unwrap();
         self.symbol_tables.call_hierarchy_incoming(&items[0]).unwrap()
+    }
+
+    /// Prepare one call hierarchy item at a source position.
+    #[inline(never)]
+    pub fn prepare_call_hierarchy(
+        &self,
+        uri: &Url,
+        position: Position,
+    ) -> Option<Vec<CallHierarchyItem>> {
+        self.symbol_tables.prepare_call_hierarchy(uri, position)
+    }
+
+    /// Return the selected range and edit count from a complete rename candidate lookup.
+    #[inline(never)]
+    pub fn rename_candidate(&self, uri: &Url, position: Position) -> Option<(Range, usize)> {
+        self.symbol_tables
+            .rename_candidate(uri, position)
+            .map(|candidate| (candidate.range, candidate.locations.len()))
     }
 
     /// Prepare a hierarchy item and query its direct subtypes.

--- a/crates/lsp/src/rename.rs
+++ b/crates/lsp/src/rename.rs
@@ -76,9 +76,37 @@ pub(crate) struct RenameIndex {
     symbol_targets: FxHashSet<SymbolId>,
     yul_symbol_targets: FxHashSet<SymbolId>,
     occurrences: Vec<RenameOccurrence>,
-    file_occurrences: FxHashMap<Url, Vec<usize>>,
+    file_occurrences: FxHashMap<Url, OccurrenceIndex>,
     target_occurrences: FxHashMap<RenameTarget, Vec<usize>>,
     ambiguous_targets: FxHashSet<RenameTarget>,
+}
+
+/// Start-sorted occurrence indexes with a prefix maximum end for point queries.
+#[derive(Clone, Debug, Default)]
+struct OccurrenceIndex {
+    entries: Vec<usize>,
+    prefix_max_end: Vec<Position>,
+}
+
+impl OccurrenceIndex {
+    fn rebuild(&mut self, occurrences: &[RenameOccurrence]) {
+        // `normalize_occurrences` orders the global list by URI and range before these
+        // per-file indexes are populated, so the entries are already start-sorted.
+        debug_assert!(self.entries.windows(2).all(|pair| {
+            let lhs = occurrences[pair[0]].location.range;
+            let rhs = occurrences[pair[1]].location.range;
+            (lhs.start, lhs.end, pair[0]) <= (rhs.start, rhs.end, pair[1])
+        }));
+
+        self.prefix_max_end.clear();
+        self.prefix_max_end.reserve(self.entries.len());
+        let mut max_end = None;
+        for &index in &self.entries {
+            let end = occurrences[index].location.range.end;
+            max_end = Some(max_end.map_or(end, |max_end: Position| max_end.max(end)));
+            self.prefix_max_end.push(max_end.unwrap());
+        }
+    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
@@ -637,7 +665,11 @@ impl RenameIndex {
         self.ambiguous_targets.clear();
 
         for (index, occurrence) in self.occurrences.iter().enumerate() {
-            self.file_occurrences.entry(occurrence.location.uri.clone()).or_default().push(index);
+            self.file_occurrences
+                .entry(occurrence.location.uri.clone())
+                .or_default()
+                .entries
+                .push(index);
             if occurrence.targets.len() > 1
                 && !same_rename_targets(
                     &self.aliases,
@@ -651,6 +683,9 @@ impl RenameIndex {
             for &target in &occurrence.targets {
                 self.target_occurrences.entry(target).or_default().push(index);
             }
+        }
+        for occurrences in self.file_occurrences.values_mut() {
+            occurrences.rebuild(&self.occurrences);
         }
     }
 
@@ -831,14 +866,27 @@ impl RenameIndex {
     }
 
     fn occurrence_at(&self, uri: &Url, position: Position) -> Option<&RenameOccurrence> {
-        self.file_occurrences
-            .get(uri)?
-            .iter()
-            .filter_map(|&index| {
-                let occurrence = &self.occurrences[index];
-                proto::range_contains(occurrence.location.range, position).then_some(occurrence)
-            })
-            .min_by_key(|occurrence| proto::range_size_key(occurrence.location.range))
+        let index = self.file_occurrences.get(uri)?;
+        let end = index
+            .entries
+            .partition_point(|&entry| self.occurrences[entry].location.range.start <= position);
+        let mut best = None;
+        for (&entry, &prefix_max_end) in
+            index.entries[..end].iter().zip(&index.prefix_max_end[..end]).rev()
+        {
+            if prefix_max_end < position {
+                break;
+            }
+            let occurrence = &self.occurrences[entry];
+            if !proto::range_contains(occurrence.location.range, position) {
+                continue;
+            }
+            let key = (proto::range_size_key(occurrence.location.range), entry);
+            if best.as_ref().is_none_or(|(best_key, _)| key < *best_key) {
+                best = Some((key, occurrence));
+            }
+        }
+        best.map(|(_, occurrence)| occurrence)
     }
 
     fn normalize_occurrences(&mut self) {

--- a/crates/lsp/src/tests/call_hierarchy.rs
+++ b/crates/lsp/src/tests/call_hierarchy.rs
@@ -49,6 +49,36 @@ fn basic_direct_call_hierarchy() {
 }
 
 #[test]
+fn call_site_endpoint_selects_enclosing_body() {
+    let marked = MarkedProject::from_fixture(
+        r#"
+        //- /Endpoint.sol
+        contract C {
+            function $1callee() internal {}
+            function $2caller() external {
+                $3callee();
+            }
+        }
+        "#,
+    );
+    let project = marked.project();
+    let path = project.path("/Endpoint.sol");
+    let tables = analyze(AnalysisBatch::from_files(
+        CompileOpts::default(),
+        [(path.clone(), project.read_file("/Endpoint.sol"))],
+    ))
+    .symbol_tables;
+    let uri = Url::from_file_path(path).unwrap();
+    let caller =
+        tables.prepare_call_hierarchy(&uri, marked.marker("$2").position()).unwrap().pop().unwrap();
+    let call_start = marked.marker("$3").position();
+    let call_end = Position::new(call_start.line, call_start.character + "callee".len() as u32);
+
+    // Call ranges are end-exclusive, so the first position after the callee belongs to the body.
+    assert_eq!(tables.prepare_call_hierarchy(&uri, call_end), Some(vec![caller]));
+}
+
+#[test]
 fn prepares_enclosing_callable_bodies_only() {
     let marked = MarkedProject::from_fixture(
         r#"


### PR DESCRIPTION
## Summary

Point lookups for rename and call hierarchy currently walk every occurrence or range in a file. This is cheap for small files but becomes visible in large contracts, especially when the cursor is near the end of a source file.

This change adds per-file interval indexes with prefix maximum end positions. Queries use the index to skip ranges that cannot contain the cursor while preserving the existing range selection and tie-breaking rules.

- Rename occurrence lookup now uses a start-sorted index and prefix maximum end values.
- Call hierarchy call-site and enclosing-body lookup use the same bounded scan.
- Redundant per-file sorting during rename index rebuild is removed; normalized occurrence order is reused.
- Regression coverage covers overlapping ranges, zero-length ranges, end-exclusive boundaries, and equal-range tie ordering.
- Criterion workloads cover rename candidates and call hierarchy preparation with 128 and 2,048 callers.

## Benchmark evidence

The measurements below use the same fixture and benchmark command for `main` and this branch. Values are medians from 10 samples; the cold case includes query-index construction.

| Workload | main | indexed | Change |
| --- | ---: | ---: | ---: |
| Rename hit, 2,048 callers | 105.81 µs | 98.69 µs | -6.5% |
| Rename miss, 2,048 callers | 5.594 µs | 29.15 ns | -99.5% |
| Call hierarchy body, 128 callers | 262.20 ns | 142.31 ns | -46.0% |
| Call hierarchy body, 2,048 callers | 2.2301 µs | 168.14 ns | -92.5% |
| Call hierarchy call-site, 128 callers | 265.17 ns | 159.81 ns | -39.6% |
| Call hierarchy call-site, 2,048 callers | 2.2197 µs | 186.14 ns | -91.6% |

The cold 2,048-caller preparation case stayed within measurement noise (1.208 ms vs 1.216 ms), so the improvement is concentrated on repeated point queries after the index is built.

![LSP point-query benchmark](https://github.com/0xKarl98/solar/blob/perf/lsp-point-query-indexes-20260912/benches/lsp/lsp-point-query-benchmark.svg)
