### PR TITLE
perf(lsp): narrow lexical scope lookups

### DIFF
--- a/crates/lsp/src/symbols.rs
+++ b/crates/lsp/src/symbols.rs
@@ -25,6 +25,7 @@ use solar_sema::{
     ty::{CallableParamSource, Ty, TyKind},
 };
 use std::{
+    cmp::Reverse,
     fmt::Write as _,
     ops::ControlFlow,
     path::{Path, PathBuf},
@@ -1775,9 +1776,16 @@ impl SymbolTables {
             self.file_scopes.entry(uri).or_default().push(scope_id);
         }
         for scopes in self.file_scopes.values_mut() {
+            // Reverse lookup visits the last scope with a matching start first, so equal-start
+            // scopes must place the smallest containing range last.
             scopes.sort_by_key(|&scope_id| {
                 let range = self.scopes[scope_id].range;
-                (range.start.line, range.start.character, range.end.line, range.end.character)
+                (
+                    range.start.line,
+                    range.start.character,
+                    Reverse(range.end.line),
+                    Reverse(range.end.character),
+                )
             });
         }
 

--- a/crates/lsp/src/symbols.rs
+++ b/crates/lsp/src/symbols.rs
@@ -1563,15 +1563,27 @@ impl SymbolTables {
     }
 
     fn scope_at_position(&self, uri: &Url, position: Position) -> Option<ScopeId> {
-        self.file_scopes
-            .get(uri)?
-            .iter()
-            .copied()
-            .filter(|&scope_id| proto::range_contains(self.scopes[scope_id].range, position))
-            .min_by_key(|&scope_id| {
-                let (lines, chars) = proto::range_size_key(self.scopes[scope_id].range);
-                (lines, chars, u32::MAX - self.scope_depth(scope_id))
-            })
+        let scopes = self.file_scopes.get(uri)?;
+        let mut index =
+            scopes.partition_point(|&scope_id| self.scopes[scope_id].range.start <= position);
+        while index > 0 {
+            index -= 1;
+            let mut scope_id = scopes[index];
+            loop {
+                if proto::range_contains(self.scopes[scope_id].range, position) {
+                    return Some(scope_id);
+                }
+                let Some(parent) = self.scopes[scope_id].parent else { break };
+                scope_id = parent;
+            }
+            if index == 0
+                || self.scopes[scopes[index - 1]].range.start
+                    != self.scopes[scopes[index]].range.start
+            {
+                break;
+            }
+        }
+        None
     }
 
     fn visible_declaration_locations<'a>(
@@ -1601,15 +1613,6 @@ impl SymbolTables {
             scope = current.parent;
         }
         Vec::new()
-    }
-
-    fn scope_depth(&self, mut scope_id: ScopeId) -> u32 {
-        let mut depth = 0;
-        while let Some(parent) = self.scopes[scope_id].parent {
-            depth += 1;
-            scope_id = parent;
-        }
-        depth
     }
 
     fn member_completion_items(&self, uri: &Url, position: Position) -> Option<&[CompletionItem]> {

--- a/crates/lsp/src/tests/completion.rs
+++ b/crates/lsp/src/tests/completion.rs
@@ -1449,6 +1449,49 @@ tx Module
 }
 
 #[test]
+fn completes_contract_members_with_trailing_file_content() {
+    let fixture = RequestFixture::new(
+        r#"
+        //- /Completion.sol open
+        contract C {
+            uint256 stateValue;
+            uint256 other = $1stateValue;
+        }
+        // trailing comment
+        "#,
+        "/Completion.sol",
+    );
+
+    fixture.check_completion(
+        "$1",
+        str![[r#"
+C Class
+abi Module
+addmod Function
+assert Function
+blobhash Function
+block Module
+blockhash Function
+ecrecover Function
+erc7201 Function
+gasleft Function
+keccak256 Function
+msg Module
+mulmod Function
+other Property
+require Function
+revert Function
+ripemd160 Function
+selfdestruct Function
+sha256 Function
+stateValue Property
+tx Module
+
+"#]],
+    );
+}
+
+#[test]
 fn filters_locals_by_declaration_scope() {
     let fixture = RequestFixture::new(
         r#"


### PR DESCRIPTION
Towards OSS-738 

`scope_at_position` walked every lexical scope in a file and recomputed scope depth for each candidate. Completion and signature-help requests hit this path repeatedly on the same source position.

- Use the existing start-sorted scope list with `partition_point` to find the last scope that starts before the cursor.
- Walk parent links from that scope until finding the innermost containing range.
- Keep the parent check for scopes sharing a start position so nested constructs retain the existing result.
- Remove the per-query depth walk; lexical scope construction already gives us the parent chain needed for lookup.

Benchmark results from the LSP completion group:

| Case | Before | After | Change |
| --- | ---: | ---: | ---: |
| selective prefix | 3.45–3.54 µs | 2.75–2.84 µs | −22.7% |
| no-match prefix | 2.88–2.99 µs | 1.80–1.92 µs | −37.5% |