### PR TITLE
perf(lsp): presort call hierarchy relations

### DIFF
--- a/crates/lsp/src/call_hierarchy.rs
+++ b/crates/lsp/src/call_hierarchy.rs
@@ -1,4 +1,9 @@
 //! Call hierarchy indexing.
+//!
+//! Analysis records source callables and direct calls as mergeable facts. The first hierarchy
+//! request builds a query index, excluding incompatible source identities before grouping edges.
+//! Neighbor lists are sorted once by source identity and retain canonical symbol IDs, so later
+//! requests only materialize their LSP items and call ranges in the established protocol order.
 
 use crate::{
     hierarchy::{HierarchyItem, HierarchyKey as CallableKey},
@@ -53,19 +58,19 @@ struct CallableFact {
 #[derive(Debug, Default)]
 struct QueryIndex {
     items_by_symbol: FxHashMap<SymbolId, HierarchyItem>,
-    candidate_key_by_symbol: FxHashMap<SymbolId, CallableKey>,
     body_range_by_symbol: FxHashMap<SymbolId, Range>,
     canonical_symbol_by_key: FxHashMap<CallableKey, SymbolId>,
-    key_by_symbol: FxHashMap<SymbolId, CallableKey>,
-    outgoing_by_key: CallRelations,
-    incoming_by_key: CallRelations,
-    incomplete_outgoing: FxHashSet<CallableKey>,
-    incomplete_incoming: FxHashSet<CallableKey>,
+    canonical_symbol_by_symbol: FxHashMap<SymbolId, SymbolId>,
+    outgoing_by_symbol: CallRelations,
+    incoming_by_symbol: CallRelations,
+    incomplete_outgoing: FxHashSet<SymbolId>,
+    incomplete_incoming: FxHashSet<SymbolId>,
     call_sites_by_uri: FxHashMap<Arc<Url>, IndexedRanges<CallSite>>,
     bodies_by_uri: FxHashMap<Arc<Url>, IndexedRanges<CallableBody>>,
 }
 
-type CallRelations = FxHashMap<CallableKey, FxHashMap<CallableKey, Vec<Range>>>;
+type CallRelations = FxHashMap<SymbolId, Vec<(SymbolId, Vec<Range>)>>;
+type CallRelationGroups = FxHashMap<SymbolId, Vec<(SymbolId, Range)>>;
 
 /// Entries sorted by start position with a prefix maximum end, allowing point queries to
 /// skip entries that end before the cursor while retaining the original range tie order.
@@ -250,14 +255,13 @@ impl QueryIndex {
             index.items_by_symbol.insert(
                 fact.symbol,
                 HierarchyItem {
-                    key: key.clone(),
+                    key,
                     name: declaration.name.clone(),
                     kind: declaration.kind,
                     detail,
                     range: declaration.location.range,
                 },
             );
-            index.candidate_key_by_symbol.insert(fact.symbol, key);
             if let Some(range) = fact.body_range {
                 index.body_range_by_symbol.insert(fact.symbol, range);
             }
@@ -269,13 +273,13 @@ impl QueryIndex {
     fn rebuild(&mut self, direct_calls: &[DirectCall], conflicting_contents: &FxHashSet<Url>) {
         let mut outgoing_facts_by_symbol = FxHashMap::<SymbolId, Vec<_>>::default();
         for call in direct_calls {
-            let Some(callee) = self.candidate_key_by_symbol.get(&call.callee) else {
+            let Some(callee) = self.items_by_symbol.get(&call.callee) else {
                 continue;
             };
             outgoing_facts_by_symbol
                 .entry(call.caller)
                 .or_default()
-                .push((callee.clone(), proto::range_key(call.from_range)));
+                .push((callee.key.clone(), proto::range_key(call.from_range)));
         }
         for facts in outgoing_facts_by_symbol.values_mut() {
             facts.sort_unstable();
@@ -283,7 +287,8 @@ impl QueryIndex {
         }
 
         let mut incompatible_keys = FxHashSet::default();
-        for (&symbol, key) in &self.candidate_key_by_symbol {
+        for (&symbol, item) in &self.items_by_symbol {
+            let key = &item.key;
             if conflicting_contents.contains(key.uri.as_ref()) || incompatible_keys.contains(key) {
                 continue;
             }
@@ -292,7 +297,7 @@ impl QueryIndex {
                     outgoing_facts_by_symbol.get(&symbol).map(Vec::as_slice).unwrap_or_default();
                 let existing_facts =
                     outgoing_facts_by_symbol.get(&existing).map(Vec::as_slice).unwrap_or_default();
-                if self.items_by_symbol.get(&symbol) != self.items_by_symbol.get(&existing)
+                if item != &self.items_by_symbol[&existing]
                     || self.body_range_by_symbol.get(&symbol)
                         != self.body_range_by_symbol.get(&existing)
                     || facts != existing_facts
@@ -304,48 +309,40 @@ impl QueryIndex {
                 self.canonical_symbol_by_key.insert(key.clone(), symbol);
             }
         }
-        self.canonical_symbol_by_key.retain(|_, symbol| self.items_by_symbol.contains_key(symbol));
-        for (&symbol, key) in &self.candidate_key_by_symbol {
-            if self.items_by_symbol.contains_key(&symbol)
-                && self.canonical_symbol_by_key.contains_key(key)
-            {
-                self.key_by_symbol.insert(symbol, key.clone());
+        for (&symbol, item) in &self.items_by_symbol {
+            if let Some(&canonical) = self.canonical_symbol_by_key.get(&item.key) {
+                self.canonical_symbol_by_symbol.insert(symbol, canonical);
             }
         }
 
+        let mut outgoing_by_symbol = CallRelationGroups::default();
+        let mut incoming_by_symbol = CallRelationGroups::default();
         for call in direct_calls {
-            let caller = self.key_by_symbol.get(&call.caller);
-            let callee = self.key_by_symbol.get(&call.callee);
+            let caller = self.canonical_symbol_by_symbol.get(&call.caller).copied();
+            let callee = self.canonical_symbol_by_symbol.get(&call.callee).copied();
             if let Some(caller) = caller {
                 self.call_sites_by_uri
-                    .entry(caller.uri.clone())
+                    .entry(self.items_by_symbol[&caller].key.uri.clone())
                     .or_default()
-                    .push(CallSite { range: call.from_range, callee: callee.cloned() });
+                    .push(CallSite {
+                        range: call.from_range,
+                        callee: callee.map(|callee| self.items_by_symbol[&callee].key.clone()),
+                    });
             }
             let (Some(caller), Some(callee)) = (caller, callee) else {
                 if let Some(caller) = caller {
-                    self.incomplete_outgoing.insert(caller.clone());
+                    self.incomplete_outgoing.insert(caller);
                 }
                 if let Some(callee) = callee {
-                    self.incomplete_incoming.insert(callee.clone());
+                    self.incomplete_incoming.insert(callee);
                 }
                 continue;
             };
-            self.outgoing_by_key
-                .entry(caller.clone())
-                .or_default()
-                .entry(callee.clone())
-                .or_default()
-                .push(call.from_range);
-            self.incoming_by_key
-                .entry(callee.clone())
-                .or_default()
-                .entry(caller.clone())
-                .or_default()
-                .push(call.from_range);
+            outgoing_by_symbol.entry(caller).or_default().push((callee, call.from_range));
+            incoming_by_symbol.entry(callee).or_default().push((caller, call.from_range));
         }
-        normalize_relations(&mut self.outgoing_by_key);
-        normalize_relations(&mut self.incoming_by_key);
+        self.outgoing_by_symbol = finish_relations(outgoing_by_symbol, &self.items_by_symbol);
+        self.incoming_by_symbol = finish_relations(incoming_by_symbol, &self.items_by_symbol);
         for sites in self.call_sites_by_uri.values_mut() {
             sites.entries.sort_by(|a, b| {
                 proto::range_key(a.range)
@@ -385,8 +382,10 @@ impl QueryIndex {
             let key = site.callee.as_ref()?;
             return Some(vec![self.item(key)?.to_call_item()]);
         }
-        if let Some(key) = declaration.and_then(|symbol| self.key_by_symbol.get(&symbol)) {
-            return Some(vec![self.item(key)?.to_call_item()]);
+        if let Some(symbol) =
+            declaration.and_then(|symbol| self.canonical_symbol_by_symbol.get(&symbol))
+        {
+            return Some(vec![self.items_by_symbol[symbol].to_call_item()]);
         }
         let key = self.enclosing_body_key(uri, position)?;
         Some(vec![self.item(key)?.to_call_item()])
@@ -396,20 +395,17 @@ impl QueryIndex {
         &self,
         item: &CallHierarchyItem,
     ) -> Option<Vec<CallHierarchyIncomingCall>> {
-        let key = self.resolve_item(item)?;
-        if self.incomplete_incoming.contains(&key) {
+        let symbol = self.resolve_item(item)?;
+        if self.incomplete_incoming.contains(&symbol) {
             return None;
         }
-        let mut callers = self.incoming_by_key.get(&key).into_iter().flatten().collect::<Vec<_>>();
-        callers.sort_by_key(|(caller, _)| *caller);
+        let callers = self.incoming_by_symbol.get(&symbol).map(Vec::as_slice).unwrap_or_default();
         Some(
             callers
-                .into_iter()
-                .filter_map(|(caller, ranges)| {
-                    Some(CallHierarchyIncomingCall {
-                        from: self.item(caller)?.to_call_item(),
-                        from_ranges: ranges.clone(),
-                    })
+                .iter()
+                .map(|(caller, ranges)| CallHierarchyIncomingCall {
+                    from: self.items_by_symbol[caller].to_call_item(),
+                    from_ranges: ranges.clone(),
                 })
                 .collect(),
         )
@@ -419,20 +415,17 @@ impl QueryIndex {
         &self,
         item: &CallHierarchyItem,
     ) -> Option<Vec<CallHierarchyOutgoingCall>> {
-        let key = self.resolve_item(item)?;
-        if self.incomplete_outgoing.contains(&key) {
+        let symbol = self.resolve_item(item)?;
+        if self.incomplete_outgoing.contains(&symbol) {
             return None;
         }
-        let mut callees = self.outgoing_by_key.get(&key).into_iter().flatten().collect::<Vec<_>>();
-        callees.sort_by_key(|(callee, _)| *callee);
+        let callees = self.outgoing_by_symbol.get(&symbol).map(Vec::as_slice).unwrap_or_default();
         Some(
             callees
-                .into_iter()
-                .filter_map(|(callee, ranges)| {
-                    Some(CallHierarchyOutgoingCall {
-                        to: self.item(callee)?.to_call_item(),
-                        from_ranges: ranges.clone(),
-                    })
+                .iter()
+                .map(|(callee, ranges)| CallHierarchyOutgoingCall {
+                    to: self.items_by_symbol[callee].to_call_item(),
+                    from_ranges: ranges.clone(),
                 })
                 .collect(),
         )
@@ -467,16 +460,17 @@ impl QueryIndex {
         self.items_by_symbol.get(self.canonical_symbol_by_key.get(key)?)
     }
 
-    fn resolve_item(&self, item: &CallHierarchyItem) -> Option<CallableKey> {
+    fn resolve_item(&self, item: &CallHierarchyItem) -> Option<SymbolId> {
         let key = CallableKey::from_data(item.data.as_ref()?)?;
-        let current = self.item(&key)?;
+        let &symbol = self.canonical_symbol_by_key.get(&key)?;
+        let current = &self.items_by_symbol[&symbol];
         // Name and kind distinguish a declaration replacement at the same source position. The
         // full range and detail are presentation data that may change while the callable remains.
         (item.uri == *current.key.uri
             && item.selection_range == current.key.selection_range
             && item.name == current.name
             && item.kind == current.kind)
-            .then_some(key)
+            .then_some(symbol)
     }
 }
 
@@ -619,13 +613,28 @@ fn resolved_source_call<'gcx>(
     Some((callee_id, span))
 }
 
-fn normalize_relations(relations: &mut CallRelations) {
-    for targets in relations.values_mut() {
-        for ranges in targets.values_mut() {
-            ranges.sort_by_key(|&range| proto::range_key(range));
-            ranges.dedup();
-        }
-    }
+/// Freezes grouped edges in protocol order after incompatible endpoints have been excluded.
+fn finish_relations(
+    relations: CallRelationGroups,
+    items: &FxHashMap<SymbolId, HierarchyItem>,
+) -> CallRelations {
+    relations
+        .into_iter()
+        .map(|(source, mut targets)| {
+            targets.sort_unstable_by(|(a, ar), (b, br)| {
+                items[a]
+                    .key
+                    .cmp(&items[b].key)
+                    .then_with(|| proto::range_key(*ar).cmp(&proto::range_key(*br)))
+            });
+            targets.dedup();
+            let grouped = targets
+                .chunk_by(|a, b| a.0 == b.0)
+                .map(|calls| (calls[0].0, calls.iter().map(|&(_, range)| range).collect()))
+                .collect();
+            (source, grouped)
+        })
+        .collect()
 }
 
 #[cfg(test)]

--- a/crates/lsp/src/tests/call_hierarchy.rs
+++ b/crates/lsp/src/tests/call_hierarchy.rs
@@ -3,7 +3,7 @@ use crate::{
     symbols::{SymbolTables, SymbolTablesAggregator},
     test_support::MarkedProject,
 };
-use lsp_types::{Position, Range, Url};
+use lsp_types::{CallHierarchyIncomingCall, CallHierarchyOutgoingCall, Position, Range, Url};
 use solar_config::CompileOpts;
 
 #[test]
@@ -46,6 +46,85 @@ fn basic_direct_call_hierarchy() {
     assert_eq!(incoming.len(), 1);
     assert_eq!(incoming[0].from, caller);
     assert_eq!(incoming[0].from_ranges, outgoing[0].from_ranges);
+}
+
+#[test]
+fn merged_relations_preserve_uri_and_source_order() {
+    let marked = MarkedProject::from_fixture(
+        r#"
+        //- /Z.sol
+        import {target} from "./B.sol";
+        function $1last() { $2target(); }
+        //- /M.sol
+        import {zebra, alpha} from "./A.sol";
+        import {target} from "./B.sol";
+        import {last} from "./Z.sol";
+        function $3caller() {
+            $4last(); $5target(); $6alpha(); $7zebra(); $8target();
+        }
+        //- /B.sol
+        function $9target() {}
+        //- /A.sol
+        import {target} from "./B.sol";
+        function $10zebra() { $11target(); }
+        function $12alpha() { $13target(); }
+        //- /Driver.sol
+        import "./M.sol";
+        "#,
+    );
+    let project = marked.project();
+    // Input, call-site and name order differ from the protocol's URI/source order.
+    let tables = analyze(AnalysisBatch::from_files(
+        CompileOpts::default(),
+        ["/Z.sol", "/M.sol", "/B.sol", "/A.sol"]
+            .map(|path| (project.path(path), project.read_file(path))),
+    ))
+    .symbol_tables;
+    let duplicate = analyze(AnalysisBatch::from_files(
+        CompileOpts::default(),
+        [(project.path("/Driver.sol"), project.read_file("/Driver.sol"))],
+    ))
+    .symbol_tables;
+    let tables = merge_symbol_tables(tables, duplicate);
+    let item = |path, marker| {
+        let uri = Url::from_file_path(project.path(path)).unwrap();
+        tables
+            .prepare_call_hierarchy(&uri, marked.marker(marker).position())
+            .unwrap()
+            .pop()
+            .unwrap()
+    };
+    let zebra = item("/A.sol", "$10");
+    let alpha = item("/A.sol", "$12");
+    let target = item("/B.sol", "$9");
+    let caller = item("/M.sol", "$3");
+    let last = item("/Z.sol", "$1");
+    let target_ranges = vec![marker_range(&marked, "$5", 6), marker_range(&marked, "$8", 6)];
+    let incoming = vec![
+        CallHierarchyIncomingCall {
+            from: zebra.clone(),
+            from_ranges: vec![marker_range(&marked, "$11", 6)],
+        },
+        CallHierarchyIncomingCall {
+            from: alpha.clone(),
+            from_ranges: vec![marker_range(&marked, "$13", 6)],
+        },
+        CallHierarchyIncomingCall { from: caller.clone(), from_ranges: target_ranges.clone() },
+        CallHierarchyIncomingCall {
+            from: last.clone(),
+            from_ranges: vec![marker_range(&marked, "$2", 6)],
+        },
+    ];
+    let outgoing = vec![
+        CallHierarchyOutgoingCall { to: zebra, from_ranges: vec![marker_range(&marked, "$7", 5)] },
+        CallHierarchyOutgoingCall { to: alpha, from_ranges: vec![marker_range(&marked, "$6", 5)] },
+        CallHierarchyOutgoingCall { to: target.clone(), from_ranges: target_ranges },
+        CallHierarchyOutgoingCall { to: last, from_ranges: vec![marker_range(&marked, "$4", 4)] },
+    ];
+    for _ in 0..2 {
+        assert_eq!(tables.call_hierarchy_incoming(&target).unwrap(), incoming);
+        assert_eq!(tables.call_hierarchy_outgoing(&caller).unwrap(), outgoing);
+    }
 }
 
 #[test]


### PR DESCRIPTION
Sort call-hierarchy neighbors once during index construction and store grouped relations by canonical symbol ID. Incoming and outgoing requests avoid repeated sorting and URI hashing. Remove redundant identity maps while preserving source ordering, deduplication, and conflict handling.

| Operation | 128 callers (µs) | Change | 2,048 callers (µs) | Change |
|---|---:|---:|---:|---:|
| Incoming calls | 21.523 → 15.546 | -27.8% | 432.301 → 246.891 | -42.9% |
| Prepare: cold | 85.820 → 73.139 | -14.8% | 1477.217 → 1277.121 | -13.5% |
| Prepare: body | 0.148 → 0.145 | -1.9% | 0.176 → 0.164 | -6.8% |
| Prepare: call site | 0.148 → 0.156 | +5.2% | 0.175 → 0.187 | +7.0% |

