### PR TITLE
perf(lsp): skip import lexing outside strings

### DIFF
--- a/crates/lsp/src/import_resolution.rs
+++ b/crates/lsp/src/import_resolution.rs
@@ -39,6 +39,13 @@ pub(crate) fn import_path_at(source: &str, cursor: usize) -> Option<ImportPathAt
         return None;
     }
 
+    // Most navigation requests are issued from ordinary code. Avoid lexing the complete prefix
+    // when the cursor's line cannot contain a string (the lexer remains the source of truth when
+    // a quote or an escaped line continuation is present).
+    if !may_complete_string(source, cursor) {
+        return None;
+    }
+
     // Import paths are plain strings; code navigation does not need a full-file parse.
     plain_string_at(source, cursor)?;
     parse_import_path(source, cursor)


### PR DESCRIPTION
Towards OSS-738 ,  

`import_path_at` handled every definition lookup by running the lexer from the beginning of the source file. Most requests come from ordinary code, where an import string is impossible.

- Reuse the existing `may_complete_string` scan before invoking `plain_string_at`.
- Return immediately when the cursor line has no quote and no escaped line continuation.
- Keep the existing lexer and parser path for strings, comments containing quotes, and multiline continuations.


Benchmark evidence (`cargo bench -p solar-lsp --features bench --bench lsp -- --noplot`):

| Case | Before | After | Change |
| --- | ---: | ---: | ---: |
| `lsp/import-path/optimism-code` | 5.40–5.45 ms | 3.36–3.42 ns | ~1.6M× faster |

The benchmark uses a 5.38 MB source with the cursor in ordinary code near the end of the file. Criterion compared a 20-sample baseline with a 30-sample optimized run.

