### PR TITLE
perf(lsp): reuse rename position indexes

### DIFF
--- a/crates/lsp/benches/lsp.rs
+++ b/crates/lsp/benches/lsp.rs
@@ -8,11 +8,11 @@ use lsp_types::{GotoDefinitionResponse, HoverContents, OneOf, Position, Url};
 use solar_config::CompileOpts;
 use solar_lsp::{
     BenchmarkAnalysis, BenchmarkDocumentUpdate, BenchmarkFoldingRangeRequests,
-    BenchmarkOpenDocuments, BenchmarkProject, BenchmarkRepeatedAnalysis, BenchmarkRequest,
-    BenchmarkResponse, BenchmarkSelectionRangeRequests, BenchmarkSignatureHelpRequests,
-    BenchmarkWorkspaceDiscovery, BenchmarkWorkspacePathQueries, BenchmarkWorkspaceReports,
-    benchmark_folding_ranges, benchmark_folding_ranges_from_rope, benchmark_import_path_at,
-    benchmark_selection_ranges,
+    BenchmarkOpenDocuments, BenchmarkProject, BenchmarkRenameRequests, BenchmarkRepeatedAnalysis,
+    BenchmarkRequest, BenchmarkResponse, BenchmarkSelectionRangeRequests,
+    BenchmarkSignatureHelpRequests, BenchmarkWorkspaceDiscovery, BenchmarkWorkspacePathQueries,
+    BenchmarkWorkspaceReports, benchmark_folding_ranges, benchmark_folding_ranges_from_rope,
+    benchmark_import_path_at, benchmark_selection_ranges,
 };
 use std::{fmt::Write as _, fs, hint::black_box, path::PathBuf};
 
@@ -219,6 +219,42 @@ fn rename_candidate_queries(c: &mut Criterion) {
     });
     group.bench_function(BenchmarkId::from_parameter("2048-callers-miss-near-eof"), |b| {
         b.iter(|| black_box(analysis.rename_candidate(black_box(&uri), black_box(miss_position))))
+    });
+    group.finish();
+}
+
+fn rename_requests(c: &mut Criterion) {
+    let mut group = c.benchmark_group("lsp/rename");
+    for reference_count in [0, 64, 2_048] {
+        let mut source = String::from("contract Root { function target() internal pure {}\n");
+        for index in 0..reference_count {
+            writeln!(source, "function caller{index}() public pure {{ target(); }}").unwrap();
+        }
+        source.push_str("}\n");
+        let project = BenchmarkProject::from_source(source);
+        let (uri, position) = project.unique_anchor("benchmark.sol", "target() internal").unwrap();
+        let mut requests = BenchmarkRenameRequests::new(project, uri.clone(), position);
+        let response = requests.run().expect("the target should be renameable");
+        let edits = &response.changes.as_ref().unwrap()[&uri];
+        assert_eq!(edits.len(), reference_count + 1);
+        assert!(edits.iter().all(|edit| edit.new_text == "renamed"));
+        group.bench_function(
+            BenchmarkId::from_parameter(format!("{reference_count}-references")),
+            |b| {
+                b.iter(|| black_box(requests.run()));
+            },
+        );
+    }
+
+    let project = unifap_project();
+    let (uri, position) = project.unique_anchor(UNIFAP_ROUTER, "_safeTransferFrom(\n").unwrap();
+    let mut requests = BenchmarkRenameRequests::new(project, uri, position);
+    let response = requests.run().expect("the router helper should be renameable");
+    let edits = response.changes.unwrap();
+    assert_eq!(edits.len(), 1);
+    assert_eq!(edits.values().next().unwrap().len(), 4);
+    group.bench_function(BenchmarkId::from_parameter("unifap-v2-router"), |b| {
+        b.iter(|| black_box(requests.run()));
     });
     group.finish();
 }
@@ -1210,6 +1246,7 @@ criterion_group!(
     benches,
     analysis_build,
     rename_candidate_queries,
+    rename_requests,
     completion_queries,
     member_completion_queries,
     signature_help_requests,

--- a/crates/lsp/src/global_state/benchmark.rs
+++ b/crates/lsp/src/global_state/benchmark.rs
@@ -23,9 +23,10 @@ use crop::Rope;
 use lsp_types::{
     CallHierarchyIncomingCall, CallHierarchyItem, CodeLens, CompletionItem, Diagnostic,
     DidChangeTextDocumentParams, DocumentSymbol, GotoDefinitionResponse, Hover, HoverContents,
-    Location, Position, PreviousResultId, Range, SignatureHelp, SignatureHelpParams,
+    Location, Position, PreviousResultId, Range, RenameParams, SignatureHelp, SignatureHelpParams,
     TextDocumentContentChangeEvent, TextDocumentIdentifier, TextDocumentPositionParams,
-    TypeHierarchyItem, Url, VersionedTextDocumentIdentifier, WorkspaceFolder, WorkspaceSymbol,
+    TypeHierarchyItem, Url, VersionedTextDocumentIdentifier, WorkspaceEdit, WorkspaceFolder,
+    WorkspaceSymbol,
 };
 use normalize_path::NormalizePath;
 use solar_config::{CompileOpts, Threads};
@@ -697,6 +698,47 @@ pub struct BenchmarkFoldingRangeRequests {
 pub struct BenchmarkSignatureHelpRequests {
     state: super::GlobalState,
     params: SignatureHelpParams,
+}
+
+/// A prepared rename request including source validation and workspace-edit construction.
+#[doc(hidden)]
+pub struct BenchmarkRenameRequests {
+    state: super::GlobalState,
+    params: RenameParams,
+    runtime: tokio::runtime::Runtime,
+}
+
+impl BenchmarkRenameRequests {
+    /// Analyze the project and retain all source documents as versioned VFS snapshots.
+    pub fn new(project: BenchmarkProject, uri: Url, position: Position) -> Self {
+        let state = super::GlobalState::new(ClientSocket::new_closed());
+        for (path, contents) in &project.files {
+            state.vfs.write().set_file_contents_with_version(
+                VfsPath::from(path.clone()),
+                Some(Rope::from(contents.as_str())),
+                Some(1),
+            );
+        }
+        state.symbol_tables.store(Arc::new(project.analyze().symbol_tables));
+        let params = RenameParams {
+            text_document_position: TextDocumentPositionParams {
+                text_document: TextDocumentIdentifier { uri },
+                position,
+            },
+            new_name: "renamed".into(),
+            work_done_progress_params: Default::default(),
+        };
+        let runtime = tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap();
+        Self { state, params, runtime }
+    }
+
+    /// Execute a complete rename through the production handler and blocking validation task.
+    #[inline(never)]
+    pub fn run(&mut self) -> Option<WorkspaceEdit> {
+        self.runtime
+            .block_on(handlers::rename(&mut self.state, self.params.clone()))
+            .expect("rename benchmark request should succeed")
+    }
 }
 
 impl BenchmarkSignatureHelpRequests {

--- a/crates/lsp/src/handlers/workspace_edit.rs
+++ b/crates/lsp/src/handlers/workspace_edit.rs
@@ -186,15 +186,20 @@ fn validate_rename(
         contents.insert(uri.clone(), (file_contents, version));
     }
 
-    for location in &candidate.locations {
-        let Some((contents, _)) = contents.get(&location.uri) else {
+    // Rename candidates are URI-sorted. Reuse one position index per file and release it
+    // before validating the next file so peak index memory stays bounded by one document.
+    for locations in candidate.locations.chunk_by(|a, b| a.uri == b.uri) {
+        let Some((contents, _)) = contents.get(&locations[0].uri) else {
             return Err(content_modified());
         };
-        let Some(range) = proto::checked_text_range(contents, location.range) else {
-            return Err(content_modified());
-        };
-        if contents.byte_slice(range) != candidate.old_name.as_str() {
-            return Err(content_modified());
+        let index = proto::LspPositionIndex::new(contents);
+        for location in locations {
+            let Some(range) = index.checked_text_range(location.range) else {
+                return Err(content_modified());
+            };
+            if contents.byte_slice(range) != candidate.old_name.as_str() {
+                return Err(content_modified());
+            }
         }
     }
 
@@ -252,7 +257,81 @@ fn content_modified() -> ResponseError {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use lsp_types::{Position, Range};
+    use crate::test_support::TestProject;
+    use lsp_types::{Location, Position, Range};
+
+    #[test]
+    fn rename_validation_checks_every_occurrence_in_each_file() {
+        let project = TestProject::from_fixture("//- /A.sol\n//- /B.sol\n");
+        let first = Url::from_file_path(project.path("/A.sol")).unwrap();
+        let second = Url::from_file_path(project.path("/B.sol")).unwrap();
+        let sources = [
+            (first.clone(), "😀 target\r\ntarget\rtarget\n"),
+            (second.clone(), "target\n😀 target\n"),
+        ];
+        let vfs = Arc::new(RwLock::new(Vfs::default()));
+        for (uri, source) in &sources {
+            vfs.write().set_file_contents_with_version(
+                proto::vfs_path(uri).unwrap(),
+                Some(Rope::from(*source)),
+                Some(7),
+            );
+        }
+        let range =
+            |line, start| Range::new(Position::new(line, start), Position::new(line, start + 6));
+        let locations = vec![
+            Location::new(first.clone(), range(0, 3)),
+            Location::new(first.clone(), range(1, 0)),
+            Location::new(first.clone(), range(2, 0)),
+            Location::new(second.clone(), range(0, 0)),
+            Location::new(second.clone(), range(1, 3)),
+        ];
+        let mut candidate = RenameCandidate {
+            old_name: "target".into(),
+            range: locations[0].range,
+            locations,
+            analyzed_contents: sources
+                .into_iter()
+                .map(|(uri, source)| (uri, Arc::new(source.into())))
+                .collect(),
+            conflicting_contents: false,
+            requires_yul_validation: false,
+        };
+        let expected = HashMap::from([
+            (
+                first,
+                vec![
+                    TextEdit::new(range(0, 3), "new".into()),
+                    TextEdit::new(range(1, 0), "new".into()),
+                    TextEdit::new(range(2, 0), "new".into()),
+                ],
+            ),
+            (
+                second,
+                vec![
+                    TextEdit::new(range(0, 0), "new".into()),
+                    TextEdit::new(range(1, 3), "new".into()),
+                ],
+            ),
+        ]);
+        let edit =
+            validated_rename_workspace_edit(candidate.clone(), "new".into(), vfs.clone(), false)
+                .unwrap();
+        assert_eq!(edit.changes, Some(expected));
+
+        // A bad later occurrence must reject the whole edit, including a split surrogate.
+        for invalid in [range(1, 1), range(1, 2), range(3, 0)] {
+            candidate.locations.last_mut().unwrap().range = invalid;
+            let error = validated_rename_workspace_edit(
+                candidate.clone(),
+                "new".into(),
+                vfs.clone(),
+                false,
+            )
+            .unwrap_err();
+            assert_eq!(error.code, ErrorCode::CONTENT_MODIFIED);
+        }
+    }
 
     #[test]
     fn code_action_edit_validation_accepts_adjacent_utf16_ranges() {

--- a/crates/lsp/src/lib.rs
+++ b/crates/lsp/src/lib.rs
@@ -355,7 +355,7 @@ mod workspace;
 pub use global_state::benchmark::{
     BenchmarkAnalysis, BenchmarkDocumentChange, BenchmarkDocumentUpdate, BenchmarkEdit,
     BenchmarkError, BenchmarkFoldingRangeRequests, BenchmarkOpenDocuments, BenchmarkProject,
-    BenchmarkRepeatedAnalysis, BenchmarkRequest, BenchmarkResponse,
+    BenchmarkRenameRequests, BenchmarkRepeatedAnalysis, BenchmarkRequest, BenchmarkResponse,
     BenchmarkSelectionRangeRequests, BenchmarkSignatureHelpRequests, BenchmarkWorkspaceDiscovery,
     BenchmarkWorkspacePathQueries, BenchmarkWorkspaceReports,
 };


### PR DESCRIPTION
Rename validation rebuilt the source line-start index once for every occurrence. This change groups the existing URI-sorted locations and reuses one `LspPositionIndex` per affected document, preserving source, UTF-16, version, occurrence, and `WorkspaceEdit` behavior while keeping peak index storage bounded to one document.


