### PR TITLE
perf(lsp): batch descending document edits

### DIFF
--- a/crates/lsp/benches/lsp.rs
+++ b/crates/lsp/benches/lsp.rs
@@ -4,16 +4,20 @@
 
 use criterion::{BatchSize, BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use crop::Rope;
-use lsp_types::{GotoDefinitionResponse, HoverContents, OneOf, Position, Url};
+use lsp_types::{
+    GotoDefinitionResponse, HoverContents, OneOf, Position, Range, TextDocumentContentChangeEvent,
+    Url,
+};
 use solar_config::CompileOpts;
 use solar_lsp::{
-    BenchmarkAnalysis, BenchmarkDocumentUpdate, BenchmarkFoldingRangeRequests,
-    BenchmarkOpenDocuments, BenchmarkProject, BenchmarkRepeatedAnalysis, BenchmarkRequest,
-    BenchmarkResponse, BenchmarkSelectionRangeRequests, BenchmarkSignatureHelpRequests,
-    BenchmarkWorkspaceDiscovery, BenchmarkWorkspacePathQueries, BenchmarkWorkspaceReports,
-    benchmark_folding_ranges, benchmark_folding_ranges_from_rope, benchmark_import_path_at,
-    benchmark_selection_ranges,
+    BenchmarkAnalysis, BenchmarkDocumentChange, BenchmarkDocumentUpdate,
+    BenchmarkFoldingRangeRequests, BenchmarkOpenDocuments, BenchmarkProject,
+    BenchmarkRepeatedAnalysis, BenchmarkRequest, BenchmarkResponse,
+    BenchmarkSelectionRangeRequests, BenchmarkSignatureHelpRequests, BenchmarkWorkspaceDiscovery,
+    BenchmarkWorkspacePathQueries, BenchmarkWorkspaceReports, benchmark_folding_ranges,
+    benchmark_folding_ranges_from_rope, benchmark_import_path_at, benchmark_selection_ranges,
 };
+use solar_parse::{Cursor, lexer::token::RawTokenKind};
 use std::{fmt::Write as _, fs, hint::black_box, path::PathBuf};
 
 const ANALYSIS_FUNCTION_COUNTS: [usize; 2] = [64, 256];
@@ -862,6 +866,98 @@ fn workspace_diagnostic_hot_paths(c: &mut Criterion) {
     reports.finish();
 }
 
+fn incoming_document_changes(c: &mut Criterion) {
+    let mut group = c.benchmark_group("lsp/incoming-document-changes");
+    for (name, source, identifier, occurrence_count, edit_counts) in [
+        ("optimism-predeploys", OPTIMISM_SOURCE, "Predeploys", 377, &[1, 8, 64, 377][..]),
+        (
+            "uniswap-tickmath",
+            include_str!("../../../testdata/UniswapV3.sol"),
+            "TickMath",
+            20,
+            &[1, 20][..],
+        ),
+        (
+            "counter",
+            "contract Counter {\n    uint256 count;\n    function increment() public { count++; }\n    function value() public view returns (uint256) { return count; }\n}\n",
+            "count",
+            3,
+            &[1, 3][..],
+        ),
+    ] {
+        let occurrences = Cursor::new(source)
+            .with_position()
+            .filter_map(|(start, token)| {
+                let end = start + token.len as usize;
+                (token.kind == RawTokenKind::Ident && &source[start..end] == identifier)
+                    .then_some(start..end)
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(occurrences.len(), occurrence_count);
+        let position_at = |offset| {
+            let prefix = &source[..offset];
+            Position::new(
+                prefix.bytes().filter(|&byte| byte == b'\n').count() as u32,
+                prefix.rsplit('\n').next().unwrap().encode_utf16().count() as u32,
+            )
+        };
+        let contents = Rope::from(source);
+        for &edit_count in edit_counts {
+            let replacement = format!("{identifier}Renamed");
+            let mut expected = source.to_owned();
+            let mut changes = Vec::with_capacity(edit_count);
+            // Clients apply independent replacements from the end to preserve earlier positions.
+            for range in occurrences.iter().rev().take(edit_count) {
+                changes.push(TextDocumentContentChangeEvent {
+                    range: Some(Range::new(position_at(range.start), position_at(range.end))),
+                    range_length: None,
+                    text: replacement.clone(),
+                });
+                expected.replace_range(range.clone(), &replacement);
+            }
+            let change = BenchmarkDocumentChange::from_changes(contents.clone(), changes);
+            assert_eq!(change.clone().apply().contents().to_string(), expected);
+            group.throughput(Throughput::Elements(edit_count as u64));
+            group.bench_function(
+                BenchmarkId::from_parameter(format!("{name}-{edit_count}")),
+                |b| {
+                    b.iter_batched(
+                        || change.clone(),
+                        |change| black_box(change.apply()),
+                        BatchSize::PerIteration,
+                    );
+                },
+            );
+        }
+    }
+
+    // Overlapping ranges must retain the sequential LSP behavior and exercise the fallback path.
+    let source = Rope::from("abcdef\nghijkl\n");
+    let changes = vec![
+        TextDocumentContentChangeEvent {
+            range: Some(Range::new(Position::new(0, 2), Position::new(0, 4))),
+            range_length: None,
+            text: "X".into(),
+        },
+        TextDocumentContentChangeEvent {
+            range: Some(Range::new(Position::new(0, 1), Position::new(0, 3))),
+            range_length: None,
+            text: "Y".into(),
+        },
+    ];
+    let change = BenchmarkDocumentChange::from_changes(source, changes);
+    assert_eq!(change.clone().apply().contents().to_string(), "aYef\nghijkl\n");
+    group.throughput(Throughput::Elements(2));
+    group.bench_function("sequential-overlap-fallback", |b| {
+        b.iter_batched(
+            || change.clone(),
+            |change| black_box(change.apply()),
+            BatchSize::PerIteration,
+        );
+    });
+    group.finish();
+}
+
 fn open_document_analysis_batches(c: &mut Criterion) {
     let documents = BenchmarkOpenDocuments::new(OPEN_DOCUMENT_COUNT, OPEN_DOCUMENT_BYTES);
     // Prime the initial snapshot so timing measures reuse across later analysis epochs.
@@ -1225,6 +1321,7 @@ criterion_group!(
     selection_range,
     open_document_selection_range,
     workspace_diagnostic_hot_paths,
+    incoming_document_changes,
     open_document_analysis_batches,
     repeated_analysis,
     workspace_index_reuse,

--- a/crates/lsp/src/global_state/benchmark.rs
+++ b/crates/lsp/src/global_state/benchmark.rs
@@ -509,6 +509,16 @@ pub struct BenchmarkDocumentChange {
 }
 
 impl BenchmarkDocumentChange {
+    /// Prepare incoming document edits without including source construction in timing.
+    pub fn from_changes(contents: Rope, changes: Vec<TextDocumentContentChangeEvent>) -> Self {
+        Self { contents, changes }
+    }
+
+    /// The complete document contents, for verifying prepared edits outside timing.
+    pub fn contents(&self) -> &Rope {
+        &self.contents
+    }
+
     /// Apply this prepared document change and return the edited document.
     #[inline(never)]
     pub fn apply(self) -> Self {

--- a/crates/lsp/src/utils.rs
+++ b/crates/lsp/src/utils.rs
@@ -17,6 +17,15 @@ pub(crate) fn apply_document_changes(
             None => (file_contents.clone(), &content_changes[..]),
         };
 
+    if let Some(ranges) = descending_ranges(&text, content_changes) {
+        // Edits sorted from the end of the document toward the beginning do not change the byte
+        // offsets of any later range. Resolve every UTF-16 range against one position index.
+        for (range, change) in ranges.into_iter().zip(content_changes) {
+            text.replace(range, &change.text);
+        }
+        return text;
+    }
+
     for change in content_changes {
         // SAFETY: we already handled the `None` case above
         let range = proto::text_range(&text, change.range.unwrap());
@@ -24,6 +33,37 @@ pub(crate) fn apply_document_changes(
     }
 
     text
+}
+
+fn descending_ranges(
+    text: &Rope,
+    changes: &[lsp_types::TextDocumentContentChangeEvent],
+) -> Option<Vec<std::ops::Range<usize>>> {
+    if changes.len() < 2 {
+        return None;
+    }
+    // Reject sequential and adjacent edits before indexing the document. An insertion at the
+    // boundary of a neighboring edit can observe that edit's newly inserted text.
+    for pair in changes.windows(2) {
+        if pair[1].range?.end >= pair[0].range?.start {
+            return None;
+        }
+    }
+    let index = proto::LspPositionIndex::new(text);
+    let mut ranges = Vec::with_capacity(changes.len());
+    for change in changes {
+        let lsp_range = change.range?;
+        let range = index.checked_text_range(lsp_range)?;
+        // Checked conversion clamps oversized columns to the line end, unlike the sequential
+        // conversion. Only reuse positions that resolve exactly without that clamping.
+        if index.position_at_byte(range.start) != Some(lsp_range.start)
+            || index.position_at_byte(range.end) != Some(lsp_range.end)
+        {
+            return None;
+        }
+        ranges.push(range);
+    }
+    Some(ranges)
 }
 
 /// Compare a rope's UTF-8 bytes with a contiguous string without flattening the rope.
@@ -64,6 +104,43 @@ mod tests {
         assert!(rope_eq_str(&rope, "alpha\nβeta😀"));
         assert!(!rope_eq_str(&rope, "alpha\nβeta"));
         assert!(!rope_eq_str(&rope, "alpha\nβeta😃"));
+    }
+
+    #[test]
+    fn descending_document_changes_preserve_oversized_columns() {
+        let changes = [
+            (Range::new(Position::new(2, 0), Position::new(2, 1)), "X"),
+            (Range::new(Position::new(0, 4), Position::new(0, 5)), "Y"),
+        ]
+        .map(|(range, text)| TextDocumentContentChangeEvent {
+            range: Some(range),
+            range_length: None,
+            text: text.into(),
+        });
+        let text = apply_document_changes(&Rope::from("abc\ndef\nghi"), changes.into());
+        assert_eq!(text, "abc\nYef\nXhi");
+    }
+
+    #[test]
+    fn descending_document_changes_preserve_unicode_and_line_endings() {
+        let original = Rope::from("a😀b\r\ncéc\rd𐐀e\nfgh");
+        let changes = [
+            (Range::new(Position::new(3, 1), Position::new(3, 2)), "😀\r\nmore"),
+            (Range::new(Position::new(2, 1), Position::new(2, 3)), "世\n界"),
+            (Range::new(Position::new(1, 1), Position::new(1, 2)), "E\r"),
+            (Range::new(Position::new(0, 1), Position::new(0, 3)), "🙂"),
+        ]
+        .map(|(range, text)| TextDocumentContentChangeEvent {
+            range: Some(range),
+            range_length: None,
+            text: text.into(),
+        });
+        let sequential = changes.iter().fold(original.clone(), |text, change| {
+            apply_document_changes(&text, vec![change.clone()])
+        });
+        let text = apply_document_changes(&original, changes.into());
+        assert_eq!(text, sequential);
+        assert_eq!(text, "a🙂b\r\ncE\rc\rd世\n界e\nf😀\r\nmoreh");
     }
 
     #[test]


### PR DESCRIPTION
Towards OSS-738

Applying a rename or Replace All can send hundreds of edits in one `didChange` notification. We currently rebuild the whole document's line-position index for every edit, blocking notification handling before analysis even starts.

- **Scan the document once per batch.** For separate edits ordered from the end of the file toward the beginning, resolve all UTF-16 positions using one index. Later edits leave earlier positions intact, so rebuilding the index adds no useful work.
- **Preserve sequential editing behavior.** Check ordering before building the index, require exact position conversions, and use the existing path for overlapping, adjacent, or otherwise unsuitable edits. Regression coverage includes oversized columns, Unicode, mixed line endings, and multiline replacements.
- **Measure realistic replacement batches.** Add Optimism and Uniswap identifier replacements, alongside single-edit and small-file controls.

The large gain comes from removing repeated full-file scans: a 377-edit batch in the 5.4 MB Optimism fixture needs one scan instead of 377.

| Edit-application workload | Before | After | Reduction |
| --- | ---: | ---: | ---: |
| Optimism, 377 replacements | 497.81 ms | 1.72 ms | 99.65% |
| Uniswap TickMath, 20 replacements | 384.18 µs | 30.24 µs | 92.13% |
