### PR TITLE
perf(lsp): reuse validated aggregate indexes

### DIFF
--- a/crates/lsp/benches/lsp.rs
+++ b/crates/lsp/benches/lsp.rs
@@ -203,7 +203,7 @@ fn rename_candidate_queries(c: &mut Criterion) {
         eof_anchor.line,
         eof_anchor.character + "function caller2047() public { ".len() as u32,
     );
-    let analysis = project.clone().analyze();
+    let analysis = project.analyze();
     assert_clean(&analysis);
     let Some((range, edit_count)) = analysis.rename_candidate(&uri, hit_position) else {
         panic!("rename candidate should resolve at the final call site");
@@ -904,6 +904,94 @@ fn repeated_analysis(c: &mut Criterion) {
     cached.finish();
 }
 
+fn workspace_index_reuse(c: &mut Criterion) {
+    let workspace_count = 4;
+    let caller_count = 256;
+    let temp = tempfile::tempdir().expect("workspace index benchmark directory");
+    let mut source = String::from(
+        "import \"./lib/Dependency.sol\";\ncontract Main is Dependency {\nfunction target() internal {}\n",
+    );
+    for index in 0..caller_count {
+        writeln!(source, "function caller{index}() public {{ target(); }}").unwrap();
+    }
+    source.push_str("uint marker0;\n}\n");
+    let edited_source = source.replace("marker0", "marker1");
+    let roots = (0..workspace_count)
+        .map(|index| {
+            let root = temp.path().join(format!("workspace-{index}"));
+            fs::create_dir(&root).expect("benchmark workspace root");
+            fs::create_dir(root.join("lib")).expect("benchmark dependency directory");
+            fs::write(root.join("Main.sol"), &source).expect("benchmark source");
+            fs::write(root.join("lib/Dependency.sol"), "contract Dependency {}\n")
+                .expect("benchmark dependency");
+            root
+        })
+        .collect::<Vec<_>>();
+    let path = roots[0].join("Main.sol");
+    let uri = Url::from_file_path(&path).unwrap();
+    let position = Position::new(
+        caller_count as u32 + 2,
+        format!("function caller{}() public {{ ", caller_count - 1).len() as u32,
+    );
+
+    let mut group = c.benchmark_group("lsp/workspace-index-reuse");
+    group.bench_function("4x256-callers-cold", |b| {
+        b.iter_batched_ref(
+            || BenchmarkRepeatedAnalysis::from_workspaces(&roots, &source),
+            |analysis| black_box(analysis.run_epoch()),
+            BatchSize::PerIteration,
+        );
+    });
+    group.bench_function("4x256-callers-open-indexed-document-first-prepare", |b| {
+        b.iter_batched_ref(
+            || {
+                let mut analysis = BenchmarkRepeatedAnalysis::from_workspaces(&roots, &source);
+                analysis.clear_open_documents();
+                assert!(analysis.run_epoch());
+                assert_eq!(analysis.prepare_call_hierarchy(&uri, position).unwrap().len(), 1);
+                analysis
+            },
+            |analysis| {
+                analysis.replace_source(&path, &source);
+                black_box(analysis.run_epoch());
+                black_box(analysis.prepare_call_hierarchy(&uri, position))
+            },
+            BatchSize::PerIteration,
+        );
+    });
+
+    let mut analysis = BenchmarkRepeatedAnalysis::from_workspaces(&roots, &source);
+    assert!(analysis.run_epoch());
+    assert_eq!(analysis.prepare_call_hierarchy(&uri, position).unwrap().len(), 1);
+    // Initialization and the first lazy query happen once, outside every incremental sample.
+    group.bench_function("4x256-callers-unchanged", |b| {
+        b.iter(|| black_box(analysis.run_epoch()));
+    });
+    group.bench_function("4x256-callers-unchanged-first-prepare", |b| {
+        b.iter(|| {
+            black_box(analysis.run_epoch());
+            black_box(analysis.prepare_call_hierarchy(&uri, position))
+        });
+    });
+    group.bench_function("4x256-callers-reverted-edit-first-prepare", |b| {
+        b.iter(|| {
+            analysis.edit_and_revert();
+            black_box(analysis.run_epoch());
+            black_box(analysis.prepare_call_hierarchy(&uri, position))
+        });
+    });
+    let mut edited = false;
+    group.bench_function("4x256-callers-one-workspace-edit-first-prepare", |b| {
+        b.iter(|| {
+            edited = !edited;
+            analysis.replace_source(&path, if edited { &edited_source } else { &source });
+            black_box(analysis.run_epoch());
+            black_box(analysis.prepare_call_hierarchy(&uri, position))
+        });
+    });
+    group.finish();
+}
+
 fn workspace_path_queries(c: &mut Criterion) {
     let queries =
         BenchmarkWorkspacePathQueries::new(PATH_INDEX_WORKSPACE_COUNT, PATH_INDEX_QUERY_COUNT);
@@ -1139,6 +1227,7 @@ criterion_group!(
     workspace_diagnostic_hot_paths,
     open_document_analysis_batches,
     repeated_analysis,
+    workspace_index_reuse,
     workspace_path_queries,
     unifap_benches
 );

--- a/crates/lsp/src/global_state.rs
+++ b/crates/lsp/src/global_state.rs
@@ -1784,6 +1784,63 @@ fn run_analysis(
     } else {
         None
     };
+    let mut next_cached_batches =
+        if cache_batches { vec![None; batches.len()] } else { Vec::new() };
+    if let Some((inputs, outputs)) = cached_batches {
+        // Validate once before cloning or merging any symbol tables. If every batch matches,
+        // retain the aggregate and its initialized lazy query indexes across analysis epochs.
+        let mut all_reused = true;
+        for (idx, batch) in batches.iter().enumerate() {
+            if cancellation.is_cancelled() || !snapshot.is_current(version) {
+                return AnalysisTaskOutcome::Superseded;
+            }
+            let inputs = &inputs[idx];
+            let inputs_match =
+                inputs.files == batch.files && inputs.preloaded_files == batch.preloaded_files;
+            if inputs_match && !batch.files.is_empty() {
+                next_cached_batches[idx] = outputs[idx]
+                    .clone()
+                    .filter(|cached| cached.dependencies.unchanged(cancellation));
+            }
+            // Empty batches participate in the key: a previously populated batch may disappear.
+            all_reused &=
+                inputs_match && (batch.files.is_empty() || next_cached_batches[idx].is_some());
+        }
+        if all_reused {
+            let cached = {
+                let mut commit = snapshot.analysis_commit.lock();
+                if snapshot.is_current(version)
+                    && !cancellation.is_cancelled()
+                    && !commit.cache_invalidated
+                    && let Some(cached) = &mut commit.cached_output
+                    && Arc::ptr_eq(&cached.config, &config)
+                {
+                    cached.vfs_content_revision = vfs_content_revision;
+                    Some(cached.output.clone())
+                } else {
+                    None
+                }
+            };
+            if let Some(mut output) = cached {
+                // Opening or closing an overlay can change versions without changing its text.
+                // Match batch aggregation's maximum version, clearing versions no longer open.
+                for (uri, version) in &mut output.result.analyzed_documents {
+                    *version = batches
+                        .iter()
+                        .filter(|batch| !batch.files.is_empty())
+                        .filter_map(|batch| batch.open_file_versions.get(uri))
+                        .copied()
+                        .max();
+                }
+                progress.report("Reusing workspace index");
+                return if snapshot.publish_analysis_output(version, output) {
+                    AnalysisTaskOutcome::Published
+                } else {
+                    AnalysisTaskOutcome::Superseded
+                };
+            }
+        }
+    }
     let inputs = if has_disk_paths {
         Vec::new()
     } else {
@@ -1796,8 +1853,6 @@ fn run_analysis(
             .collect::<Vec<_>>()
     };
     let mut results = AnalysisOutputAccumulator::default();
-    let mut next_cached_batches =
-        if cache_batches { vec![None; batches.len()] } else { Vec::new() };
 
     for (idx, batch) in batches.into_iter().enumerate() {
         if batch.files.is_empty() {
@@ -1808,13 +1863,7 @@ fn run_analysis(
             return AnalysisTaskOutcome::Superseded;
         }
 
-        let cached = cached_batches.as_ref().and_then(|(inputs, outputs)| {
-            let inputs = &inputs[idx];
-            (inputs.files == batch.files && inputs.preloaded_files == batch.preloaded_files)
-                .then(|| outputs[idx].clone())
-                .flatten()
-                .filter(|cached| cached.dependencies.unchanged(cancellation))
-        });
+        let cached = next_cached_batches.get_mut(idx).and_then(Option::take);
         let result = if let Some(cached) = cached {
             let mut result = cached.output.clone();
             // Exact source contents permit reuse, but document versions belong to this epoch.

--- a/crates/lsp/src/global_state/benchmark.rs
+++ b/crates/lsp/src/global_state/benchmark.rs
@@ -540,6 +540,88 @@ impl BenchmarkRepeatedAnalysis {
         Self { state }
     }
 
+    /// Prepare one open document in each independently configured workspace.
+    ///
+    /// The caller keeps these roots and their disk dependencies alive for the workload.
+    pub fn from_workspaces(roots: &[PathBuf], source: &str) -> Self {
+        let params = lsp_types::InitializeParams {
+            workspace_folders: Some(
+                roots
+                    .iter()
+                    .enumerate()
+                    .map(|(index, root)| WorkspaceFolder {
+                        uri: Url::from_file_path(root).expect("benchmark root should be absolute"),
+                        name: format!("workspace-{index}"),
+                    })
+                    .collect(),
+            ),
+            ..Default::default()
+        };
+        let (_, mut config) = negotiate_capabilities(params);
+        config.try_rediscover_workspaces().expect("benchmark workspace discovery should succeed");
+        assert_eq!(config.workspaces().len(), roots.len());
+        assert!(config.workspaces().iter().all(|workspace| {
+            workspace.source_files().len() == 1
+                && workspace.source_files()[0].file_name().is_some_and(|name| name == "Main.sol")
+        }));
+        let mut state = super::GlobalState::new(ClientSocket::new_closed());
+        state.config = Arc::new(config);
+        for root in roots {
+            state.vfs.write().set_file_contents_with_version(
+                VfsPath::from(root.join("Main.sol")),
+                Some(Rope::from(source)),
+                Some(1),
+            );
+        }
+        Self { state }
+    }
+
+    /// Open or replace one source while leaving the other workspaces unchanged.
+    pub fn replace_source(&mut self, path: &Path, source: &str) {
+        let path = VfsPath::from(path.to_path_buf());
+        let mut vfs = self.state.vfs.write();
+        let version = vfs.get_file_version(&path).unwrap_or_default() + 1;
+        vfs.set_file_contents_with_version(path, Some(Rope::from(source)), Some(version));
+    }
+
+    /// Remove all document overlays before preparing an initial disk-only analysis.
+    pub fn clear_open_documents(&mut self) {
+        *self.state.vfs.write() = Default::default();
+    }
+
+    /// Advance and synchronously run a production document-analysis epoch.
+    #[inline(never)]
+    pub fn run_epoch(&mut self) -> bool {
+        let version = self.state.next_analysis_version();
+        self.state.commit_analysis_epoch(
+            &mut self.state.analysis_commit.lock(),
+            version,
+            Vec::new(),
+            false,
+        );
+        let mut snapshot = self.state.snapshot();
+        let progress = self.state.analysis_progress.reserve(version);
+        matches!(
+            run_analysis(
+                &mut snapshot,
+                version,
+                Vec::new(),
+                &progress,
+                &IndexingCancellation::default(),
+            ),
+            AnalysisTaskOutcome::Published
+        )
+    }
+
+    /// Prepare call hierarchy against the latest published snapshot.
+    pub fn prepare_call_hierarchy(
+        &self,
+        uri: &Url,
+        position: Position,
+    ) -> Option<Vec<CallHierarchyItem>> {
+        self.state.symbol_tables.load().prepare_call_hierarchy(uri, position)
+    }
+
     /// Advance the VFS revision through an edit and undo before analysis begins.
     pub fn edit_and_revert(&mut self) {
         let mut vfs = self.state.vfs.write();

--- a/crates/lsp/src/tests/indexing.rs
+++ b/crates/lsp/src/tests/indexing.rs
@@ -211,6 +211,116 @@ fn cached_batch_for_path(state: &GlobalState, path: &Path) -> Option<Arc<CachedA
 }
 
 #[tokio::test(flavor = "current_thread")]
+async fn unchanged_workspace_batches_reuse_aggregate_and_initialized_queries() {
+    let marked = MarkedProject::from_fixture(
+        r#"
+        //- /a/Main.sol
+        contract Main {
+            function target() internal {}
+            function $1caller() external { target(); }
+        }
+        //- /b/Other.sol
+        contract Other {}
+        "#,
+    );
+    let project = marked.project();
+    let path = project.path("/a/Main.sol");
+    let uri = Url::from_file_path(&path).unwrap();
+    let source = project.read_file("/a/Main.sol");
+    let mut state = GlobalState::new(ClientSocket::new_closed());
+    state.config = Arc::new(project.config_with_roots(&["/a", "/b"]));
+    state.recompute_after_opening_source(Vec::new());
+    tokio::time::timeout(ASYNC_TEST_TIMEOUT, state.latest_analysis()).await.unwrap().unwrap();
+    let published = state.symbol_tables.load_full();
+    let caller = published
+        .prepare_call_hierarchy(&uri, marked.marker("$1").position())
+        .unwrap()
+        .pop()
+        .unwrap();
+    assert_eq!(published.call_hierarchy_outgoing(&caller).unwrap().len(), 1);
+    assert!(published.call_hierarchy_is_initialized());
+
+    state.recompute_after_opening_source(Vec::new());
+    tokio::time::timeout(ASYNC_TEST_TIMEOUT, state.latest_analysis()).await.unwrap().unwrap();
+    assert!(Arc::ptr_eq(&published, &state.symbol_tables.load()));
+    assert!(state.symbol_tables.load().call_hierarchy_is_initialized());
+
+    let _ = handlers::did_open_text_document(
+        &mut state,
+        DidOpenTextDocumentParams {
+            text_document: TextDocumentItem::new(uri.clone(), "solidity".into(), 7, source.clone()),
+        },
+    );
+    tokio::time::timeout(ASYNC_TEST_TIMEOUT, state.latest_analysis()).await.unwrap().unwrap();
+    assert!(Arc::ptr_eq(&published, &state.symbol_tables.load()));
+    let reports = state.diagnostics.read().workspace_pull_reports(Vec::new());
+    assert_eq!(reports.iter().find(|report| report.uri == uri).unwrap().version, Some(7));
+
+    {
+        let mut vfs = state.vfs.write();
+        vfs.set_file_contents_with_version(
+            VfsPath::from(path.clone()),
+            Some(Rope::from("contract Edited {}")),
+            Some(8),
+        );
+        vfs.set_file_contents_with_version(
+            VfsPath::from(path.clone()),
+            Some(Rope::from(source.as_str())),
+            Some(9),
+        );
+    }
+    state.recompute_after_opening_source(vec![path.clone()]);
+    tokio::time::timeout(ASYNC_TEST_TIMEOUT, state.latest_analysis()).await.unwrap().unwrap();
+    assert!(Arc::ptr_eq(&published, &state.symbol_tables.load()));
+    assert!(state.symbol_tables.load().call_hierarchy_is_initialized());
+    let reports = state.diagnostics.read().workspace_pull_reports(Vec::new());
+    assert_eq!(reports.iter().find(|report| report.uri == uri).unwrap().version, Some(9));
+
+    // Exercise cached analysis with disk-identical inputs after the overlay disappears.
+    // The didClose handler explicitly invalidates the cache before reaching this path.
+    state.vfs.write().set_file_contents(VfsPath::from(path), None);
+    state.recompute_after_opening_source(Vec::new());
+    tokio::time::timeout(ASYNC_TEST_TIMEOUT, state.latest_analysis()).await.unwrap().unwrap();
+    assert!(Arc::ptr_eq(&published, &state.symbol_tables.load()));
+    assert!(state.symbol_tables.load().call_hierarchy_is_initialized());
+    assert_eq!(state.symbol_tables.load().call_hierarchy_outgoing(&caller).unwrap().len(), 1);
+    let reports = state.diagnostics.read().workspace_pull_reports(Vec::new());
+    assert_eq!(reports.iter().find(|report| report.uri == uri).unwrap().version, None);
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn removing_workspace_batch_inputs_invalidates_the_aggregate() {
+    let project = TestProject::new();
+    let mut state = GlobalState::new(ClientSocket::new_closed());
+    for (root, name) in [("/a", "First"), ("/b", "Second"), ("/c", "Removed")] {
+        std::fs::create_dir_all(project.path(root)).unwrap();
+        state.vfs.write().set_file_contents_with_version(
+            VfsPath::from(project.path(&format!("{root}/Main.sol"))),
+            Some(Rope::from(format!("contract {name} {{}}").as_str())),
+            Some(1),
+        );
+    }
+    state.config = Arc::new(project.config_with_roots(&["/a", "/b", "/c"]));
+    state.recompute_after_opening_source(Vec::new());
+    tokio::time::timeout(ASYNC_TEST_TIMEOUT, state.latest_analysis()).await.unwrap().unwrap();
+    let published = state.symbol_tables.load_full();
+    assert_eq!(published.workspace_symbols("").len(), 3);
+
+    // The remaining batches are reusable, but the newly empty batch changes the aggregate.
+    state.vfs.write().set_file_contents(VfsPath::from(project.path("/c/Main.sol")), None);
+    state.recompute_after_opening_source(Vec::new());
+    tokio::time::timeout(ASYNC_TEST_TIMEOUT, state.latest_analysis()).await.unwrap().unwrap();
+    let current = state.symbol_tables.load_full();
+    assert!(!Arc::ptr_eq(&published, &current));
+    assert!(current.workspace_symbols("Removed").is_empty());
+    assert_eq!(current.workspace_symbols("").len(), 2);
+
+    state.recompute_after_opening_source(Vec::new());
+    tokio::time::timeout(ASYNC_TEST_TIMEOUT, state.latest_analysis()).await.unwrap().unwrap();
+    assert!(Arc::ptr_eq(&current, &state.symbol_tables.load()));
+}
+
+#[tokio::test(flavor = "current_thread")]
 async fn editing_one_workspace_reuses_other_workspace_and_current_document_versions() {
     let project = TestProject::from_fixture(
         r#"
@@ -367,6 +477,53 @@ async fn workspace_batch_cache_rechecks_untracked_imports_and_resolver_probes() 
         tokio::time::timeout(ASYNC_TEST_TIMEOUT, state.latest_analysis()).await.unwrap().unwrap();
         assert_eq!(state.symbol_tables.load().workspace_symbols("dependencyChanged").len(), 1);
         assert!(cached_batch_for_path(&state, &other).is_some());
+    }
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn unchanged_workspace_inputs_still_recheck_disk_dependencies() {
+    for initially_missing in [false, true] {
+        let project = TestProject::from_fixture(
+            r#"
+            //- /a/Main.sol
+            contract Main {}
+            //- /b/Other.sol
+            import "./lib/Dep.sol";
+            contract Other is Dep {}
+            //- /b/lib/Dep.sol
+            contract Dep {}
+            "#,
+        );
+        let main = project.path("/a/Main.sol");
+        let other = project.path("/b/Other.sol");
+        if initially_missing {
+            project.remove_file("/b/lib/Dep.sol");
+        }
+        let mut state = GlobalState::new(ClientSocket::new_closed());
+        state.config = Arc::new(project.config_with_roots(&["/a", "/b"]));
+        state.recompute_after_opening_source(Vec::new());
+        tokio::time::timeout(ASYNC_TEST_TIMEOUT, state.latest_analysis()).await.unwrap().unwrap();
+        let published = state.symbol_tables.load_full();
+        let original_main = cached_batch_for_path(&state, &main).unwrap();
+        let original_other = cached_batch_for_path(&state, &other).unwrap();
+        let vfs_revision = state.vfs.read().content_revision();
+
+        // All batch inputs match, but the previously observed import must be checked again.
+        // Neither a document edit nor a watcher event signals this disk change.
+        project.write_file("/b/lib/Dep.sol", "contract Dep { uint public dependencyChanged; }");
+        state.recompute_after_opening_source(Vec::new());
+        tokio::time::timeout(ASYNC_TEST_TIMEOUT, state.latest_analysis()).await.unwrap().unwrap();
+        assert_eq!(state.vfs.read().content_revision(), vfs_revision);
+        assert!(!Arc::ptr_eq(&published, &state.symbol_tables.load()));
+        assert!(Arc::ptr_eq(&original_main, &cached_batch_for_path(&state, &main).unwrap()));
+        assert!(!Arc::ptr_eq(&original_other, &cached_batch_for_path(&state, &other).unwrap()));
+        assert_eq!(state.symbol_tables.load().workspace_symbols("dependencyChanged").len(), 1);
+        assert!(state.diagnostics.read().workspace_pull_reports(Vec::new()).into_iter().all(
+            |report| match report.report {
+                PullReport::Full { diagnostics, .. } => diagnostics.is_empty(),
+                PullReport::Unchanged { .. } => unreachable!("no previous result IDs"),
+            }
+        ));
     }
 }
 


### PR DESCRIPTION
Towards OSS-738 , 

- Reuse the combined workspace index when every batch still matches its source inputs and filesystem dependencies. This keeps initialized query indexes alive across analysis epochs instead of cloning each batch and rebuilding the aggregate.

- Refresh document versions on reuse, including closed overlays, while keeping the existing rebuild path for changed sources, missing imports, dependency changes, and workspaces that become empty.

- Add lifecycle benchmarks that separate initial indexing from incremental first requests. 

![Incremental LSP first-request latency](https://github.com/0xKarl98/solar/releases/download/lsp-aggregate-reuse-bench/benchmark.png)
