### PR TITLE
perf(lsp): reduce repeated analysis work

### DIFF
--- a/crates/lsp/src/signature_help.rs
+++ b/crates/lsp/src/signature_help.rs
@@ -241,7 +241,12 @@ impl SignatureHelpIndex {
         let signature = self.intern_signature(signature);
         let entries = self.callables_by_name.entry(name).or_default();
         if !entries.iter().any(|entry| {
-            entry.location == location && entry.form == form && entry.signature == signature
+            // Most same-name declarations differ in range; compare it before their longer URI.
+            entry.form == form
+                && entry.location.as_ref().map(|location| location.range)
+                    == location.as_ref().map(|location| location.range)
+                && entry.location == location
+                && entry.signature == signature
         }) {
             entries.push(CatalogEntry { location, form, signature });
         }

--- a/crates/lsp/src/symbols.rs
+++ b/crates/lsp/src/symbols.rs
@@ -1824,7 +1824,11 @@ impl SymbolTables {
 
     fn rebuild_indexes(&mut self) {
         for symbols in self.files.values_mut() {
-            sort_symbol_ids(&self.declarations, symbols);
+            // Each group has one URI, so only source position and ID can affect its order.
+            symbols.sort_by_key(|&id| {
+                let position = self.declarations[id].location.range.start;
+                (position.line, position.character, id.index())
+            });
         }
 
         self.file_declaration_positions.clear();
@@ -1854,8 +1858,11 @@ impl SymbolTables {
 
         self.workspace_symbol_ids.clear();
         self.workspace_symbol_ids.reserve(self.declarations.len());
-        self.workspace_symbol_ids.extend(self.declarations.indices());
-        sort_symbol_ids(&self.declarations, &mut self.workspace_symbol_ids);
+        // Per-file declarations are already ordered. Concatenate files in URI order instead of
+        // sorting every declaration again with repeated URI comparisons.
+        let mut files = self.files.iter().collect::<Vec<_>>();
+        files.sort_unstable_by(|(a, _), (b, _)| a.as_str().cmp(b.as_str()));
+        self.workspace_symbol_ids.extend(files.into_iter().flat_map(|(_, symbols)| symbols));
         self.workspace_search = OnceLock::new();
 
         self.file_scopes.clear();
@@ -2585,21 +2592,6 @@ impl<'gcx> hir::Visit<'gcx> for ReferenceCollector<'_, 'gcx> {
         self.in_yul = previous;
         result
     }
-}
-
-fn sort_symbol_ids(
-    declarations: &IndexVec<SymbolId, DeclarationSymbol>,
-    symbol_ids: &mut [SymbolId],
-) {
-    symbol_ids.sort_by_key(|symbol_id| {
-        let location = &declarations[*symbol_id].location;
-        (
-            location.uri.as_str(),
-            location.range.start.line,
-            location.range.start.character,
-            symbol_id.index(),
-        )
-    });
 }
 
 fn sort_locations(locations: &mut [Location]) {

--- a/crates/sema/src/typeck/mod.rs
+++ b/crates/sema/src/typeck/mod.rs
@@ -277,31 +277,48 @@ fn check_payable_fallback_without_receive(gcx: Gcx<'_>, contract_id: hir::Contra
 }
 
 /// Checks for definitions that have the same name and parameter types in the given scope.
+///
+/// Normalizes parameter types lazily once per declaration in each name group. The pairwise
+/// traversal is retained so diagnostic grouping and ordering remain unchanged.
 fn check_duplicate_definitions(gcx: Gcx<'_>, scope: &Declarations) {
-    let is_duplicate = |a: Declaration, b: Declaration| -> bool {
-        let (Res::Item(a), Res::Item(b)) = (a.res, b.res) else { return false };
-        if !a.matches(&b) {
-            return false;
-        }
-        if !(a.is_function() || a.is_event()) {
-            return false;
-        }
-        // Don't check inheritance since this check would be incorrect with virtual/override.
-        if let (hir::ItemId::Function(f1), hir::ItemId::Function(f2)) = (a, b) {
-            let f1 = gcx.hir.function(f1);
-            let f2 = gcx.hir.function(f2);
-            if f1.contract != f2.contract {
-                return false;
-            }
-        }
-        same_external_params(gcx, gcx.type_of_item(a), gcx.type_of_item(b))
-    };
-
+    let mut external_params = Vec::new();
     let mut reported = GrowableBitSet::new_empty();
     for (_name, decls) in scope.iter() {
         if decls.len() <= 1 {
             continue;
         }
+        external_params.clear();
+        external_params.resize(decls.len(), None);
+        let mut is_duplicate = |i: usize, a: Declaration, j: usize, b: Declaration| -> bool {
+            let (Res::Item(a), Res::Item(b)) = (a.res, b.res) else { return false };
+            if !a.matches(&b) {
+                return false;
+            }
+            if !(a.is_function() || a.is_event()) {
+                return false;
+            }
+            // Don't check inheritance since this check would be incorrect with virtual/override.
+            if let (hir::ItemId::Function(f1), hir::ItemId::Function(f2)) = (a, b) {
+                let f1 = gcx.hir.function(f1);
+                let f2 = gcx.hir.function(f2);
+                if f1.contract != f2.contract {
+                    return false;
+                }
+            }
+            // Keep type queries before normalization, matching `same_external_params`.
+            let a_ty = external_params[i].is_none().then(|| gcx.type_of_item(a));
+            let b_ty = external_params[j].is_none().then(|| gcx.type_of_item(b));
+            if let Some(ty) = a_ty {
+                external_params[i] =
+                    Some(ty.as_externally_callable_function(false, gcx).parameters().unwrap());
+            }
+            if let Some(ty) = b_ty {
+                external_params[j] =
+                    Some(ty.as_externally_callable_function(false, gcx).parameters().unwrap());
+            }
+            external_params[i] == external_params[j]
+        };
+
         reported.clear();
         for (i, &decl) in decls.iter().enumerate() {
             if reported.contains(i) {
@@ -310,7 +327,7 @@ fn check_duplicate_definitions(gcx: Gcx<'_>, scope: &Declarations) {
 
             let mut duplicates = Vec::new();
             for (j, &other_decl) in decls.iter().enumerate().skip(i + 1) {
-                if is_duplicate(decl, other_decl) {
+                if is_duplicate(i, decl, j, other_decl) {
                     reported.insert(j);
                     duplicates.push(other_decl.span);
                 }

--- a/tests/ui/typeck/duplicate_overloaded_items.sol
+++ b/tests/ui/typeck/duplicate_overloaded_items.sol
@@ -100,3 +100,33 @@ contract C2 {
 contract D is C2 {
     event E5() anonymous; //~ ERROR: event with same name and parameter types declared twice
 }
+
+contract InterleavedDuplicates {
+    // Interleaved duplicate classes keep their original diagnostic grouping.
+    function f(uint) internal pure returns (uint) { return 0; }
+    //~^ ERROR: function with same name and parameter types declared twice
+    function f(bytes calldata) internal view {}
+    //~^ ERROR: function with same name and parameter types declared twice
+    function f(uint) internal view returns (bytes32) { return 0; }
+    function f(bytes memory) internal pure {}
+    function f(bytes storage) internal {}
+
+    // Keys from another name must not leak into these distinct overloads.
+    function g(address) internal {}
+    function g(uint) internal {}
+    function g(bytes32) internal {}
+    function g(bool) internal {}
+
+    event Interleaved(uint);
+    //~^ ERROR: event with same name and parameter types declared twice
+    event Interleaved(bytes);
+    //~^ ERROR: event with same name and parameter types declared twice
+    event Interleaved(uint indexed) anonymous;
+    event Interleaved(bytes indexed);
+}
+
+contract InvalidParameters {
+    function f(Missing) internal {} //~ ERROR: unresolved symbol `Missing`
+    //~^ ERROR: function with same name and parameter types declared twice
+    function f(Missing) internal {} //~ ERROR: unresolved symbol `Missing`
+}

--- a/tests/ui/typeck/duplicate_overloaded_items.stderr
+++ b/tests/ui/typeck/duplicate_overloaded_items.stderr
@@ -1,3 +1,15 @@
+error: unresolved symbol `Missing`
+   ╭▸ ROOT/tests/ui/typeck/duplicate_overloaded_items.sol:LL:CC
+   │
+LL │     function f(Missing) internal {}
+   ╰╴               ━━━━━━━
+
+error: unresolved symbol `Missing`
+   ╭▸ ROOT/tests/ui/typeck/duplicate_overloaded_items.sol:LL:CC
+   │
+LL │     function f(Missing) internal {}
+   ╰╴               ━━━━━━━
+
 error: event with same name and parameter types declared twice
    ╭▸ ROOT/tests/ui/typeck/duplicate_overloaded_items.sol:LL:CC
    │
@@ -241,5 +253,65 @@ note: other declaration
 LL │     event E5();
    ╰╴          ━━
 
-error: aborting due to 19 previous errors
+error: function with same name and parameter types declared twice
+   ╭▸ ROOT/tests/ui/typeck/duplicate_overloaded_items.sol:LL:CC
+   │
+LL │     function f(uint) internal pure returns (uint) { return 0; }
+   │              ━
+   ╰╴
+note: other declaration
+   ╭▸ ROOT/tests/ui/typeck/duplicate_overloaded_items.sol:LL:CC
+   │
+LL │     function f(uint) internal view returns (bytes32) { return 0; }
+   ╰╴             ━
+
+error: function with same name and parameter types declared twice
+   ╭▸ ROOT/tests/ui/typeck/duplicate_overloaded_items.sol:LL:CC
+   │
+LL │     function f(bytes calldata) internal view {}
+   │              ━
+   ╰╴
+note: other declaration
+   ╭▸ ROOT/tests/ui/typeck/duplicate_overloaded_items.sol:LL:CC
+   │
+LL │     function f(bytes memory) internal pure {}
+   ╰╴             ━
+
+error: event with same name and parameter types declared twice
+   ╭▸ ROOT/tests/ui/typeck/duplicate_overloaded_items.sol:LL:CC
+   │
+LL │     event Interleaved(uint);
+   │           ━━━━━━━━━━━
+   ╰╴
+note: other declaration
+   ╭▸ ROOT/tests/ui/typeck/duplicate_overloaded_items.sol:LL:CC
+   │
+LL │     event Interleaved(uint indexed) anonymous;
+   ╰╴          ━━━━━━━━━━━
+
+error: event with same name and parameter types declared twice
+   ╭▸ ROOT/tests/ui/typeck/duplicate_overloaded_items.sol:LL:CC
+   │
+LL │     event Interleaved(bytes);
+   │           ━━━━━━━━━━━
+   ╰╴
+note: other declaration
+   ╭▸ ROOT/tests/ui/typeck/duplicate_overloaded_items.sol:LL:CC
+   │
+LL │     event Interleaved(bytes indexed);
+   ╰╴          ━━━━━━━━━━━
+
+error: function with same name and parameter types declared twice
+   ╭▸ ROOT/tests/ui/typeck/duplicate_overloaded_items.sol:LL:CC
+   │
+LL │     function f(Missing) internal {}
+   │              ━
+   ╰╴
+note: other declaration
+   ╭▸ ROOT/tests/ui/typeck/duplicate_overloaded_items.sol:LL:CC
+   │
+LL │     function f(Missing) internal {}
+   ╰╴             ━
+
+error: aborting due to 26 previous errors
 


### PR DESCRIPTION
Towards OSS-738 , 

Frequent edits repeat semantic analysis and rebuild LSP indexes. Normalize overload parameters once per declaration within each duplicate-check group, reuse per-file declaration order for workspace symbols, and compare signature ranges before longer URIs. This removes repeated conversion and sorting while preserving diagnostic and symbol ordering, complementing the scheduling change in #1460.

