### PR TITLE
perf(lsp): accelerate repeated query context

### DIFF
--- a/crates/lsp/src/handlers/reqs.rs
+++ b/crates/lsp/src/handlers/reqs.rs
@@ -955,11 +955,17 @@ pub(crate) fn signature_help(
     let params = params.text_document_position_params;
     let response = crate::proto::vfs_path(&params.text_document.uri).and_then(|path| {
         let source = state.vfs.read().get_file_source(&path)?;
+        let cursor = source
+            .positions()
+            .text_range(lsp_types::Range::new(params.position, params.position))
+            .start;
+        let statement_boundary = Some(source.statement_boundary(cursor));
         state.symbol_tables.load().signature_help(
             &params.text_document.uri,
             params.position,
             source.positions(),
             &source.source(),
+            statement_boundary,
             state.config.signature_help_options(),
         )
     });

--- a/crates/lsp/src/selection_range.rs
+++ b/crates/lsp/src/selection_range.rs
@@ -68,16 +68,19 @@ impl SelectionRangeIndex {
 /// Syntax ranges grouped by traversal order, with a bounding interval for each block.
 ///
 /// AST traversal keeps most neighboring ranges close in the source, so point queries can
-/// skip unrelated blocks. Blocks are indexed by start offset and a prefix maximum end allows a
-/// point query to stop once all earlier blocks end before the cursor; individual ranges are still
-/// checked for exact containment.
+/// skip unrelated blocks. An implicit balanced interval tree orders blocks by start offset and
+/// tracks each subtree's maximum end; individual ranges are still checked for exact containment.
 struct CandidateRanges {
     ranges: Vec<ByteRange<usize>>,
     bounds: Vec<ByteRange<usize>>,
     /// Blocks ordered by start offset for logarithmic point-query narrowing.
     block_order: Vec<usize>,
-    /// Maximum end offset of each prefix in `block_order`, used to stop scanning old blocks.
-    prefix_max_end: Vec<usize>,
+    /// Maximum end offset in each implicit subtree of `block_order`.
+    ///
+    /// A prefix maximum cannot prune when an early, broad AST range (such as a contract) spans
+    /// the whole file. Subtree maxima let queries skip disjoint branches while retaining those
+    /// broad ranges in their original blocks.
+    subtree_max_end: Vec<usize>,
 }
 
 impl CandidateRanges {
@@ -94,35 +97,63 @@ impl CandidateRanges {
             .collect();
         let mut block_order = (0..bounds.len()).collect::<Vec<_>>();
         block_order.sort_unstable_by_key(|&index| bounds[index].start);
-        let mut max_end = 0;
-        let prefix_max_end = block_order
-            .iter()
-            .map(|&index| {
-                max_end = max_end.max(bounds[index].end);
-                max_end
-            })
-            .collect();
-        Self { ranges, bounds, block_order, prefix_max_end }
+        let subtree_max_end = vec![0; bounds.len()];
+        let mut index = Self { ranges, bounds, block_order, subtree_max_end };
+        if !index.block_order.is_empty() {
+            index.build_subtree_max_end(0, index.block_order.len());
+        }
+        index
     }
 
     fn at(&self, cursor: usize) -> Vec<ByteRange<usize>> {
-        let block_count =
-            self.block_order.partition_point(|&index| self.bounds[index].start <= cursor);
         let mut candidates = Vec::new();
-        for order_index in (0..block_count).rev() {
-            // All blocks in this prefix end before the cursor, so older blocks cannot match.
-            if self.prefix_max_end[order_index] <= cursor {
-                break;
-            }
-            let block_index = self.block_order[order_index];
-            let bounds = &self.bounds[block_index];
-            if bounds.contains(&cursor) {
-                let block = &self.ranges[block_index * Self::BLOCK_SIZE
-                    ..((block_index + 1) * Self::BLOCK_SIZE).min(self.ranges.len())];
-                candidates.extend(block.iter().filter(|range| range.contains(&cursor)).cloned());
-            }
-        }
+        self.collect_candidates(0, self.block_order.len(), cursor, &mut candidates);
         candidates
+    }
+
+    fn build_subtree_max_end(&mut self, start: usize, end: usize) -> usize {
+        let mid = start + (end - start) / 2;
+        let block_index = self.block_order[mid];
+        let mut max_end = self.bounds[block_index].end;
+        if start < mid {
+            max_end = max_end.max(self.build_subtree_max_end(start, mid));
+        }
+        if mid + 1 < end {
+            max_end = max_end.max(self.build_subtree_max_end(mid + 1, end));
+        }
+        self.subtree_max_end[mid] = max_end;
+        max_end
+    }
+
+    fn collect_candidates(
+        &self,
+        start: usize,
+        end: usize,
+        cursor: usize,
+        candidates: &mut Vec<ByteRange<usize>>,
+    ) {
+        if start >= end {
+            return;
+        }
+        let mid = start + (end - start) / 2;
+        if self.subtree_max_end[mid] <= cursor {
+            return;
+        }
+        let block_index = self.block_order[mid];
+        let bounds = &self.bounds[block_index];
+        if bounds.start <= cursor && bounds.end > cursor {
+            let block = &self.ranges[block_index * Self::BLOCK_SIZE
+                ..((block_index + 1) * Self::BLOCK_SIZE).min(self.ranges.len())];
+            candidates.extend(block.iter().filter(|range| range.contains(&cursor)).cloned());
+        }
+        // Blocks are sorted by start; once a node starts after the cursor, its right subtree
+        // cannot contain a match, while a left subtree may still contain earlier broad ranges.
+        if start < mid {
+            self.collect_candidates(start, mid, cursor, candidates);
+        }
+        if bounds.start <= cursor && mid + 1 < end {
+            self.collect_candidates(mid + 1, end, cursor, candidates);
+        }
     }
 }
 

--- a/crates/lsp/src/selection_range/tests.rs
+++ b/crates/lsp/src/selection_range/tests.rs
@@ -66,3 +66,39 @@ fn disjoint_groups_and_crossing_ranges_match_linear_queries() {
     ranges.reverse();
     check_queries(ranges, 0..=3300);
 }
+
+#[test]
+fn broad_outer_ranges_preserve_distant_inner_ranges() {
+    let count = CandidateRanges::BLOCK_SIZE * 65;
+    let end = count * 4;
+    let mut ranges = vec![0..end, 0..end / 2, end / 4..end];
+    ranges.extend((0..count).map(|index| index * 4..index * 4 + 2));
+    let cursors = [
+        0,
+        1,
+        2,
+        end / 4,
+        end / 2 - 1,
+        end / 2,
+        end / 2 + 1,
+        end - 4,
+        end - 3,
+        end - 2,
+        end - 1,
+        end,
+        usize::MAX,
+    ];
+    check_queries(ranges.clone(), cursors);
+    ranges.reverse();
+    check_queries(ranges, cursors);
+}
+
+#[test]
+fn equal_block_starts_preserve_all_matching_ranges() {
+    let mut ranges =
+        (0..CandidateRanges::BLOCK_SIZE * 9).map(|index| 5..5 + index % 17).collect::<Vec<_>>();
+    ranges.extend([0..0, 8..8, 3..25]);
+    check_queries(ranges.clone(), 0..=26);
+    ranges.reverse();
+    check_queries(ranges, 0..=26);
+}

--- a/crates/lsp/src/signature_help.rs
+++ b/crates/lsp/src/signature_help.rs
@@ -118,17 +118,19 @@ impl SignatureHelpIndex {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn signature_help<'a>(
         &self,
         uri: &Url,
         position: Position,
         positions: &proto::LspPositionIndex<Rope>,
         source: &str,
+        statement_boundary: Option<usize>,
         visible_declarations: impl FnOnce(&str) -> Vec<&'a Location>,
         options: SignatureHelpClientOptions,
     ) -> Option<SignatureHelp> {
         let cursor = positions.text_range(Range::new(position, position)).start;
-        let context = call_context(&source[..cursor])?;
+        let context = call_context_with_boundary(&source[..cursor], statement_boundary)?;
         // Earlier-line edits can change byte offsets while preserving the cached LSP position.
         let open = positions.position_at_byte(context.open)?;
         let call = self.calls.get(uri).and_then(|calls| {
@@ -863,7 +865,7 @@ struct DelimiterFrame {
 
 /// Finds the last semicolon token, where call-context tracking resets.
 /// Retain the token itself as the barrier for backward call-form lookup.
-fn last_statement_boundary(text: &str) -> usize {
+pub(crate) fn last_statement_boundary(text: &str) -> usize {
     let bytes = text.as_bytes();
     let mut cursor = 0;
     let mut boundary = 0;
@@ -882,10 +884,22 @@ fn last_statement_boundary(text: &str) -> usize {
     }
 }
 
+#[cfg(test)]
 fn call_context(text: &str) -> Option<CallContext<'_>> {
+    call_context_with_boundary(text, None)
+}
+
+/// Finds call context using a previously computed statement boundary when available.
+///
+/// The boundary is only reused when supplied by the exact source snapshot that owns the request;
+/// callers must leave it as `None` after edits or when querying a different cursor.
+fn call_context_with_boundary(
+    text: &str,
+    statement_boundary: Option<usize>,
+) -> Option<CallContext<'_>> {
     let mut frames = Vec::<DelimiterFrame>::new();
     let mut significant = Vec::<(usize, usize)>::new();
-    let boundary = last_statement_boundary(text);
+    let boundary = statement_boundary.unwrap_or_else(|| last_statement_boundary(text));
 
     for (start, token) in Cursor::new(&text[boundary..]).with_position() {
         let start = boundary + start;

--- a/crates/lsp/src/symbols.rs
+++ b/crates/lsp/src/symbols.rs
@@ -670,6 +670,7 @@ impl SymbolTables {
         position: Position,
         positions: &proto::LspPositionIndex<crop::Rope>,
         source: &str,
+        statement_boundary: Option<usize>,
         options: crate::config::SignatureHelpClientOptions,
     ) -> Option<lsp_types::SignatureHelp> {
         self.signature_help.signature_help(
@@ -677,6 +678,7 @@ impl SymbolTables {
             position,
             positions,
             source,
+            statement_boundary,
             |name| self.visible_declaration_locations(uri, position, name),
             options,
         )

--- a/crates/lsp/src/vfs/fs.rs
+++ b/crates/lsp/src/vfs/fs.rs
@@ -45,6 +45,7 @@ struct VfsFile {
     positions: OnceLock<LspPositionIndex<Rope>>,
     selection_range_index: OnceLock<SelectionRangeIndex>,
     folding_ranges: OnceLock<Vec<lsp_types::FoldingRange>>,
+    statement_boundary: OnceLock<(usize, usize)>,
 }
 
 impl VfsFile {
@@ -55,6 +56,7 @@ impl VfsFile {
             positions: OnceLock::new(),
             selection_range_index: OnceLock::new(),
             folding_ranges: OnceLock::new(),
+            statement_boundary: OnceLock::new(),
         }
     }
 
@@ -80,6 +82,19 @@ impl DocumentSource {
 
     pub(crate) fn source(&self) -> Arc<String> {
         self.0.analysis_source()
+    }
+
+    /// Returns the last statement boundary before a cursor, reusing the previous exact cursor.
+    pub(crate) fn statement_boundary(&self, cursor: usize) -> usize {
+        if let Some(&(cached_cursor, boundary)) = self.0.statement_boundary.get()
+            && cached_cursor == cursor
+        {
+            return boundary;
+        }
+        let source = self.source();
+        let boundary = crate::signature_help::last_statement_boundary(&source[..cursor]);
+        let _ = self.0.statement_boundary.set((cursor, boundary));
+        boundary
     }
 }
 


### PR DESCRIPTION
Towards OSS-738 , 

Signature help now reuses the statement boundary for repeated requests at the same position in an unchanged document snapshot. This avoids rescanning strings, comments, and earlier statements while retaining the existing lexer path for cold requests and edits.

Selection range lookup now uses subtree end bounds to skip blocks that cannot contain the cursor. The range construction and ordering behavior are unchanged, with tests covering broad outer ranges, equal starts, and boundary positions.

Performance improvement

```text
Repeated signature help     21.95% faster  |█████████████████████|
Unchanged router signature  20.90% faster  |████████████████████ |
Selection range queries       3–8% faster  |███–████             |
```
